### PR TITLE
Generate Splice Daml reference pages

### DIFF
--- a/config/x2mdx/splice-daml-reference/source-artifacts.json
+++ b/config/x2mdx/splice-daml-reference/source-artifacts.json
@@ -1,0 +1,43 @@
+{
+  "release_repo": "digital-asset/decentralized-canton-sync",
+  "tag_regex": "^v(?P<version>\\d+\\.\\d+\\.\\d+)$",
+  "min_version": "0.6.4",
+  "publish_version": "0.6.4",
+  "asset_template": "{version}_splice-node.tar.gz",
+  "nav_product": "API Reference",
+  "nav_parent_groups": [
+    "Splice APIs"
+  ],
+  "nav_group_label": "Splice Daml Packages",
+  "families": [
+    "splice-amulet",
+    "splice-amulet-name-service",
+    "splice-api-featured-app-v1",
+    "splice-api-featured-app-v2",
+    "splice-api-token-allocation-instruction-v1",
+    "splice-api-token-allocation-request-v1",
+    "splice-api-token-allocation-v1",
+    "splice-api-token-burn-mint-v1",
+    "splice-api-token-holding-v1",
+    "splice-api-token-metadata-v1",
+    "splice-api-token-transfer-instruction-v1",
+    "splice-dso-governance",
+    "splice-token-test-trading-app",
+    "splice-util",
+    "splice-util-batched-markers",
+    "splice-util-featured-app-proxies",
+    "splice-util-token-standard-wallet",
+    "splice-validator-lifecycle",
+    "splice-wallet-payments"
+  ],
+  "blocked_live_families": [
+    {
+      "name": "splice-token-standard-test",
+      "reason": "The published splice-node release bundle does not include a corresponding DAR. The existing static pages are preserved until a source artifact is available."
+    },
+    {
+      "name": "splice-wallet",
+      "reason": "The published DAR source currently fails `daml damlc docs --format json` because Splice.Wallet.Install references InvalidTransfer, which is not available from the extracted source/dependency set. The existing static pages are preserved until that package can be generated through x2mdx."
+    }
+  ]
+}

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1586,195 +1586,6 @@
               "sdks-tools/api-reference/splice-daml-apis",
               "sdks-tools/api-reference/splice-daml-models",
               {
-                "group": "Splice Daml Packages",
-                "pages": [
-                  {
-                    "group": "splice-amulet",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/index",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-round",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-types",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense"
-                    ]
-                  },
-                  {
-                    "group": "splice-amulet-name-service",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed",
-                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-featured-app-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-featured-app-v2",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-allocation-instruction-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-allocation-request-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-allocation-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-burn-mint-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-holding-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-metadata-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1"
-                    ]
-                  },
-                  {
-                    "group": "splice-api-token-transfer-instruction-v1",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index",
-                      "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
-                    ]
-                  },
-                  {
-                    "group": "splice-dso-governance",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/index",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules",
-                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding"
-                    ]
-                  },
-                  {
-                    "group": "splice-token-standard-test",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/index",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp",
-                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer"
-                    ]
-                  },
-                  {
-                    "group": "splice-token-test-trading-app",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index",
-                      "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp"
-                    ]
-                  },
-                  {
-                    "group": "splice-util",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-util/index",
-                      "sdks-tools/api-reference/splice-daml/splice-util/splice-util"
-                    ]
-                  },
-                  {
-                    "group": "splice-util-batched-markers",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index",
-                      "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy"
-                    ]
-                  },
-                  {
-                    "group": "splice-util-featured-app-proxies",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index",
-                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy",
-                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy"
-                    ]
-                  },
-                  {
-                    "group": "splice-util-token-standard-wallet",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index",
-                      "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation"
-                    ]
-                  },
-                  {
-                    "group": "splice-validator-lifecycle",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index",
-                      "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding"
-                    ]
-                  },
-                  {
-                    "group": "splice-wallet",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/index",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval"
-                    ]
-                  },
-                  {
-                    "group": "splice-wallet-payments",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/index",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment",
-                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions"
-                    ]
-                  }
-                ]
-              },
-              {
                 "group": "Scan APIs",
                 "pages": [
                   {
@@ -1970,6 +1781,195 @@
                     },
                     "pages": [
                       "POST /registry/allocation-instruction/v1/allocation-factory"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Splice Daml Packages",
+                "pages": [
+                  {
+                    "group": "splice-amulet",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/index",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-round",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-types",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense"
+                    ]
+                  },
+                  {
+                    "group": "splice-amulet-name-service",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-featured-app-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-featured-app-v2",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-allocation-instruction-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-allocation-request-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-allocation-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-burn-mint-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-holding-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-metadata-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-transfer-instruction-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-dso-governance",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/index",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding"
+                    ]
+                  },
+                  {
+                    "group": "splice-token-test-trading-app",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index",
+                      "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp"
+                    ]
+                  },
+                  {
+                    "group": "splice-util",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util/splice-util"
+                    ]
+                  },
+                  {
+                    "group": "splice-util-batched-markers",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy"
+                    ]
+                  },
+                  {
+                    "group": "splice-util-featured-app-proxies",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy",
+                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy"
+                    ]
+                  },
+                  {
+                    "group": "splice-util-token-standard-wallet",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation"
+                    ]
+                  },
+                  {
+                    "group": "splice-validator-lifecycle",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index",
+                      "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding"
+                    ]
+                  },
+                  {
+                    "group": "splice-wallet-payments",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/index",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions"
+                    ]
+                  },
+                  {
+                    "group": "splice-token-standard-test",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/index",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer"
+                    ]
+                  },
+                  {
+                    "group": "splice-wallet",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/index",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval"
                     ]
                   }
                 ]

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index.mdx
@@ -1,11 +1,245 @@
 ---
-title: "splice-amulet-name-service docs"
-description: "Documentation for splice-amulet-name-service docs"
+title: "splice-amulet-name-service"
+description: "Reference documentation for splice-amulet-name-service modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet-name-service/docs/index.rst" tag="0.6.4" hash="88d9960a" */}
+<div class="x2mdx-ref-hero">
 
-- [Splice.Ans](/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans)
-- [Splice.Ans.AmuletConversionRateFeed](/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed)
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-{/* COPIED_END */}
+
+  <h1 class="x2mdx-ref-title">splice-amulet-name-service</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-amulet-name-service, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Ans</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Ans.AmuletConversionRateFeed</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Templates to communicate amulet conversion rates.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 2</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed.mdx
@@ -1,153 +1,165 @@
 ---
 title: "Splice.Ans.AmuletConversionRateFeed"
-description: "Documentation for Splice.Ans.AmuletConversionRateFeed"
+description: "Reference documentation for Daml module Splice.Ans.AmuletConversionRateFeed."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet-name-service/docs/Splice-Ans-AmuletConversionRateFeed.rst" tag="0.6.4" hash="463d54ac" */}
+<span id="module-splice-ans-amuletconversionratefeed-3650"></span>
+
+# Splice.Ans.AmuletConversionRateFeed
 
 Templates to communicate amulet conversion rates.
 
-This does not fit a narrow interpretation of "Amulet Name Service", but it fits very well if we widen the role of the ANS to serve as a store for public data of high-value to network participants. Evolving ANS in this direction is a long-standing plan.
+This does not fit a narrow interpretation of "Amulet Name Service", but it fits
 
-## Templates
+very well if we widen the role of the ANS to serve as a store for
 
-<div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeed-90528">
+public data of high-value to network participants. Evolving ANS in this direction
 
-**template** AmuletConversionRateFeed
+is a long-standing plan.
 
-</div>
+## Module Snapshot
 
-> Amulet conversion rate feed published by a given 'publisher'. Publisher must only create one feed per publisher. The feed can only be updated every 0.5 tickDuration as the SVs also only change the price on round boundaries and this avoids unnecessary load.
->
-> Signatory: publisher
->
-> | Field                | Type                                                                                                                                                                                                                                             | Description                                                                 |
-> |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-> | publisher            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              |                                                                             |
-> | dso                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              |                                                                             |
-> | nextUpdateAfter      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The earliest time after which the publisher is allowed to update this feed. |
-> | amuletConversionRate | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                               | conversion rate in USD/Amulet                                               |
->
-> - <div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdso-84096">
->
->   **Choice** AmuletConversionRateFeed_ArchiveAsDso
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletConversionRateFeed_ArchiveAsDsoResult
->
->   | Field  | Type                                                                                                         | Description |
->   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - <div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdate-913">
->
->   **Choice** AmuletConversionRateFeed_Update
->
->   </div>
->
->   Controller: publisher
->
->   Returns: AmuletConversionRateFeed_UpdateResult
->
->   | Field                | Type                                                                                                                                         | Description                                    |
->   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
->   | amuletConversionRate | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                           |                                                |
->   | amuletRulesCid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules    |                                                |
->   | markerContextO       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MarkerContext |                                                |
->   | newNextUpdateAfter   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                            | Must be set to at least now + 0.5 tickDuration |
->
-> - **Choice** Archive
->
->   Controller: publisher
->
->   Returns: ()
->
->   (no fields)
-
-## Orphan Typeclass Instances
-
-**instance** HasCheckedFetch FeaturedAppRightView ForOwner
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-71133">
+<span id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-71133"></span>
 
-**data** AmuletConversionRateFeed_ArchiveAsDsoResult
+### `data AmuletConversionRateFeed_ArchiveAsDsoResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-72702">
->
-> AmuletConversionRateFeed_ArchiveAsDsoResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult
+<span id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-72702"></span>
 
-<div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-36312">
+- `AmuletConversionRateFeed_ArchiveAsDsoResult`
 
-**data** AmuletConversionRateFeed_UpdateResult
+Instances:
 
-</div>
+- `instance HasExercise AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult`
+- `instance HasFromAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult`
+- `instance HasToAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult`
 
-> <div id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-68907">
->
-> AmuletConversionRateFeed_UpdateResult
->
-> </div>
->
-> > | Field | Type                                                                                                                                                   | Description |
-> > |-------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletConversionRateFeed |             |
->
-> **instance** GetField "cid" AmuletConversionRateFeed_UpdateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletConversionRateFeed)
->
-> **instance** SetField "cid" AmuletConversionRateFeed_UpdateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletConversionRateFeed)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult
+<span id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-36312"></span>
 
-<div id="type-splice-ans-amuletconversionratefeed-markercontext-2172">
+### `data AmuletConversionRateFeed_UpdateResult`
 
-**data** MarkerContext
+Constructors:
 
-</div>
+<span id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-68907"></span>
 
-> <div id="constr-splice-ans-amuletconversionratefeed-markercontext-1187">
->
-> MarkerContext
->
-> </div>
->
-> > | Field               | Type                                                                                                                                           | Description |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
-> > | beneficiaries       | \[AppRewardBeneficiary\]                                                                                                                       |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MarkerContext
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MarkerContext
->
-> **instance** GetField "beneficiaries" MarkerContext \[AppRewardBeneficiary\]
->
-> **instance** GetField "featuredAppRightCid" MarkerContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** GetField "markerContextO" AmuletConversionRateFeed_Update ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MarkerContext)
->
-> **instance** SetField "beneficiaries" MarkerContext \[AppRewardBeneficiary\]
->
-> **instance** SetField "featuredAppRightCid" MarkerContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** SetField "markerContextO" AmuletConversionRateFeed_Update ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MarkerContext)
+- `AmuletConversionRateFeed_UpdateResult`
 
-{/* COPIED_END */}
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AmuletConversionRateFeed |  |
+
+Instances:
+
+- `instance GetField cid AmuletConversionRateFeed_UpdateResult (ContractId AmuletConversionRateFeed)`
+- `instance SetField cid AmuletConversionRateFeed_UpdateResult (ContractId AmuletConversionRateFeed)`
+- `instance HasExercise AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult`
+- `instance HasFromAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult`
+- `instance HasToAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult`
+
+<span id="type-splice-ans-amuletconversionratefeed-markercontext-2172"></span>
+
+### `data MarkerContext`
+
+Constructors:
+
+<span id="constr-splice-ans-amuletconversionratefeed-markercontext-1187"></span>
+
+- `MarkerContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+| beneficiaries | [AppRewardBeneficiary] |  |
+
+Instances:
+
+- `instance Eq MarkerContext`
+- `instance Show MarkerContext`
+- `instance GetField beneficiaries MarkerContext [AppRewardBeneficiary]`
+- `instance GetField featuredAppRightCid MarkerContext (ContractId FeaturedAppRight)`
+- `instance GetField markerContextO AmuletConversionRateFeed_Update (Optional MarkerContext)`
+- `instance SetField beneficiaries MarkerContext [AppRewardBeneficiary]`
+- `instance SetField featuredAppRightCid MarkerContext (ContractId FeaturedAppRight)`
+- `instance SetField markerContextO AmuletConversionRateFeed_Update (Optional MarkerContext)`
+
+## Templates
+
+<span id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeed-90528"></span>
+
+### Template `AmuletConversionRateFeed`
+
+Amulet conversion rate feed published by a given 'publisher'.
+Publisher must only create one feed per publisher.
+The feed can only be updated every 0.5 tickDuration as the SVs also only change the price on round boundaries
+and this avoids unnecessary load.
+
+Signatories: `publisher`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| publisher | Party |  |
+| dso | Party |  |
+| nextUpdateAfter | Optional Time | The earliest time after which the publisher is  allowed to update this feed. |
+| amuletConversionRate | Decimal | conversion rate in USD/Amulet |
+
+Choices:
+
+<span id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdso-84096"></span>
+
+#### Choice `AmuletConversionRateFeed_ArchiveAsDso`
+
+Controllers: `dso`
+
+Returns: `AmuletConversionRateFeed_ArchiveAsDsoResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<span id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdate-913"></span>
+
+#### Choice `AmuletConversionRateFeed_Update`
+
+Controllers: `publisher`
+
+Returns: `AmuletConversionRateFeed_UpdateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletConversionRate | Decimal |  |
+| amuletRulesCid | ContractId AmuletRules |  |
+| markerContextO | Optional MarkerContext |  |
+| newNextUpdateAfter | Time | Must be set to at least now + 0.5 tickDuration |
+
+#### Choice `Archive`
+
+Controllers: `publisher`
+
+Returns: `()`
+
+## Orphan Typeclass Instances
+
+- `instance HasCheckedFetch FeaturedAppRightView ForOwner`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans.mdx
@@ -1,655 +1,607 @@
 ---
 title: "Splice.Ans"
-description: "Documentation for Splice.Ans"
+description: "Reference documentation for Daml module Splice.Ans."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet-name-service/docs/Splice-Ans.rst" tag="0.6.4" hash="d9f9bd5b" */}
+<span id="module-splice-ans-61283"></span>
 
-## Templates
+# Splice.Ans
 
-<div id="type-splice-ans-ansentry-10233">
+## Module Snapshot
 
-**template** AnsEntry
-
-</div>
-
-> A ans entry that needs to be renewed continuously. Renewal recreates this contract with an updated `expiresAt` field.
->
-> Signatory: user, dso
->
-> | Field       | Type                                                                                                                | Description |
-> |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | user        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | name        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
-> | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
-> | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
-> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
->
-> - <div id="type-splice-ans-ansentryexpire-47228">
->
->   **Choice** AnsEntry_Expire
->
->   </div>
->
->   Controller: actor
->
->   Returns: AnsEntry_ExpireResult
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-ans-ansentryrenew-67717">
->
->   **Choice** AnsEntry_Renew
->
->   </div>
->
->   Controller: user, dso
->
->   Returns: AnsEntry_RenewResult
->
->   | Field     | Type                                                                                                                   | Description |
->   |-----------|------------------------------------------------------------------------------------------------------------------------|-------------|
->   | extension | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
->
-> - **Choice** Archive
->
->   Controller: user, dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-ans-ansentrycontext-23879">
-
-**template** AnsEntryContext
-
-</div>
-
-> Signatory: dso, user
->
-> | Field       | Type                                                                                                                                              | Description                                                                                                              |
-> |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |                                                                                                                          |
-> | user        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |                                                                                                                          |
-> | name        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                      |                                                                                                                          |
-> | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                      |                                                                                                                          |
-> | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                      |                                                                                                                          |
-> | reference   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest | Reference to the corresponding subscription, note that the contract may already be archived. This is just a tracking id. |
->
-> - <div id="type-splice-ans-ansentrycontextcollectentryrenewalpayment-76943">
->
->   **Choice** AnsEntryContext_CollectEntryRenewalPayment
->
->   </div>
->
->   Controller: dso
->
->   Returns: AnsEntryContext_CollectEntryRenewalPaymentResult
->
->   | Field           | Type                                                                                                                                              | Description                 |
->   |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
->   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment |                             |
->   | entryCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry            | The currently active entry. |
->   | transferContext | AppTransferContext                                                                                                                                |                             |
->   | ansRulesCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsRules            |                             |
->
-> - <div id="type-splice-ans-ansentrycontextcollectinitialentrypayment-71811">
->
->   **Choice** AnsEntryContext_CollectInitialEntryPayment
->
->   </div>
->
->   Controller: dso
->
->   Returns: AnsEntryContext_CollectInitialEntryPaymentResult
->
->   | Field           | Type                                                                                                                                                     | Description |
->   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
->   | transferContext | AppTransferContext                                                                                                                                       |             |
->   | ansRulesCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsRules                   |             |
->
-> - <div id="type-splice-ans-ansentrycontextrejectentryinitialpayment-22257">
->
->   **Choice** AnsEntryContext_RejectEntryInitialPayment
->
->   </div>
->
->   Controller: dso
->
->   Returns: AnsEntryContext_RejectEntryInitialPaymentResult
->
->   | Field           | Type                                                                                                                                                     | Description |
->   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
->   | transferContext | AppTransferContext                                                                                                                                       |             |
->   | ansRulesCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsRules                   |             |
->
-> - <div id="type-splice-ans-ansentrycontextterminate-64657">
->
->   **Choice** AnsEntryContext_Terminate
->
->   </div>
->
->   Controller: actor
->
->   Returns: AnsEntryContext_TerminateResult
->
->   | Field                     | Type                                                                                                                                                 | Description |
->   |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor                     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                  |             |
->   | terminatedSubscriptionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
->
-> - **Choice** Archive
->
->   Controller: dso, user
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-ans-ansrules-7552">
-
-**template** AnsRules
-
-</div>
-
-> The rules governing how users can pay to use the Amulet Name service.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                | Description |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | config | AnsRulesConfig                                                                                                      |             |
->
-> - <div id="type-splice-ans-ansrulescollectentryrenewalpayment-11710">
->
->   **Choice** AnsRules_CollectEntryRenewalPayment
->
->   </div>
->
->   Controller: dso, user
->
->   Returns: AnsRules_CollectEntryRenewalPaymentResult
->
->   | Field           | Type                                                                                                                                              | Description                 |
->   |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
->   | user            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |                             |
->   | entryContext    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext     |                             |
->   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment |                             |
->   | entryCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry            | The currently active entry. |
->   | transferContext | AppTransferContext                                                                                                                                |                             |
->
-> - <div id="type-splice-ans-ansrulescollectinitialentrypayment-44970">
->
->   **Choice** AnsRules_CollectInitialEntryPayment
->
->   </div>
->
->   Controller: dso, user
->
->   Returns: AnsRules_CollectInitialEntryPaymentResult
->
->   | Field           | Type                                                                                                                                                     | Description |
->   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | user            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                      |             |
->   | entryContext    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext            |             |
->   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
->   | transferContext | AppTransferContext                                                                                                                                       |             |
->
-> - <div id="type-splice-ans-ansrulesrejectentryinitialpayment-30886">
->
->   **Choice** AnsRules_RejectEntryInitialPayment
->
->   </div>
->
->   Controller: dso
->
->   Returns: AnsRules_RejectEntryInitialPaymentResult
->
->   | Field           | Type                                                                                                                                                     | Description |
->   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
->   | transferContext | AppTransferContext                                                                                                                                       |             |
->
-> - <div id="type-splice-ans-ansrulesrequestentry-90125">
->
->   **Choice** AnsRules_RequestEntry
->
->   </div>
->
->   Controller: user
->
->   Returns: AnsRules_RequestEntryResult
->
->   | Field       | Type                                                                                                                | Description |
->   |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | name        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | user        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-69826">
+<span id="type-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-69826"></span>
 
-**data** AnsEntryContext_CollectEntryRenewalPaymentResult
+### `data AnsEntryContext_CollectEntryRenewalPaymentResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-18109">
->
-> AnsEntryContext_CollectEntryRenewalPaymentResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                                | Description |
-> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
-> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
->
-> **instance** GetField "entryCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** GetField "subscriptionStateCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "entryCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** SetField "subscriptionStateCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult
+<span id="constr-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-18109"></span>
 
-<div id="type-splice-ans-ansentrycontextcollectinitialentrypaymentresult-28518">
+- `AnsEntryContext_CollectEntryRenewalPaymentResult`
 
-**data** AnsEntryContext_CollectInitialEntryPaymentResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-ans-ansentrycontextcollectinitialentrypaymentresult-16577">
->
-> AnsEntryContext_CollectInitialEntryPaymentResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                                | Description |
-> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
-> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
->
-> **instance** GetField "entryCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** GetField "subscriptionStateCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "entryCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** SetField "subscriptionStateCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult
+- `instance GetField entryCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult`
 
-<div id="type-splice-ans-ansentrycontextrejectentryinitialpaymentresult-4316">
+<span id="type-splice-ans-ansentrycontextcollectinitialentrypaymentresult-28518"></span>
 
-**data** AnsEntryContext_RejectEntryInitialPaymentResult
+### `data AnsEntryContext_CollectInitialEntryPaymentResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-ansentrycontextrejectentryinitialpaymentresult-49933">
->
-> AnsEntryContext_RejectEntryInitialPaymentResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult
+<span id="constr-splice-ans-ansentrycontextcollectinitialentrypaymentresult-16577"></span>
 
-<div id="type-splice-ans-ansentrycontextterminateresult-94524">
+- `AnsEntryContext_CollectInitialEntryPaymentResult`
 
-**data** AnsEntryContext_TerminateResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-ans-ansentrycontextterminateresult-84145">
->
-> AnsEntryContext_TerminateResult
->
-> </div>
->
-> > (no fields)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult
+- `instance GetField entryCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult`
 
-<div id="type-splice-ans-ansentryexpireresult-89925">
+<span id="type-splice-ans-ansentrycontextrejectentryinitialpaymentresult-4316"></span>
 
-**data** AnsEntry_ExpireResult
+### `data AnsEntryContext_RejectEntryInitialPaymentResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-ansentryexpireresult-16032">
->
-> AnsEntry_ExpireResult
->
-> </div>
->
-> > (no fields)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntry AnsEntry_Expire AnsEntry_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntry AnsEntry_Expire AnsEntry_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntry AnsEntry_Expire AnsEntry_ExpireResult
+<span id="constr-splice-ans-ansentrycontextrejectentryinitialpaymentresult-49933"></span>
 
-<div id="type-splice-ans-ansentryrenewresult-81012">
+- `AnsEntryContext_RejectEntryInitialPaymentResult`
 
-**data** AnsEntry_RenewResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-ans-ansentryrenewresult-69331">
->
-> AnsEntry_RenewResult
->
-> </div>
->
-> > | Field    | Type                                                                                                                                   | Description |
-> > |----------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | entryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry |             |
->
-> **instance** GetField "entryCid" AnsEntry_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** SetField "entryCid" AnsEntry_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntry AnsEntry_Renew AnsEntry_RenewResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntry AnsEntry_Renew AnsEntry_RenewResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntry AnsEntry_Renew AnsEntry_RenewResult
+- `instance GetField amuletSum AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult`
 
-<div id="type-splice-ans-ansrulesconfig-16984">
+<span id="type-splice-ans-ansentrycontextterminateresult-94524"></span>
 
-**data** AnsRulesConfig
+### `data AnsEntryContext_TerminateResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-ansrulesconfig-70959">
->
-> AnsRulesConfig
->
-> </div>
->
-> > | Field             | Type                                                                                                                   | Description |
-> > |-------------------|------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | renewalDuration   | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
-> > | entryLifetime     | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
-> > | entryFee          | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     |             |
-> > | descriptionPrefix | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)           |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AnsRulesConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AnsRulesConfig
->
-> **instance** GetField "config" AnsRules AnsRulesConfig
->
-> **instance** GetField "descriptionPrefix" AnsRulesConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "entryFee" AnsRulesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "entryLifetime" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "renewalDuration" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "config" AnsRules AnsRulesConfig
->
-> **instance** SetField "descriptionPrefix" AnsRulesConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "entryFee" AnsRulesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "entryLifetime" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "renewalDuration" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+<span id="constr-splice-ans-ansentrycontextterminateresult-84145"></span>
 
-<div id="type-splice-ans-ansrulescollectentryrenewalpaymentresult-39091">
+- `AnsEntryContext_TerminateResult`
 
-**data** AnsRules_CollectEntryRenewalPaymentResult
+(no fields)
 
-</div>
+Instances:
 
-> <div id="constr-splice-ans-ansrulescollectentryrenewalpaymentresult-73922">
->
-> AnsRules_CollectEntryRenewalPaymentResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                                | Description |
-> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
-> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
->
-> **instance** GetField "entryCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** GetField "subscriptionStateCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "entryCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** SetField "subscriptionStateCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult
+- `instance HasExercise AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult`
 
-<div id="type-splice-ans-ansrulescollectinitialentrypaymentresult-64239">
+<span id="type-splice-ans-ansentryexpireresult-89925"></span>
 
-**data** AnsRules_CollectInitialEntryPaymentResult
+### `data AnsEntry_ExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-ansrulescollectinitialentrypaymentresult-27238">
->
-> AnsRules_CollectInitialEntryPaymentResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                                | Description |
-> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
-> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
->
-> **instance** GetField "entryCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** GetField "subscriptionStateCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "entryCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** SetField "subscriptionStateCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult
+<span id="constr-splice-ans-ansentryexpireresult-16032"></span>
 
-<div id="type-splice-ans-ansrulesrejectentryinitialpaymentresult-67395">
+- `AnsEntry_ExpireResult`
 
-**data** AnsRules_RejectEntryInitialPaymentResult
+(no fields)
 
-</div>
+Instances:
 
-> <div id="constr-splice-ans-ansrulesrejectentryinitialpaymentresult-46056">
->
-> AnsRules_RejectEntryInitialPaymentResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult
+- `instance HasExercise AnsEntry AnsEntry_Expire AnsEntry_ExpireResult`
+- `instance HasFromAnyChoice AnsEntry AnsEntry_Expire AnsEntry_ExpireResult`
+- `instance HasToAnyChoice AnsEntry AnsEntry_Expire AnsEntry_ExpireResult`
 
-<div id="type-splice-ans-ansrulesrequestentryresult-71096">
+<span id="type-splice-ans-ansentryrenewresult-81012"></span>
 
-**data** AnsRules_RequestEntryResult
+### `data AnsEntry_RenewResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-ansrulesrequestentryresult-91097">
->
-> AnsRules_RequestEntryResult
->
-> </div>
->
-> > | Field      | Type                                                                                                                                              | Description |
-> > |------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | entryCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext     |             |
-> > | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
->
-> **instance** GetField "entryCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
->
-> **instance** GetField "requestCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
->
-> **instance** SetField "entryCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
->
-> **instance** SetField "requestCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult
+<span id="constr-splice-ans-ansentryrenewresult-69331"></span>
 
-<div id="type-splice-ans-expectedentrycontext-86972">
+- `AnsEntry_RenewResult`
 
-**data** ExpectedEntryContext
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-ans-expectedentrycontext-22467">
->
-> ExpectedEntryContext
->
-> </div>
->
-> > | Field     | Type                                                                                                                                              | Description |
-> > |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
-> > | user      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
-> > | reference | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExpectedEntryContext
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExpectedEntryContext
->
-> **instance** GetField "dso" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "reference" ExpectedEntryContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
->
-> **instance** GetField "user" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "dso" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "reference" ExpectedEntryContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
->
-> **instance** SetField "user" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+- `instance GetField entryCid AnsEntry_RenewResult (ContractId AnsEntry)`
+- `instance SetField entryCid AnsEntry_RenewResult (ContractId AnsEntry)`
+- `instance HasExercise AnsEntry AnsEntry_Renew AnsEntry_RenewResult`
+- `instance HasFromAnyChoice AnsEntry AnsEntry_Renew AnsEntry_RenewResult`
+- `instance HasToAnyChoice AnsEntry AnsEntry_Renew AnsEntry_RenewResult`
 
-<div id="type-splice-ans-expectedpayment-99084">
+<span id="type-splice-ans-ansrulesconfig-16984"></span>
 
-**data** ExpectedPayment
+### `data AnsRulesConfig`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-ans-expectedpayment-84341">
->
-> ExpectedPayment
->
-> </div>
->
-> > | Field  | Type                                                                                                                | Description |
-> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExpectedPayment
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExpectedPayment
->
-> **instance** GetField "dso" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "sender" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "dso" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "sender" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+<span id="constr-splice-ans-ansrulesconfig-70959"></span>
+
+- `AnsRulesConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| renewalDuration | RelTime |  |
+| entryLifetime | RelTime |  |
+| entryFee | Decimal |  |
+| descriptionPrefix | Text |  |
+
+Instances:
+
+- `instance Eq AnsRulesConfig`
+- `instance Show AnsRulesConfig`
+- `instance GetField config AnsRules AnsRulesConfig`
+- `instance GetField descriptionPrefix AnsRulesConfig Text`
+- `instance GetField entryFee AnsRulesConfig Decimal`
+- `instance GetField entryLifetime AnsRulesConfig RelTime`
+- `instance GetField renewalDuration AnsRulesConfig RelTime`
+- `instance SetField config AnsRules AnsRulesConfig`
+- `instance SetField descriptionPrefix AnsRulesConfig Text`
+- `instance SetField entryFee AnsRulesConfig Decimal`
+- `instance SetField entryLifetime AnsRulesConfig RelTime`
+- `instance SetField renewalDuration AnsRulesConfig RelTime`
+
+<span id="type-splice-ans-ansrulescollectentryrenewalpaymentresult-39091"></span>
+
+### `data AnsRules_CollectEntryRenewalPaymentResult`
+
+Constructors:
+
+<span id="constr-splice-ans-ansrulescollectentryrenewalpaymentresult-73922"></span>
+
+- `AnsRules_CollectEntryRenewalPaymentResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField entryCid AnsRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult`
+- `instance HasToAnyChoice AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult`
+
+<span id="type-splice-ans-ansrulescollectinitialentrypaymentresult-64239"></span>
+
+### `data AnsRules_CollectInitialEntryPaymentResult`
+
+Constructors:
+
+<span id="constr-splice-ans-ansrulescollectinitialentrypaymentresult-27238"></span>
+
+- `AnsRules_CollectInitialEntryPaymentResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField entryCid AnsRules_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsRules_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsRules_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsRules_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult`
+- `instance HasToAnyChoice AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult`
+
+<span id="type-splice-ans-ansrulesrejectentryinitialpaymentresult-67395"></span>
+
+### `data AnsRules_RejectEntryInitialPaymentResult`
+
+Constructors:
+
+<span id="constr-splice-ans-ansrulesrejectentryinitialpaymentresult-46056"></span>
+
+- `AnsRules_RejectEntryInitialPaymentResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult`
+- `instance HasToAnyChoice AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult`
+
+<span id="type-splice-ans-ansrulesrequestentryresult-71096"></span>
+
+### `data AnsRules_RequestEntryResult`
+
+Constructors:
+
+<span id="constr-splice-ans-ansrulesrequestentryresult-91097"></span>
+
+- `AnsRules_RequestEntryResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntryContext |  |
+| requestCid | ContractId SubscriptionRequest |  |
+
+Instances:
+
+- `instance GetField entryCid AnsRules_RequestEntryResult (ContractId AnsEntryContext)`
+- `instance GetField requestCid AnsRules_RequestEntryResult (ContractId SubscriptionRequest)`
+- `instance SetField entryCid AnsRules_RequestEntryResult (ContractId AnsEntryContext)`
+- `instance SetField requestCid AnsRules_RequestEntryResult (ContractId SubscriptionRequest)`
+- `instance HasExercise AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult`
+- `instance HasToAnyChoice AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult`
+
+<span id="type-splice-ans-expectedentrycontext-86972"></span>
+
+### `data ExpectedEntryContext`
+
+Constructors:
+
+<span id="constr-splice-ans-expectedentrycontext-22467"></span>
+
+- `ExpectedEntryContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| reference | ContractId SubscriptionRequest |  |
+
+Instances:
+
+- `instance Eq ExpectedEntryContext`
+- `instance Show ExpectedEntryContext`
+- `instance GetField dso ExpectedEntryContext Party`
+- `instance GetField reference ExpectedEntryContext (ContractId SubscriptionRequest)`
+- `instance GetField user ExpectedEntryContext Party`
+- `instance SetField dso ExpectedEntryContext Party`
+- `instance SetField reference ExpectedEntryContext (ContractId SubscriptionRequest)`
+- `instance SetField user ExpectedEntryContext Party`
+
+<span id="type-splice-ans-expectedpayment-99084"></span>
+
+### `data ExpectedPayment`
+
+Constructors:
+
+<span id="constr-splice-ans-expectedpayment-84341"></span>
+
+- `ExpectedPayment`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+
+Instances:
+
+- `instance Eq ExpectedPayment`
+- `instance Show ExpectedPayment`
+- `instance GetField dso ExpectedPayment Party`
+- `instance GetField sender ExpectedPayment Party`
+- `instance SetField dso ExpectedPayment Party`
+- `instance SetField sender ExpectedPayment Party`
 
 ## Functions
 
-<div id="function-splice-ans-fetchandvalidateinitialpayment-51068">
+<span id="function-splice-ans-fetchandvalidateinitialpayment-51068"></span>
 
-fetchAndValidateInitialPayment
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment -\> ExpectedPayment -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) SubscriptionInitialPayment
+### `fetchAndValidateInitialPayment`
 
-</div>
+```daml
+fetchAndValidateInitialPayment : ContractId SubscriptionInitialPayment -> ExpectedPayment -> Update SubscriptionInitialPayment
+```
 
-<div id="function-splice-ans-fetchandvalidatepayment-2827">
+<span id="function-splice-ans-fetchandvalidatepayment-2827"></span>
 
-fetchAndValidatePayment
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment -\> ExpectedPayment -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) SubscriptionPayment
+### `fetchAndValidatePayment`
 
-</div>
+```daml
+fetchAndValidatePayment : ContractId SubscriptionPayment -> ExpectedPayment -> Update SubscriptionPayment
+```
 
-<div id="function-splice-ans-fetchandvalidateentrycontext-91041">
+<span id="function-splice-ans-fetchandvalidateentrycontext-91041"></span>
 
-fetchAndValidateEntryContext
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext -\> ExpectedEntryContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AnsEntryContext
+### `fetchAndValidateEntryContext`
 
-</div>
+```daml
+fetchAndValidateEntryContext : ContractId AnsEntryContext -> ExpectedEntryContext -> Update AnsEntryContext
+```
 
-<div id="function-splice-ans-validansconfig-37443">
+<span id="function-splice-ans-validansconfig-37443"></span>
 
-validAnsConfig
-: AnsRulesConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validAnsConfig`
 
-</div>
+```daml
+validAnsConfig : AnsRulesConfig -> Bool
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-ans-ansentry-10233"></span>
+
+### Template `AnsEntry`
+
+A ans entry that needs to be renewed continuously.
+Renewal recreates this contract with an updated `expiresAt` field.
+
+Signatories: `user`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party |  |
+| dso | Party |  |
+| name | Text |  |
+| url | Text |  |
+| description | Text |  |
+| expiresAt | Time |  |
+
+Choices:
+
+<span id="type-splice-ans-ansentryexpire-47228"></span>
+
+#### Choice `AnsEntry_Expire`
+
+Controllers: `actor`
+
+Returns: `AnsEntry_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<span id="type-splice-ans-ansentryrenew-67717"></span>
+
+#### Choice `AnsEntry_Renew`
+
+Controllers: `user`, `dso`
+
+Returns: `AnsEntry_RenewResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extension | RelTime |  |
+
+#### Choice `Archive`
+
+Controllers: `user`, `dso`
+
+Returns: `()`
+
+<span id="type-splice-ans-ansentrycontext-23879"></span>
+
+### Template `AnsEntryContext`
+
+Signatories: `dso`, `user`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| name | Text |  |
+| url | Text |  |
+| description | Text |  |
+| reference | ContractId SubscriptionRequest | Reference to the corresponding subscription, note that the contract may already be archived. This is just a tracking id. |
+
+Choices:
+
+<span id="type-splice-ans-ansentrycontextcollectentryrenewalpayment-76943"></span>
+
+#### Choice `AnsEntryContext_CollectEntryRenewalPayment`
+
+Controllers: `dso`
+
+Returns: `AnsEntryContext_CollectEntryRenewalPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionPayment |  |
+| entryCid | ContractId AnsEntry | The currently active entry. |
+| transferContext | AppTransferContext |  |
+| ansRulesCid | ContractId AnsRules |  |
+
+<span id="type-splice-ans-ansentrycontextcollectinitialentrypayment-71811"></span>
+
+#### Choice `AnsEntryContext_CollectInitialEntryPayment`
+
+Controllers: `dso`
+
+Returns: `AnsEntryContext_CollectInitialEntryPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+| ansRulesCid | ContractId AnsRules |  |
+
+<span id="type-splice-ans-ansentrycontextrejectentryinitialpayment-22257"></span>
+
+#### Choice `AnsEntryContext_RejectEntryInitialPayment`
+
+Controllers: `dso`
+
+Returns: `AnsEntryContext_RejectEntryInitialPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+| ansRulesCid | ContractId AnsRules |  |
+
+<span id="type-splice-ans-ansentrycontextterminate-64657"></span>
+
+#### Choice `AnsEntryContext_Terminate`
+
+Controllers: `actor`
+
+Returns: `AnsEntryContext_TerminateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| terminatedSubscriptionCid | ContractId TerminatedSubscription |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`, `user`
+
+Returns: `()`
+
+<span id="type-splice-ans-ansrules-7552"></span>
+
+### Template `AnsRules`
+
+The rules governing how users can pay to use the Amulet Name service.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| config | AnsRulesConfig |  |
+
+Choices:
+
+<span id="type-splice-ans-ansrulescollectentryrenewalpayment-11710"></span>
+
+#### Choice `AnsRules_CollectEntryRenewalPayment`
+
+Controllers: `dso`, `user`
+
+Returns: `AnsRules_CollectEntryRenewalPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party |  |
+| entryContext | ContractId AnsEntryContext |  |
+| paymentCid | ContractId SubscriptionPayment |  |
+| entryCid | ContractId AnsEntry | The currently active entry. |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-ans-ansrulescollectinitialentrypayment-44970"></span>
+
+#### Choice `AnsRules_CollectInitialEntryPayment`
+
+Controllers: `dso`, `user`
+
+Returns: `AnsRules_CollectInitialEntryPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party |  |
+| entryContext | ContractId AnsEntryContext |  |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-ans-ansrulesrejectentryinitialpayment-30886"></span>
+
+#### Choice `AnsRules_RejectEntryInitialPayment`
+
+Controllers: `dso`
+
+Returns: `AnsRules_RejectEntryInitialPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-ans-ansrulesrequestentry-90125"></span>
+
+#### Choice `AnsRules_RequestEntry`
+
+Controllers: `user`
+
+Returns: `AnsRules_RequestEntryResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| name | Text |  |
+| url | Text |  |
+| description | Text |  |
+| user | Party |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/index.mdx
@@ -1,27 +1,1045 @@
 ---
-title: "splice-amulet docs"
-description: "Documentation for splice-amulet docs"
+title: "splice-amulet"
+description: "Reference documentation for splice-amulet modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/index.rst" tag="0.6.4" hash="c1fc8b73" */}
+<div class="x2mdx-ref-hero">
 
-- [Splice.Amulet](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet)
-- [Splice.Amulet.TokenApiUtils](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils)
-- [Splice.Amulet.TwoStepTransfer](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer)
-- [Splice.AmuletAllocation](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation)
-- [Splice.AmuletConfig](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig)
-- [Splice.AmuletRules](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules)
-- [Splice.AmuletTransferInstruction](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction)
-- [Splice.DecentralizedSynchronizer](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer)
-- [Splice.Expiry](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry)
-- [Splice.ExternalPartyAmuletRules](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules)
-- [Splice.ExternalPartyConfigState](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate)
-- [Splice.Fees](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees)
-- [Splice.Issuance](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance)
-- [Splice.RelRound](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround)
-- [Splice.Round](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round)
-- [Splice.Schedule](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule)
-- [Splice.Types](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types)
-- [Splice.ValidatorLicense](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense)
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-{/* COPIED_END */}
+
+  <h1 class="x2mdx-ref-title">splice-amulet</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-amulet, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Amulet</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The contracts representing the long-term state of Splice.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Amulet.TokenApiUtils</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Common utilities for implementing the token APIs for Amulet.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Amulet.TwoStepTransfer</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Generic code for a two-step transfer of amulet. The first step is to lock</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.AmuletAllocation</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.AmuletConfig</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.AmuletRules</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.AmuletTransferInstruction</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.DecentralizedSynchronizer</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Types and contracts for managing synchronizer fees</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Expiry</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Functions for computing amulet and lock expiry times and conditions.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.ExternalPartyAmuletRules</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.ExternalPartyConfigState</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Fees</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Utility functions for different kinds of fees.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Issuance</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Amulet rewards issuance configuration and computation.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.RelRound</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Round</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Schedule</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Types</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.ValidatorLicense</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 18</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils.mdx
@@ -1,445 +1,463 @@
 ---
 title: "Splice.Amulet.TokenApiUtils"
-description: "Documentation for Splice.Amulet.TokenApiUtils"
+description: "Reference documentation for Daml module Splice.Amulet.TokenApiUtils."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Amulet-TokenApiUtils.rst" tag="0.6.4" hash="545e6b9f" */}
+<span id="module-splice-amulet-tokenapiutils-32536"></span>
+
+# Splice.Amulet.TokenApiUtils
 
 Common utilities for implementing the token APIs for Amulet.
 
-## Typeclasses
+## Module Snapshot
 
-<div id="class-splice-amulet-tokenapiutils-toanyvalue-45157">
-
-**class** ToAnyValue a **where**
-
-</div>
-
-> Values that can be converted to AnyValue
->
-> <div id="function-splice-amulet-tokenapiutils-toanyvalue-91682">
->
-> toAnyValue
-> : a -\> AnyValue
->
-> </div>
->
-> **instance** ToAnyValue TimeLock
->
-> **instance** ToAnyValue [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** ToAnyValue [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** ToAnyValue [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** ToAnyValue [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** ToAnyValue ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t)
->
-> **instance** ToAnyValue [Date](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-date-32253)
->
-> **instance** ToAnyValue [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** ToAnyValue [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** ToAnyValue [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** ToAnyValue ChoiceContext
->
-> **instance** ToAnyValue a =\> ToAnyValue \[a\]
-
-<div id="class-splice-amulet-tokenapiutils-fromanyvalue-31164">
-
-**class** FromAnyValue a **where**
-
-</div>
-
-> Attempt to parse a value from AnyValue.
->
-> If a type implements both `ToAnyValue` and `FromAnyValue` then it must hold that `fromAnyValue (toAnyValue x) = Right x` for all `x`.
->
-> <div id="function-splice-amulet-tokenapiutils-fromanyvalue-32255">
->
-> fromAnyValue
-> : AnyValue -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) a
->
-> </div>
->
-> **instance** FromAnyValue TimeLock
->
-> **instance** FromAnyValue [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** FromAnyValue [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** FromAnyValue [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** FromAnyValue [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** [Template](/appdev/reference/daml-standard-library/prelude#type-da-internal-template-functions-template-31804) t =\> FromAnyValue ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t)
->
-> **instance** FromAnyValue [Date](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-date-32253)
->
-> **instance** FromAnyValue [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** FromAnyValue [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** FromAnyValue [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** FromAnyValue ChoiceContext
->
-> **instance** FromAnyValue a =\> FromAnyValue \[a\]
-
-## Orphan Typeclass Instances
-
-**instance** [Semigroup](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-semigroup-78998) Metadata
-
-**instance** [Monoid](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-monoid-6742) Metadata
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-amulet-tokenapiutils-txkind-33822">
+<span id="type-splice-amulet-tokenapiutils-txkind-33822"></span>
 
-**data** TxKind
+### `data TxKind`
 
-</div>
+Internal type for the transaction kind.
 
-> Internal type for the transaction kind.
->
-> <div id="constr-splice-amulet-tokenapiutils-txkindtransfer-31504">
->
-> TxKind_Transfer
->
-> </div>
->
-> <div id="constr-splice-amulet-tokenapiutils-txkindunlock-53359">
->
-> TxKind_Unlock
->
-> </div>
->
-> <div id="constr-splice-amulet-tokenapiutils-txkindmergesplit-69091">
->
-> TxKind_MergeSplit
->
-> </div>
->
-> <div id="constr-splice-amulet-tokenapiutils-txkindburn-1830">
->
-> TxKind_Burn
->
-> </div>
->
-> <div id="constr-splice-amulet-tokenapiutils-txkindmint-40517">
->
-> TxKind_Mint
->
-> </div>
->
-> <div id="constr-splice-amulet-tokenapiutils-txkindexpiredust-93818">
->
-> TxKind_ExpireDust
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TxKind
+Constructors:
+
+<span id="constr-splice-amulet-tokenapiutils-txkindtransfer-31504"></span>
+
+- `TxKind_Transfer`
+
+<span id="constr-splice-amulet-tokenapiutils-txkindunlock-53359"></span>
+
+- `TxKind_Unlock`
+
+<span id="constr-splice-amulet-tokenapiutils-txkindmergesplit-69091"></span>
+
+- `TxKind_MergeSplit`
+
+<span id="constr-splice-amulet-tokenapiutils-txkindburn-1830"></span>
+
+- `TxKind_Burn`
+
+<span id="constr-splice-amulet-tokenapiutils-txkindmint-40517"></span>
+
+- `TxKind_Mint`
+
+<span id="constr-splice-amulet-tokenapiutils-txkindexpiredust-93818"></span>
+
+- `TxKind_ExpireDust`
+
+Instances:
+
+- `instance Eq TxKind`
+
+## Typeclasses
+
+<span id="class-splice-amulet-tokenapiutils-toanyvalue-45157"></span>
+
+### `class ToAnyValue a`
+
+Values that can be converted to AnyValue
+
+Methods:
+
+- `toAnyValue : a -> AnyValue`
+
+Instances:
+
+- `instance ToAnyValue ChoiceContext`
+- `instance ToAnyValue TimeLock`
+- `instance ToAnyValue Bool`
+- `instance ToAnyValue Decimal`
+- `instance ToAnyValue Int`
+- `instance ToAnyValue Text`
+- `instance ToAnyValue (ContractId t)`
+- `instance ToAnyValue Date`
+- `instance ToAnyValue Party`
+- `instance ToAnyValue Time`
+- `instance ToAnyValue RelTime`
+- `instance ToAnyValue a => ToAnyValue [a]`
+
+<span id="class-splice-amulet-tokenapiutils-fromanyvalue-31164"></span>
+
+### `class FromAnyValue a`
+
+Attempt to parse a value from AnyValue.
+
+If a type implements both `ToAnyValue` and `FromAnyValue` then it must hold that
+`fromAnyValue (toAnyValue x) = Right x` for all `x`.
+
+Methods:
+
+- `fromAnyValue : AnyValue -> Either Text a`
+
+Instances:
+
+- `instance FromAnyValue ChoiceContext`
+- `instance FromAnyValue TimeLock`
+- `instance FromAnyValue Bool`
+- `instance FromAnyValue Decimal`
+- `instance FromAnyValue Int`
+- `instance FromAnyValue Text`
+- `instance Template t => FromAnyValue (ContractId t)`
+- `instance FromAnyValue Date`
+- `instance FromAnyValue Party`
+- `instance FromAnyValue Time`
+- `instance FromAnyValue RelTime`
+- `instance FromAnyValue a => FromAnyValue [a]`
 
 ## Functions
 
-<div id="function-splice-amulet-tokenapiutils-spliceprefix-80926">
+<span id="function-splice-amulet-tokenapiutils-spliceprefix-80926"></span>
 
-splicePrefix
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+### `splicePrefix`
 
-</div>
+```daml
+splicePrefix : Text
+```
 
-<div id="function-splice-amulet-tokenapiutils-amuletprefix-59772">
+<span id="function-splice-amulet-tokenapiutils-amuletprefix-59772"></span>
 
-amuletPrefix
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+### `amuletPrefix`
 
-</div>
+```daml
+amuletPrefix : Text
+```
 
-<div id="function-splice-amulet-tokenapiutils-amuletinstrumentid-11366">
+<span id="function-splice-amulet-tokenapiutils-amuletinstrumentid-11366"></span>
 
-amuletInstrumentId
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId
+### `amuletInstrumentId`
+
+```daml
+amuletInstrumentId : Party -> InstrumentId
+```
 
 Shared definition of the instrument-id used for amulets.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-optionalmetadata-95597"></span>
 
-<div id="function-splice-amulet-tokenapiutils-optionalmetadata-95597">
+### `optionalMetadata`
 
-optionalMetadata
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> (a -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+optionalMetadata : Text -> (a -> Text) -> Optional a -> TextMap Text -> TextMap Text
+```
 
 Add an optional metadata entry.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-nonzerometadata-67227"></span>
 
-<div id="function-splice-amulet-tokenapiutils-nonzerometadata-67227">
+### `nonZeroMetadata`
 
-nonZeroMetadata
-: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Additive](/appdev/reference/daml-standard-library/prelude#class-ghc-num-additive-25881) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a) =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+nonZeroMetadata : (Eq a, Additive a, Show a) => Text -> a -> TextMap Text -> TextMap Text
+```
 
 Add an metadata entry if it is non-zero number.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-optionalnonzerometadata-8763"></span>
 
-<div id="function-splice-amulet-tokenapiutils-optionalnonzerometadata-8763">
+### `optionalNonZeroMetadata`
 
-optionalNonZeroMetadata
-: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Additive](/appdev/reference/daml-standard-library/prelude#class-ghc-num-additive-25881) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a) =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+optionalNonZeroMetadata : (Eq a, Additive a, Show a) => Text -> Optional a -> TextMap Text -> TextMap Text
+```
 
 Add an metadata entry for an optional value if it is non-zero number.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-createdinroundmetakey-43020"></span>
 
-<div id="function-splice-amulet-tokenapiutils-createdinroundmetakey-43020">
+### `createdInRoundMetaKey`
 
-createdInRoundMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+createdInRoundMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-rateperroundmetakey-80476"></span>
 
-<div id="function-splice-amulet-tokenapiutils-rateperroundmetakey-80476">
+### `ratePerRoundMetaKey`
 
-ratePerRoundMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+ratePerRoundMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-svrewardamountmetakey-76087"></span>
 
-<div id="function-splice-amulet-tokenapiutils-svrewardamountmetakey-76087">
+### `svRewardAmountMetaKey`
 
-svRewardAmountMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+svRewardAmountMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-apprewardamountmetakey-17776"></span>
 
-<div id="function-splice-amulet-tokenapiutils-apprewardamountmetakey-17776">
+### `appRewardAmountMetaKey`
 
-appRewardAmountMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+appRewardAmountMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-unclaimedactivityrecordamountmetakey-33086"></span>
 
-<div id="function-splice-amulet-tokenapiutils-unclaimedactivityrecordamountmetakey-33086">
+### `unclaimedActivityRecordAmountMetaKey`
 
-unclaimedActivityRecordAmountMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+unclaimedActivityRecordAmountMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-validatorrewardamountmetakey-47315"></span>
 
-<div id="function-splice-amulet-tokenapiutils-validatorrewardamountmetakey-47315">
+### `validatorRewardAmountMetaKey`
 
-validatorRewardAmountMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+validatorRewardAmountMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-apprewardbeneficiariesmetakey-63876"></span>
 
-<div id="function-splice-amulet-tokenapiutils-apprewardbeneficiariesmetakey-63876">
+### `appRewardBeneficiariesMetaKey`
 
-appRewardBeneficiariesMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+appRewardBeneficiariesMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-apprewardbeneficiaryweightsmetakey-52370"></span>
 
-<div id="function-splice-amulet-tokenapiutils-apprewardbeneficiaryweightsmetakey-52370">
+### `appRewardBeneficiaryWeightsMetaKey`
 
-appRewardBeneficiaryWeightsMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+appRewardBeneficiaryWeightsMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-developmentfundamountmetakey-16464"></span>
 
-<div id="function-splice-amulet-tokenapiutils-developmentfundamountmetakey-16464">
+### `developmentFundAmountMetaKey`
 
-developmentFundAmountMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+developmentFundAmountMetaKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-reasonmetakey-98413"></span>
 
-<div id="function-splice-amulet-tokenapiutils-reasonmetakey-98413">
+### `reasonMetaKey`
 
-reasonMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+reasonMetaKey : Text
+```
 
 Short, human-readable reason for the transaction.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-txkindmetakey-86963"></span>
 
-<div id="function-splice-amulet-tokenapiutils-txkindmetakey-86963">
+### `txKindMetaKey`
 
-txKindMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+txKindMetaKey : Text
+```
 
 Kind of the transaction.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-sendermetakey-57316"></span>
 
-<div id="function-splice-amulet-tokenapiutils-sendermetakey-57316">
+### `senderMetaKey`
 
-senderMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+senderMetaKey : Text
+```
 
 The sender of a transfer.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-burnedmetakey-57705"></span>
 
-<div id="function-splice-amulet-tokenapiutils-burnedmetakey-57705">
+### `burnedMetaKey`
 
-burnedMetaKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+burnedMetaKey : Text
+```
 
 The amount of token holdings burned as part of a transaction.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-holdingtxmeta-93547"></span>
 
-<div id="function-splice-amulet-tokenapiutils-holdingtxmeta-93547">
+### `holdingTxMeta`
 
-holdingTxMeta
-: TxKind -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Metadata
+```daml
+holdingTxMeta : TxKind -> Optional Text -> Optional Party -> Optional Decimal -> Metadata
+```
 
 Build the metadata for a transaction affecting the amulet holdings.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-txkindtotext-55602"></span>
 
-<div id="function-splice-amulet-tokenapiutils-txkindtotext-55602">
+### `txKindToText`
 
-txKindToText
-: TxKind -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+txKindToText : TxKind -> Text
+```
 
 Exported for testing only
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-simpleholdingtxmeta-84235"></span>
 
-<div id="function-splice-amulet-tokenapiutils-simpleholdingtxmeta-84235">
+### `simpleHoldingTxMeta`
 
-simpleHoldingTxMeta
-: TxKind -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Metadata
+```daml
+simpleHoldingTxMeta : TxKind -> Optional Text -> Optional Decimal -> Metadata
+```
 
 Simplified version for a few of the common cases.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-externalpartyconfigstatecontextkey-59994"></span>
 
-<div id="function-splice-amulet-tokenapiutils-externalpartyconfigstatecontextkey-59994">
+### `externalPartyConfigStateContextKey`
 
-externalPartyConfigStateContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+externalPartyConfigStateContextKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-featuredapprightcontextkey-84565"></span>
 
-<div id="function-splice-amulet-tokenapiutils-featuredapprightcontextkey-84565">
+### `featuredAppRightContextKey`
 
-featuredAppRightContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+featuredAppRightContextKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-transferpreapprovalcontextkey-6006"></span>
 
-<div id="function-splice-amulet-tokenapiutils-transferpreapprovalcontextkey-6006">
+### `transferPreapprovalContextKey`
 
-transferPreapprovalContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+transferPreapprovalContextKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-lockcontextkey-29271"></span>
 
-<div id="function-splice-amulet-tokenapiutils-lockcontextkey-29271">
+### `lockContextKey`
 
-lockContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+lockContextKey : Text
+```
 
 The key used to embed all the lock specification in the choice context.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-lockexpiresatcontextkey-3269"></span>
 
-<div id="function-splice-amulet-tokenapiutils-lockexpiresatcontextkey-3269">
+### `lockExpiresAtContextKey`
 
-lockExpiresAtContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+lockExpiresAtContextKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-lockholderscontextkey-51785"></span>
 
-<div id="function-splice-amulet-tokenapiutils-lockholderscontextkey-51785">
+### `lockHoldersContextKey`
 
-lockHoldersContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+lockHoldersContextKey : Text
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-lockcontextcontextkey-63153"></span>
 
-<div id="function-splice-amulet-tokenapiutils-lockcontextcontextkey-63153">
+### `lockContextContextKey`
 
-lockContextContextKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+lockContextContextKey : Text
+```
 
 The context description of a lock.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-expirelockkey-74460"></span>
 
-<div id="function-splice-amulet-tokenapiutils-expirelockkey-74460">
+### `expireLockKey`
 
-expireLockKey
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+expireLockKey : Text
+```
 
-Key used to signal to a choice whether an expired locked amulet should be unlocked.
+Key used to signal to a choice whether an expired locked amulet should be
+unlocked.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-beneficiariesfrommetadata-93977"></span>
 
-<div id="function-splice-amulet-tokenapiutils-beneficiariesfrommetadata-93977">
+### `beneficiariesFromMetadata`
 
-beneficiariesFromMetadata
-: Metadata -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\])
+```daml
+beneficiariesFromMetadata : Metadata -> Either Text (Optional [AppRewardBeneficiary])
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-parsecommaseparated-63776"></span>
 
-<div id="function-splice-amulet-tokenapiutils-parsecommaseparated-63776">
+### `parseCommaSeparated`
 
-parseCommaSeparated
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> ([Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) \[a\]
+```daml
+parseCommaSeparated : Text -> (Text -> Optional a) -> Text -> Either Text [a]
+```
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-addoptionalanyvalue-87443"></span>
 
-<div id="function-splice-amulet-tokenapiutils-addoptionalanyvalue-87443">
+### `addOptionalAnyValue`
 
-addOptionalAnyValue
-: ToAnyValue a =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue
+```daml
+addOptionalAnyValue : ToAnyValue a => Text -> Optional a -> TextMap AnyValue -> TextMap AnyValue
+```
 
-Convenience function to create maps that contain an optional value if it is set. See its use sites for examples.
+Convenience function to create maps that contain an optional value if it is
+set. See its use sites for examples.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-lookupfromcontext-26074"></span>
 
-<div id="function-splice-amulet-tokenapiutils-lookupfromcontext-26074">
+### `lookupFromContext`
 
-lookupFromContext
-: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a)
+```daml
+lookupFromContext : FromAnyValue a => ChoiceContext -> Text -> Either Text (Optional a)
+```
 
 Lookup and decode a value within a choice context.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-getfromcontext-35521"></span>
 
-<div id="function-splice-amulet-tokenapiutils-getfromcontext-35521">
+### `getFromContext`
 
-getFromContext
-: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) a
+```daml
+getFromContext : FromAnyValue a => ChoiceContext -> Text -> Either Text a
+```
 
 Get a value from a choice context, failing if it is not present or fails to parse.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-lookupfromcontextu-72244"></span>
 
-<div id="function-splice-amulet-tokenapiutils-lookupfromcontextu-72244">
+### `lookupFromContextU`
 
-lookupFromContextU
-: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a)
+```daml
+lookupFromContextU : FromAnyValue a => ChoiceContext -> Text -> Update (Optional a)
+```
 
 Convenience version of `lookupFromContext` that raises the failure within the `Update`.
 
-</div>
+<span id="function-splice-amulet-tokenapiutils-getfromcontextu-55645"></span>
 
-<div id="function-splice-amulet-tokenapiutils-getfromcontextu-55645">
+### `getFromContextU`
 
-getFromContextU
-: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) a
+```daml
+getFromContextU : FromAnyValue a => ChoiceContext -> Text -> Update a
+```
 
 Convenience version of `getFromContext` that raises the failure within the `Update`.
 
-</div>
+## Orphan Typeclass Instances
 
-{/* COPIED_END */}
+- `instance Semigroup Metadata`
+
+- `instance Monoid Metadata`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer.mdx
@@ -1,106 +1,112 @@
 ---
 title: "Splice.Amulet.TwoStepTransfer"
-description: "Documentation for Splice.Amulet.TwoStepTransfer"
+description: "Reference documentation for Daml module Splice.Amulet.TwoStepTransfer."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Amulet-TwoStepTransfer.rst" tag="0.6.4" hash="c2645962" */}
+<span id="module-splice-amulet-twosteptransfer-66725"></span>
 
-Generic code for a two-step transfer of amulet. The first step is to lock the amulet, the second step is to transfer it.
+# Splice.Amulet.TwoStepTransfer
+
+Generic code for a two-step transfer of amulet. The first step is to lock
+
+the amulet, the second step is to transfer it.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-amulet-twosteptransfer-twosteptransfer-31697">
+<span id="type-splice-amulet-twosteptransfer-twosteptransfer-31697"></span>
 
-**data** TwoStepTransfer
+### `data TwoStepTransfer`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-amulet-twosteptransfer-twosteptransfer-922">
->
-> TwoStepTransfer
->
-> </div>
->
-> > | Field                  | Type                                                                                                                | Description                                                                                  |
-> > |------------------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                              |
-> > | sender                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                              |
-> > | receiver               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                              |
-> > | amount                 | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |                                                                                              |
-> > | lockContext            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Context description of the lock. This is used to display the reason for the lock in wallets. |
-> > | transferBefore         | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |                                                                                              |
-> > | transferBeforeDeadline | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Name of the deadline for the transfer                                                        |
-> > | provider               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Provider that should be marked as the app provider on the second step.                       |
-> > | allowFeaturing         | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)        | Whether the second step can be featured.                                                     |
->
-> **instance** GetField "allowFeaturing" TwoStepTransfer [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** GetField "amount" TwoStepTransfer [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "dso" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "lockContext" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "provider" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "receiver" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "sender" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "transferBefore" TwoStepTransfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "transferBeforeDeadline" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "allowFeaturing" TwoStepTransfer [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "amount" TwoStepTransfer [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "dso" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "lockContext" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "provider" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "receiver" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "sender" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "transferBefore" TwoStepTransfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "transferBeforeDeadline" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+<span id="constr-splice-amulet-twosteptransfer-twosteptransfer-922"></span>
+
+- `TwoStepTransfer`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+| receiver | Party |  |
+| amount | Decimal |  |
+| lockContext | Text | Context description of the lock. This is used to display the reason for<br/><br/>the lock in wallets. |
+| transferBefore | Time |  |
+| transferBeforeDeadline | Text | Name of the deadline for the transfer |
+| provider | Party | Provider that should be marked as the app provider on the second step. |
+| allowFeaturing | Bool | Whether the second step can be featured. |
+
+Instances:
+
+- `instance GetField allowFeaturing TwoStepTransfer Bool`
+- `instance GetField amount TwoStepTransfer Decimal`
+- `instance GetField dso TwoStepTransfer Party`
+- `instance GetField lockContext TwoStepTransfer Text`
+- `instance GetField provider TwoStepTransfer Party`
+- `instance GetField receiver TwoStepTransfer Party`
+- `instance GetField sender TwoStepTransfer Party`
+- `instance GetField transferBefore TwoStepTransfer Time`
+- `instance GetField transferBeforeDeadline TwoStepTransfer Text`
+- `instance SetField allowFeaturing TwoStepTransfer Bool`
+- `instance SetField amount TwoStepTransfer Decimal`
+- `instance SetField dso TwoStepTransfer Party`
+- `instance SetField lockContext TwoStepTransfer Text`
+- `instance SetField provider TwoStepTransfer Party`
+- `instance SetField receiver TwoStepTransfer Party`
+- `instance SetField sender TwoStepTransfer Party`
+- `instance SetField transferBefore TwoStepTransfer Time`
+- `instance SetField transferBeforeDeadline TwoStepTransfer Text`
 
 ## Functions
 
-<div id="function-splice-amulet-twosteptransfer-holdingtotransferinputs-13824">
+<span id="function-splice-amulet-twosteptransfer-holdingtotransferinputs-13824"></span>
 
-holdingToTransferInputs
-: ForOwner -\> \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) \[TransferInput\]
+### `holdingToTransferInputs`
 
-Converting a set of holding inputs to inputs for an amulet transfer, unlocking any expired LockedAmulet holdings on the fly.
+```daml
+holdingToTransferInputs : ForOwner -> [ContractId Holding] -> Update [TransferInput]
+```
 
-</div>
+Converting a set of holding inputs to inputs for an amulet transfer,
+unlocking any expired LockedAmulet holdings on the fly.
 
-<div id="function-splice-amulet-twosteptransfer-preparetwosteptransfer-60675">
+<span id="function-splice-amulet-twosteptransfer-preparetwosteptransfer-60675"></span>
 
-prepareTwoStepTransfer
-: TwoStepTransfer -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] -\> ExternalPartyTransferContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet, \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\], Metadata)
+### `prepareTwoStepTransfer`
+
+```daml
+prepareTwoStepTransfer : TwoStepTransfer -> Time -> [ContractId Holding] -> ExternalPartyTransferContext -> Update (ContractId LockedAmulet, [ContractId Holding], Metadata)
+```
 
 Prepare a two-step transfer of amulet by locking the funds.
 
-</div>
+<span id="function-splice-amulet-twosteptransfer-executetwosteptransfer-18767"></span>
 
-<div id="function-splice-amulet-twosteptransfer-executetwosteptransfer-18767">
+### `executeTwoStepTransfer`
 
-executeTwoStepTransfer
-: TwoStepTransfer -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet -\> ExtraArgs -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (\[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\], \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\], Metadata)
+```daml
+executeTwoStepTransfer : TwoStepTransfer -> ContractId LockedAmulet -> ExtraArgs -> Update ([ContractId Holding], [ContractId Holding], Metadata)
+```
 
-</div>
+<span id="function-splice-amulet-twosteptransfer-aborttwosteptransfer-11048"></span>
 
-<div id="function-splice-amulet-twosteptransfer-aborttwosteptransfer-11048">
+### `abortTwoStepTransfer`
 
-abortTwoStepTransfer
-: TwoStepTransfer -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet -\> ExtraArgs -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
-
-</div>
-
-{/* COPIED_END */}
+```daml
+abortTwoStepTransfer : TwoStepTransfer -> ContractId LockedAmulet -> ExtraArgs -> Update [ContractId Holding]
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet.mdx
@@ -1,1325 +1,1199 @@
 ---
 title: "Splice.Amulet"
-description: "Documentation for Splice.Amulet"
+description: "Reference documentation for Daml module Splice.Amulet."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Amulet.rst" tag="0.6.4" hash="48e2f479" */}
+<span id="module-splice-amulet-64804"></span>
+
+# Splice.Amulet
 
 The contracts representing the long-term state of Splice.
 
-## Templates
+## Module Snapshot
 
-<div id="type-splice-amulet-amulet-63582">
-
-**template** Amulet
-
-</div>
-
-> A amulet, which can be locked and whose amount expires over time.
->
-> The expiry serves to charge an inactivity fee, and thereby ensures that the SVs can reclaim the corresponding storage space at some point in the future.
->
-> Signatory: dso, owner
->
-> | Field  | Type                                                                                                                | Description |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | owner  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | amount | ExpiringAmount                                                                                                      |             |
->
-> - <div id="type-splice-amulet-amuletexpire-87297">
->
->   **Choice** Amulet_Expire
->
->   </div>
->
->   Controller: dso
->
->   Returns: Amulet_ExpireResult
->
->   | Field    | Type                                                                                                                                          | Description |
->   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | roundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amulet-amuletexpirev2-59227">
->
->   **Choice** Amulet_ExpireV2
->
->   </div>
->
->   Controller: dso
->
->   Returns: Amulet_ExpireV2Result
->
->   | Field                        | Type                                                                                                                                                   | Description |
->   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | externalPartyConfigState0Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->   | externalPartyConfigState1Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->
-> - **Choice** Archive
->
->   Controller: dso, owner
->
->   Returns: ()
->
->   (no fields)
->
-> - **interface instance** Holding **for** Amulet
-
-<div id="type-splice-amulet-apprewardcoupon-57229">
-
-**template** AppRewardCoupon
-
-</div>
-
-> A coupon for receiving app rewards proportional to the usage fee paid as part of a Amulet transfer coordinated by the app of a provider.
->
-> Signatory: dso
->
-> | Field       | Type                                                                                                                                                                                                                                               | Description                                                           |
-> |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |                                                                       |
-> | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                | Application provider                                                  |
-> | featured    | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                                       |                                                                       |
-> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                 |                                                                       |
-> | round       | Round                                                                                                                                                                                                                                              |                                                                       |
-> | beneficiary | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that can mint this reward. If not set, this is the provider |
->
-> - <div id="type-splice-amulet-apprewardcoupondsoexpire-84081">
->
->   **Choice** AppRewardCoupon_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: AppRewardCoupon_DsoExpireResult
->
->   | Field          | Type                                                                                                                                            | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-amulet-developmentfundcoupon-75673">
-
-**template** DevelopmentFundCoupon
-
-</div>
-
-> A coupon recording an emission for the Development Fund under CIP-0082, which can be collected by the designated beneficiary.
->
-> Signatory: dso
->
-> | Field       | Type                                                                                                                | Description                                                                                                         |
-> |-------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                     |
-> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the `Amulet` to be minted.                                                                             |
-> | fundManager | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that executed the assignment of the coupon to the beneficiary so they can mint from the development fund. |
-> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The total amount of `Amulet` to mint on collection.                                                                 |
-> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Until when the minting can be completed.                                                                            |
-> | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Reason for the emission of the coupon.                                                                              |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-developmentfundcoupondsoexpire-7301">
->
->   **Choice** DevelopmentFundCoupon_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: DevelopmentFundCoupon_DsoExpireResult
->
->   (no fields)
->
-> - <div id="type-splice-amulet-developmentfundcouponreject-89668">
->
->   **Choice** DevelopmentFundCoupon_Reject
->
->   </div>
->
->   Controller: beneficiary
->
->   Returns: DevelopmentFundCoupon_RejectResult
->
->   | Field  | Type                                                                                                         | Description                      |
->   |--------|--------------------------------------------------------------------------------------------------------------|----------------------------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Reason for rejecting the coupon. |
->
-> - <div id="type-splice-amulet-developmentfundcouponwithdraw-58125">
->
->   **Choice** DevelopmentFundCoupon_Withdraw
->
->   </div>
->
->   Controller: fundManager
->
->   Returns: DevelopmentFundCoupon_WithdrawResult
->
->   | Field  | Type                                                                                                         | Description                        |
->   |--------|--------------------------------------------------------------------------------------------------------------|------------------------------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Reason for withdrawing the coupon. |
-
-<div id="type-splice-amulet-featuredappactivitymarker-16451">
-
-**template** FeaturedAppActivityMarker
-
-</div>
-
-> A marker created by a featured application for activity generated from that app. This is used to record activity other than amulet transfers where regular AppRewardCoupons are not created directly.
->
-> Will be converted to a AppRewardCoupon through automation run by the SVs and can then be minted as part of the normal minting process.
->
-> Signatory: dso
->
-> | Field       | Type                                                                                                                | Description                                                                                                                                                                                                                                                  |
-> |-------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                                                                                                                                                              |
-> | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The featured app provider that created the activity marker.                                                                                                                                                                                                  |
-> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that has the right to mint the reward.                                                                                                                                                                                                             |
-> | weight      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The weight of the marker. This is used to split the rewards for a single action, e.g., multiple parties collaborating to enable a transfer, by creating several FeaturedAppActivityMarkers with different beneficiaries such that the weights add up to 1.0. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - **interface instance** FeaturedAppActivityMarker **for** FeaturedAppActivityMarker
->
-> - **interface instance** FeaturedAppActivityMarker **for** FeaturedAppActivityMarker
-
-<div id="type-splice-amulet-featuredappright-765">
-
-**template** FeaturedAppRight
-
-</div>
-
-> The right for an application provider to earn featured app rewards.
->
-> Signatory: dso
->
-> | Field    | Type                                                                                                                | Description |
-> |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-featuredapprightcancel-96535">
->
->   **Choice** FeaturedAppRight_Cancel
->
->   </div>
->
->   Controller: provider
->
->   Returns: FeaturedAppRight_CancelResult
->
->   (no fields)
->
-> - <div id="type-splice-amulet-featuredapprightwithdraw-8217">
->
->   **Choice** FeaturedAppRight_Withdraw
->
->   </div>
->
->   Controller: dso
->
->   Returns: FeaturedAppRight_WithdrawResult
->
->   | Field  | Type                                                                                                         | Description |
->   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - **interface instance** FeaturedAppRight **for** FeaturedAppRight
->
-> - **interface instance** FeaturedAppRight **for** FeaturedAppRight
-
-<div id="type-splice-amulet-lockedamulet-7030">
-
-**template** LockedAmulet
-
-</div>
-
-> Signatory: (DA.Internal.Record.getField @"holders" lock), signatory amulet
->
-> | Field  | Type     | Description |
-> |--------|----------|-------------|
-> | amulet | Amulet   |             |
-> | lock   | TimeLock |             |
->
-> - **Choice** Archive
->
->   Controller: (DA.Internal.Record.getField @"holders" lock), signatory amulet
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-lockedamuletexpireamulet-28333">
->
->   **Choice** LockedAmulet_ExpireAmulet
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"dso" amulet)
->
->   Returns: LockedAmulet_ExpireAmuletResult
->
->   | Field    | Type                                                                                                                                          | Description |
->   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | roundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amulet-lockedamuletexpireamuletv2-51335">
->
->   **Choice** LockedAmulet_ExpireAmuletV2
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"dso" amulet)
->
->   Returns: LockedAmulet_ExpireAmuletV2Result
->
->   | Field                        | Type                                                                                                                                                   | Description |
->   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | externalPartyConfigState0Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->   | externalPartyConfigState1Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->
-> - <div id="type-splice-amulet-lockedamuletownerexpirelock-79102">
->
->   **Choice** LockedAmulet_OwnerExpireLock
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"owner" amulet)
->
->   Returns: LockedAmulet_OwnerExpireLockResult
->
->   | Field        | Type                                                                                                                                          | Description |
->   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amulet-lockedamuletownerexpirelockv2-20152">
->
->   **Choice** LockedAmulet_OwnerExpireLockV2
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"owner" amulet)
->
->   Returns: LockedAmulet_OwnerExpireLockV2Result
->
->   (no fields)
->
-> - <div id="type-splice-amulet-lockedamuletunlock-59352">
->
->   **Choice** LockedAmulet_Unlock
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)
->
->   Returns: LockedAmulet_UnlockResult
->
->   | Field        | Type                                                                                                                                          | Description |
->   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amulet-lockedamuletunlockv2-31390">
->
->   **Choice** LockedAmulet_UnlockV2
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)
->
->   Returns: LockedAmulet_UnlockV2Result
->
->   (no fields)
->
-> - **interface instance** Holding **for** LockedAmulet
-
-<div id="type-splice-amulet-svrewardcoupon-68580">
-
-**template** SvRewardCoupon
-
-</div>
-
-> A coupon for a beneficiary to receive part of the SV issuance for a specific SV node and round.
->
-> Signatory: dso
->
-> | Field       | Type                                                                                                                | Description                                                              |
-> |-------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                          |
-> | sv          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party identifying the SV node for which the reward is issued.        |
-> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The beneficiary allowed to receive the reward.                           |
-> | round       | Round                                                                                                               |                                                                          |
-> | weight      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | Coupons receive a share of the SV issuance proportional to their weight. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-svrewardcouponarchiveasbeneficiary-26109">
->
->   **Choice** SvRewardCoupon_ArchiveAsBeneficiary
->
->   </div>
->
->   Controller: beneficiary
->
->   Returns: SvRewardCoupon_ArchiveAsBeneficiaryResult
->
->   (no fields)
->
-> - <div id="type-splice-amulet-svrewardcoupondsoexpire-92140">
->
->   **Choice** SvRewardCoupon_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: SvRewardCoupon_DsoExpireResult
->
->   | Field          | Type                                                                                                                                            | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
-
-<div id="type-splice-amulet-unclaimedactivityrecord-97331">
-
-**template** UnclaimedActivityRecord
-
-</div>
-
-> A record of activity that can be minted by the beneficiary. Note that these do not come out of the per-round issuance but are instead created by burning UnclaimedRewardCoupon as defined through a vote by the SVs. That's also why expiry is a separate time-based expiry instead of being tied to a round like the other activity records.
->
-> Signatory: dso
->
-> | Field       | Type                                                                                                                | Description                                               |
-> |-------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                           |
-> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the `Amulet` to be minted.                   |
-> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The amount of `Amulet` to be minted.                      |
-> | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | A reason to mint the `Amulet`.                            |
-> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Selected timestamp defining the lifetime of the contract. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-unclaimedactivityrecorddsoexpire-41307">
->
->   **Choice** UnclaimedActivityRecord_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: UnclaimedActivityRecord_DsoExpireResult
->
->   (no fields)
-
-<div id="type-splice-amulet-unclaimeddevelopmentfundcoupon-41000">
-
-**template** UnclaimedDevelopmentFundCoupon
-
-</div>
-
-> A coupon recording an emission for the Development Fund from CIP-0082 that was not yet assigned to a specific beneficiary.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                | Description                                         |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                     |
-> | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The total amount of `Amulet` to mint on collection. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-amulet-unclaimedreward-7814">
-
-**template** UnclaimedReward
-
-</div>
-
-> Rewards that have not been claimed and are thus at the disposal of the foundation.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                | Description |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-amulet-validatorrewardcoupon-76808">
-
-**template** ValidatorRewardCoupon
-
-</div>
-
-> A coupon for receiving validator rewards proportional to the usage fee paid by a user hosted by a validator operator.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                | Description |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | user   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
-> | round  | Round                                                                                                               |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-validatorrewardcouponarchiveasvalidator-99406">
->
->   **Choice** ValidatorRewardCoupon_ArchiveAsValidator
->
->   </div>
->
->   This choice is used by validators to archive the burn receipt upon claiming its corresponding issuance.
->
->   Controller: dso, validator
->
->   Returns: ValidatorRewardCoupon_ArchiveAsValidatorResult
->
->   | Field     | Type                                                                                                                                         | Description |
->   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                          |             |
->   | rightCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight |             |
->
-> - <div id="type-splice-amulet-validatorrewardcoupondsoexpire-85552">
->
->   **Choice** ValidatorRewardCoupon_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: ValidatorRewardCoupon_DsoExpireResult
->
->   | Field          | Type                                                                                                                                            | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
-
-<div id="type-splice-amulet-validatorright-15964">
-
-**template** ValidatorRight
-
-</div>
-
-> The right to claim amulet issuances for a user's burns as their validator.
->
-> Signatory: user, validator
->
-> | Field     | Type                                                                                                                | Description |
-> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | user      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: user, validator
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amulet-validatorrightarchiveasuser-43276">
->
->   **Choice** ValidatorRight_ArchiveAsUser
->
->   </div>
->
->   Controller: user
->
->   Returns: ValidatorRight_ArchiveAsUserResult
->
->   (no fields)
->
-> - <div id="type-splice-amulet-validatorrightarchiveasvalidator-83210">
->
->   **Choice** ValidatorRight_ArchiveAsValidator
->
->   </div>
->
->   Controller: validator
->
->   Returns: ValidatorRight_ArchiveAsValidatorResult
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-amulet-amuletcreatesummary-15609">
-
-**data** AmuletCreateSummary amuletContractId
-
-</div>
-
-> Result of an operation that created a new amulet, e.g., by minting a fresh amulet, or by unlocking a locked amulet.
->
-> <div id="constr-splice-amulet-amuletcreatesummary-64070">
->
-> AmuletCreateSummary
->
-> </div>
->
-> > | Field       | Type                                                                                                               | Description                                          |
-> > |-------------|--------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-> > | amulet      | amuletContractId                                                                                                   | The new amulet that was created                      |
-> > | amuletPrice | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The amulet price at the round the amulet was created |
-> > | round       | Round                                                                                                              | Round for which this amulet was created.             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) amuletContractId =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (AmuletCreateSummary amuletContractId)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) amuletContractId =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (AmuletCreateSummary amuletContractId)
->
-> **instance** GetField "amulet" (AmuletCreateSummary amuletContractId) amuletContractId
->
-> **instance** GetField "amuletPrice" (AmuletCreateSummary amuletContractId) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "round" (AmuletCreateSummary amuletContractId) Round
->
-> **instance** SetField "amulet" (AmuletCreateSummary amuletContractId) amuletContractId
->
-> **instance** SetField "amuletPrice" (AmuletCreateSummary amuletContractId) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "round" (AmuletCreateSummary amuletContractId) Round
-
-<div id="type-splice-amulet-amuletexpiresummary-4706">
-
-**data** AmuletExpireSummary
-
-</div>
-
-> <div id="constr-splice-amulet-amuletexpiresummary-31721">
->
-> AmuletExpireSummary
->
-> </div>
->
-> > | Field                              | Type                                                                                                                | Description                                                     |
-> > |------------------------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-> > | owner                              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                 |
-> > | round                              | Round                                                                                                               | Round for which this expiry was registered.                     |
-> > | changeToInitialAmountAsOfRoundZero | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |                                                                 |
-> > | changeToHoldingFeesRate            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The change of total holding fees introduced by a amulet expiry. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletExpireSummary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletExpireSummary
->
-> **instance** GetField "changeToHoldingFeesRate" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "changeToInitialAmountAsOfRoundZero" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
->
-> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
->
-> **instance** GetField "owner" AmuletExpireSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "round" AmuletExpireSummary Round
->
-> **instance** SetField "changeToHoldingFeesRate" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "changeToInitialAmountAsOfRoundZero" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
->
-> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
->
-> **instance** SetField "owner" AmuletExpireSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "round" AmuletExpireSummary Round
-
-<div id="type-splice-amulet-amuletexpirev2summary-45428">
-
-**data** AmuletExpireV2Summary
-
-</div>
-
-> <div id="constr-splice-amulet-amuletexpirev2summary-89407">
->
-> AmuletExpireV2Summary
->
-> </div>
->
-> > | Field | Type                                                                                                                | Description |
-> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | owner | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletExpireV2Summary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletExpireV2Summary
->
-> **instance** GetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
->
-> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
->
-> **instance** GetField "owner" AmuletExpireV2Summary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
->
-> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
->
-> **instance** SetField "owner" AmuletExpireV2Summary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
-
-<div id="type-splice-amulet-amuletexpireresult-11748">
-
-**data** Amulet_ExpireResult
-
-</div>
-
-> <div id="constr-splice-amulet-amuletexpireresult-71583">
->
-> Amulet_ExpireResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                    | Description |
-> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | expireSum | AmuletExpireSummary                                                                                                                     |             |
-> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata |             |
->
-> **instance** GetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
->
-> **instance** GetField "meta" Amulet_ExpireResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
->
-> **instance** SetField "meta" Amulet_ExpireResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Amulet Amulet_Expire Amulet_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Amulet Amulet_Expire Amulet_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Amulet Amulet_Expire Amulet_ExpireResult
-
-<div id="type-splice-amulet-amuletexpirev2result-68414">
-
-**data** Amulet_ExpireV2Result
-
-</div>
-
-> <div id="constr-splice-amulet-amuletexpirev2result-95029">
->
-> Amulet_ExpireV2Result
->
-> </div>
->
-> > | Field     | Type                  | Description |
-> > |-----------|-----------------------|-------------|
-> > | expireSum | AmuletExpireV2Summary |             |
-> > | meta      | Metadata              |             |
->
-> **instance** GetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
->
-> **instance** GetField "meta" Amulet_ExpireV2Result Metadata
->
-> **instance** SetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
->
-> **instance** SetField "meta" Amulet_ExpireV2Result Metadata
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Amulet Amulet_ExpireV2 Amulet_ExpireV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Amulet Amulet_ExpireV2 Amulet_ExpireV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Amulet Amulet_ExpireV2 Amulet_ExpireV2Result
-
-<div id="type-splice-amulet-apprewardcoupondsoexpireresult-15772">
-
-**data** AppRewardCoupon_DsoExpireResult
-
-</div>
-
-> <div id="constr-splice-amulet-apprewardcoupondsoexpireresult-84547">
->
-> AppRewardCoupon_DsoExpireResult
->
-> </div>
->
-> > | Field    | Type                                                                                                               | Description |
-> > |----------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | featured | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)       |             |
-> > | amount   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
->
-> **instance** GetField "amount" AppRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "featured" AppRewardCoupon_DsoExpireResult [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "amount" AppRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "featured" AppRewardCoupon_DsoExpireResult [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult
-
-<div id="type-splice-amulet-developmentfundcoupondsoexpireresult-6252">
-
-**data** DevelopmentFundCoupon_DsoExpireResult
-
-</div>
-
-> <div id="constr-splice-amulet-developmentfundcoupondsoexpireresult-48451">
->
-> DevelopmentFundCoupon_DsoExpireResult
->
-> </div>
->
-> > | Field                             | Type                                                                                                                                                         | Description |
-> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
->
-> **instance** GetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** SetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult
-
-<div id="type-splice-amulet-developmentfundcouponrejectresult-16689">
-
-**data** DevelopmentFundCoupon_RejectResult
-
-</div>
-
-> <div id="constr-splice-amulet-developmentfundcouponrejectresult-31260">
->
-> DevelopmentFundCoupon_RejectResult
->
-> </div>
->
-> > | Field                             | Type                                                                                                                                                         | Description |
-> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
->
-> **instance** GetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** SetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult
-
-<div id="type-splice-amulet-developmentfundcouponwithdrawresult-40988">
-
-**data** DevelopmentFundCoupon_WithdrawResult
-
-</div>
-
-> <div id="constr-splice-amulet-developmentfundcouponwithdrawresult-40985">
->
-> DevelopmentFundCoupon_WithdrawResult
->
-> </div>
->
-> > | Field                             | Type                                                                                                                                                         | Description |
-> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
->
-> **instance** GetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** SetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult
-
-<div id="type-splice-amulet-featuredapprightcancelresult-22074">
-
-**data** FeaturedAppRight_CancelResult
-
-</div>
-
-> <div id="constr-splice-amulet-featuredapprightcancelresult-30485">
->
-> FeaturedAppRight_CancelResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult
-
-<div id="type-splice-amulet-featuredapprightwithdrawresult-98740">
-
-**data** FeaturedAppRight_WithdrawResult
-
-</div>
-
-> <div id="constr-splice-amulet-featuredapprightwithdrawresult-88987">
->
-> FeaturedAppRight_WithdrawResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult
-
-<div id="type-splice-amulet-lockedamuletexpireamuletresult-88432">
-
-**data** LockedAmulet_ExpireAmuletResult
-
-</div>
-
-> <div id="constr-splice-amulet-lockedamuletexpireamuletresult-82939">
->
-> LockedAmulet_ExpireAmuletResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                    | Description |
-> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | expireSum | AmuletExpireSummary                                                                                                                     |             |
-> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata |             |
->
-> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
->
-> **instance** GetField "meta" LockedAmulet_ExpireAmuletResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
->
-> **instance** SetField "meta" LockedAmulet_ExpireAmuletResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult
-
-<div id="type-splice-amulet-lockedamuletexpireamuletv2result-81066">
-
-**data** LockedAmulet_ExpireAmuletV2Result
-
-</div>
-
-> <div id="constr-splice-amulet-lockedamuletexpireamuletv2result-89449">
->
-> LockedAmulet_ExpireAmuletV2Result
->
-> </div>
->
-> > | Field     | Type                  | Description |
-> > |-----------|-----------------------|-------------|
-> > | expireSum | AmuletExpireV2Summary |             |
-> > | meta      | Metadata              |             |
->
-> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
->
-> **instance** GetField "meta" LockedAmulet_ExpireAmuletV2Result Metadata
->
-> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
->
-> **instance** SetField "meta" LockedAmulet_ExpireAmuletV2Result Metadata
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result
-
-<div id="type-splice-amulet-lockedamuletownerexpirelockresult-44583">
-
-**data** LockedAmulet_OwnerExpireLockResult
-
-</div>
-
-> <div id="constr-splice-amulet-lockedamuletownerexpirelockresult-40926">
->
-> LockedAmulet_OwnerExpireLockResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
-> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                    |             |
->
-> **instance** GetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "meta" LockedAmulet_OwnerExpireLockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "meta" LockedAmulet_OwnerExpireLockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult
-
-<div id="type-splice-amulet-lockedamuletownerexpirelockv2result-70273">
-
-**data** LockedAmulet_OwnerExpireLockV2Result
-
-</div>
-
-> <div id="constr-splice-amulet-lockedamuletownerexpirelockv2result-66952">
->
-> LockedAmulet_OwnerExpireLockV2Result
->
-> </div>
->
-> > | Field     | Type                                                                                                                                 | Description |
-> > |-----------|--------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet |             |
-> > | meta      | Metadata                                                                                                                             |             |
->
-> **instance** GetField "amuletCid" LockedAmulet_OwnerExpireLockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** GetField "meta" LockedAmulet_OwnerExpireLockV2Result Metadata
->
-> **instance** SetField "amuletCid" LockedAmulet_OwnerExpireLockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** SetField "meta" LockedAmulet_OwnerExpireLockV2Result Metadata
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result
-
-<div id="type-splice-amulet-lockedamuletunlockresult-29457">
-
-**data** LockedAmulet_UnlockResult
-
-</div>
-
-> <div id="constr-splice-amulet-lockedamuletunlockresult-40430">
->
-> LockedAmulet_UnlockResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
-> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                    |             |
->
-> **instance** GetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "meta" LockedAmulet_UnlockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "meta" LockedAmulet_UnlockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult
-
-<div id="type-splice-amulet-lockedamuletunlockv2result-80903">
-
-**data** LockedAmulet_UnlockV2Result
-
-</div>
-
-> <div id="constr-splice-amulet-lockedamuletunlockv2result-28736">
->
-> LockedAmulet_UnlockV2Result
->
-> </div>
->
-> > | Field     | Type                                                                                                                                 | Description |
-> > |-----------|--------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet |             |
-> > | meta      | Metadata                                                                                                                             |             |
->
-> **instance** GetField "amuletCid" LockedAmulet_UnlockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** GetField "meta" LockedAmulet_UnlockV2Result Metadata
->
-> **instance** SetField "amuletCid" LockedAmulet_UnlockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** SetField "meta" LockedAmulet_UnlockV2Result Metadata
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result
-
-<div id="type-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-20724">
-
-**data** SvRewardCoupon_ArchiveAsBeneficiaryResult
-
-</div>
-
-> <div id="constr-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-19239">
->
-> SvRewardCoupon_ArchiveAsBeneficiaryResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult
-
-<div id="type-splice-amulet-svrewardcoupondsoexpireresult-4801">
-
-**data** SvRewardCoupon_DsoExpireResult
-
-</div>
-
-> <div id="constr-splice-amulet-svrewardcoupondsoexpireresult-59696">
->
-> SvRewardCoupon_DsoExpireResult
->
-> </div>
->
-> > | Field  | Type                                                                                                       | Description |
-> > |--------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | weight | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> **instance** GetField "weight" SvRewardCoupon_DsoExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "weight" SvRewardCoupon_DsoExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult
-
-<div id="type-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59553">
-
-**data** UnclaimedActivityRecord_ArchiveAsBeneficiaryResult
-
-</div>
-
-> <div id="constr-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59904">
->
-> UnclaimedActivityRecord_ArchiveAsBeneficiaryResult
->
-> </div>
-
-<div id="type-splice-amulet-unclaimedactivityrecorddsoexpireresult-73042">
-
-**data** UnclaimedActivityRecord_DsoExpireResult
-
-</div>
-
-> <div id="constr-splice-amulet-unclaimedactivityrecorddsoexpireresult-28805">
->
-> UnclaimedActivityRecord_DsoExpireResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedRewardCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
->
-> **instance** GetField "unclaimedRewardCid" UnclaimedActivityRecord_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** SetField "unclaimedRewardCid" UnclaimedActivityRecord_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult
-
-<div id="type-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-41727">
-
-**data** ValidatorRewardCoupon_ArchiveAsValidatorResult
-
-</div>
-
-> <div id="constr-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-51782">
->
-> ValidatorRewardCoupon_ArchiveAsValidatorResult
->
-> </div>
->
-> > (no fields)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult
-
-<div id="type-splice-amulet-validatorrewardcoupondsoexpireresult-94761">
-
-**data** ValidatorRewardCoupon_DsoExpireResult
-
-</div>
-
-> <div id="constr-splice-amulet-validatorrewardcoupondsoexpireresult-92822">
->
-> ValidatorRewardCoupon_DsoExpireResult
->
-> </div>
->
-> > | Field  | Type                                                                                                               | Description |
-> > |--------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
->
-> **instance** GetField "amount" ValidatorRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amount" ValidatorRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult
-
-<div id="type-splice-amulet-validatorrightarchiveasuserresult-3193">
-
-**data** ValidatorRight_ArchiveAsUserResult
-
-</div>
-
-> <div id="constr-splice-amulet-validatorrightarchiveasuserresult-47620">
->
-> ValidatorRight_ArchiveAsUserResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult
-
-<div id="type-splice-amulet-validatorrightarchiveasvalidatorresult-59299">
-
-**data** ValidatorRight_ArchiveAsValidatorResult
-
-</div>
-
-> <div id="constr-splice-amulet-validatorrightarchiveasvalidatorresult-93588">
->
-> ValidatorRight_ArchiveAsValidatorResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult
+<span id="type-splice-amulet-amuletcreatesummary-15609"></span>
+
+### `data AmuletCreateSummary amuletContractId`
+
+Result of an operation that created a new amulet, e.g.,
+by minting a fresh amulet, or by unlocking a locked amulet.
+
+Constructors:
+
+<span id="constr-splice-amulet-amuletcreatesummary-64070"></span>
+
+- `AmuletCreateSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | amuletContractId | The new amulet that was created |
+| amuletPrice | Decimal | The amulet price at the round the amulet was created |
+| round | Round | Round for which this amulet was created. |
+
+Instances:
+
+- `instance Eq amuletContractId => Eq (AmuletCreateSummary amuletContractId)`
+- `instance Show amuletContractId => Show (AmuletCreateSummary amuletContractId)`
+- `instance GetField amulet (AmuletCreateSummary amuletContractId) amuletContractId`
+- `instance GetField amuletPrice (AmuletCreateSummary amuletContractId) Decimal`
+- `instance GetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField round (AmuletCreateSummary amuletContractId) Round`
+- `instance SetField amulet (AmuletCreateSummary amuletContractId) amuletContractId`
+- `instance SetField amuletPrice (AmuletCreateSummary amuletContractId) Decimal`
+- `instance SetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField round (AmuletCreateSummary amuletContractId) Round`
+
+<span id="type-splice-amulet-amuletexpiresummary-4706"></span>
+
+### `data AmuletExpireSummary`
+
+Constructors:
+
+<span id="constr-splice-amulet-amuletexpiresummary-31721"></span>
+
+- `AmuletExpireSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party |  |
+| round | Round | Round for which this expiry was registered. |
+| changeToInitialAmountAsOfRoundZero | Decimal |  |
+| changeToHoldingFeesRate | Decimal | The change of total holding fees introduced by a amulet expiry. |
+
+Instances:
+
+- `instance Eq AmuletExpireSummary`
+- `instance Show AmuletExpireSummary`
+- `instance GetField changeToHoldingFeesRate AmuletExpireSummary Decimal`
+- `instance GetField changeToInitialAmountAsOfRoundZero AmuletExpireSummary Decimal`
+- `instance GetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance GetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance GetField owner AmuletExpireSummary Party`
+- `instance GetField round AmuletExpireSummary Round`
+- `instance SetField changeToHoldingFeesRate AmuletExpireSummary Decimal`
+- `instance SetField changeToInitialAmountAsOfRoundZero AmuletExpireSummary Decimal`
+- `instance SetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance SetField owner AmuletExpireSummary Party`
+- `instance SetField round AmuletExpireSummary Round`
+
+<span id="type-splice-amulet-amuletexpirev2summary-45428"></span>
+
+### `data AmuletExpireV2Summary`
+
+Constructors:
+
+<span id="constr-splice-amulet-amuletexpirev2summary-89407"></span>
+
+- `AmuletExpireV2Summary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party |  |
+
+Instances:
+
+- `instance Eq AmuletExpireV2Summary`
+- `instance Show AmuletExpireV2Summary`
+- `instance GetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance GetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance GetField owner AmuletExpireV2Summary Party`
+- `instance SetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance SetField owner AmuletExpireV2Summary Party`
+
+<span id="type-splice-amulet-amuletexpireresult-11748"></span>
+
+### `data Amulet_ExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-amuletexpireresult-71583"></span>
+
+- `Amulet_ExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance GetField meta Amulet_ExpireResult (Optional Metadata)`
+- `instance SetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance SetField meta Amulet_ExpireResult (Optional Metadata)`
+- `instance HasExercise Amulet Amulet_Expire Amulet_ExpireResult`
+- `instance HasFromAnyChoice Amulet Amulet_Expire Amulet_ExpireResult`
+- `instance HasToAnyChoice Amulet Amulet_Expire Amulet_ExpireResult`
+
+<span id="type-splice-amulet-amuletexpirev2result-68414"></span>
+
+### `data Amulet_ExpireV2Result`
+
+Constructors:
+
+<span id="constr-splice-amulet-amuletexpirev2result-95029"></span>
+
+- `Amulet_ExpireV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance GetField meta Amulet_ExpireV2Result Metadata`
+- `instance SetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance SetField meta Amulet_ExpireV2Result Metadata`
+- `instance HasExercise Amulet Amulet_ExpireV2 Amulet_ExpireV2Result`
+- `instance HasFromAnyChoice Amulet Amulet_ExpireV2 Amulet_ExpireV2Result`
+- `instance HasToAnyChoice Amulet Amulet_ExpireV2 Amulet_ExpireV2Result`
+
+<span id="type-splice-amulet-apprewardcoupondsoexpireresult-15772"></span>
+
+### `data AppRewardCoupon_DsoExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-apprewardcoupondsoexpireresult-84547"></span>
+
+- `AppRewardCoupon_DsoExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featured | Bool |  |
+| amount | Decimal |  |
+
+Instances:
+
+- `instance GetField amount AppRewardCoupon_DsoExpireResult Decimal`
+- `instance GetField featured AppRewardCoupon_DsoExpireResult Bool`
+- `instance SetField amount AppRewardCoupon_DsoExpireResult Decimal`
+- `instance SetField featured AppRewardCoupon_DsoExpireResult Bool`
+- `instance HasExercise AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult`
+- `instance HasToAnyChoice AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult`
+
+<span id="type-splice-amulet-developmentfundcoupondsoexpireresult-6252"></span>
+
+### `data DevelopmentFundCoupon_DsoExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-developmentfundcoupondsoexpireresult-48451"></span>
+
+- `DevelopmentFundCoupon_DsoExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_DsoExpireResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_DsoExpireResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult`
+- `instance HasToAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult`
+
+<span id="type-splice-amulet-developmentfundcouponrejectresult-16689"></span>
+
+### `data DevelopmentFundCoupon_RejectResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-developmentfundcouponrejectresult-31260"></span>
+
+- `DevelopmentFundCoupon_RejectResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_RejectResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_RejectResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult`
+- `instance HasFromAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult`
+- `instance HasToAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult`
+
+<span id="type-splice-amulet-developmentfundcouponwithdrawresult-40988"></span>
+
+### `data DevelopmentFundCoupon_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-developmentfundcouponwithdrawresult-40985"></span>
+
+- `DevelopmentFundCoupon_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_WithdrawResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_WithdrawResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult`
+- `instance HasFromAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult`
+- `instance HasToAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult`
+
+<span id="type-splice-amulet-featuredapprightcancelresult-22074"></span>
+
+### `data FeaturedAppRight_CancelResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-featuredapprightcancelresult-30485"></span>
+
+- `FeaturedAppRight_CancelResult`
+
+Instances:
+
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult`
+
+<span id="type-splice-amulet-featuredapprightwithdrawresult-98740"></span>
+
+### `data FeaturedAppRight_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-featuredapprightwithdrawresult-88987"></span>
+
+- `FeaturedAppRight_WithdrawResult`
+
+Instances:
+
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult`
+
+<span id="type-splice-amulet-lockedamuletexpireamuletresult-88432"></span>
+
+### `data LockedAmulet_ExpireAmuletResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-lockedamuletexpireamuletresult-82939"></span>
+
+- `LockedAmulet_ExpireAmuletResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance GetField meta LockedAmulet_ExpireAmuletResult (Optional Metadata)`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance SetField meta LockedAmulet_ExpireAmuletResult (Optional Metadata)`
+- `instance HasExercise LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult`
+
+<span id="type-splice-amulet-lockedamuletexpireamuletv2result-81066"></span>
+
+### `data LockedAmulet_ExpireAmuletV2Result`
+
+Constructors:
+
+<span id="constr-splice-amulet-lockedamuletexpireamuletv2result-89449"></span>
+
+- `LockedAmulet_ExpireAmuletV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance GetField meta LockedAmulet_ExpireAmuletV2Result Metadata`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance SetField meta LockedAmulet_ExpireAmuletV2Result Metadata`
+- `instance HasExercise LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result`
+
+<span id="type-splice-amulet-lockedamuletownerexpirelockresult-44583"></span>
+
+### `data LockedAmulet_OwnerExpireLockResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-lockedamuletownerexpirelockresult-40926"></span>
+
+- `LockedAmulet_OwnerExpireLockResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField meta LockedAmulet_OwnerExpireLockResult (Optional Metadata)`
+- `instance SetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField meta LockedAmulet_OwnerExpireLockResult (Optional Metadata)`
+- `instance HasExercise LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult`
+
+<span id="type-splice-amulet-lockedamuletownerexpirelockv2result-70273"></span>
+
+### `data LockedAmulet_OwnerExpireLockV2Result`
+
+Constructors:
+
+<span id="constr-splice-amulet-lockedamuletownerexpirelockv2result-66952"></span>
+
+- `LockedAmulet_OwnerExpireLockV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletCid | ContractId Amulet |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField amuletCid LockedAmulet_OwnerExpireLockV2Result (ContractId Amulet)`
+- `instance GetField meta LockedAmulet_OwnerExpireLockV2Result Metadata`
+- `instance SetField amuletCid LockedAmulet_OwnerExpireLockV2Result (ContractId Amulet)`
+- `instance SetField meta LockedAmulet_OwnerExpireLockV2Result Metadata`
+- `instance HasExercise LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result`
+
+<span id="type-splice-amulet-lockedamuletunlockresult-29457"></span>
+
+### `data LockedAmulet_UnlockResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-lockedamuletunlockresult-40430"></span>
+
+- `LockedAmulet_UnlockResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField meta LockedAmulet_UnlockResult (Optional Metadata)`
+- `instance SetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField meta LockedAmulet_UnlockResult (Optional Metadata)`
+- `instance HasExercise LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult`
+
+<span id="type-splice-amulet-lockedamuletunlockv2result-80903"></span>
+
+### `data LockedAmulet_UnlockV2Result`
+
+Constructors:
+
+<span id="constr-splice-amulet-lockedamuletunlockv2result-28736"></span>
+
+- `LockedAmulet_UnlockV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletCid | ContractId Amulet |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField amuletCid LockedAmulet_UnlockV2Result (ContractId Amulet)`
+- `instance GetField meta LockedAmulet_UnlockV2Result Metadata`
+- `instance SetField amuletCid LockedAmulet_UnlockV2Result (ContractId Amulet)`
+- `instance SetField meta LockedAmulet_UnlockV2Result Metadata`
+- `instance HasExercise LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result`
+
+<span id="type-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-20724"></span>
+
+### `data SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-19239"></span>
+
+- `SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+Instances:
+
+- `instance HasExercise SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult`
+- `instance HasFromAnyChoice SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult`
+- `instance HasToAnyChoice SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+<span id="type-splice-amulet-svrewardcoupondsoexpireresult-4801"></span>
+
+### `data SvRewardCoupon_DsoExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-svrewardcoupondsoexpireresult-59696"></span>
+
+- `SvRewardCoupon_DsoExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| weight | Int |  |
+
+Instances:
+
+- `instance GetField weight SvRewardCoupon_DsoExpireResult Int`
+- `instance SetField weight SvRewardCoupon_DsoExpireResult Int`
+- `instance HasExercise SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult`
+- `instance HasToAnyChoice SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult`
+
+<span id="type-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59553"></span>
+
+### `data UnclaimedActivityRecord_ArchiveAsBeneficiaryResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59904"></span>
+
+- `UnclaimedActivityRecord_ArchiveAsBeneficiaryResult`
+
+<span id="type-splice-amulet-unclaimedactivityrecorddsoexpireresult-73042"></span>
+
+### `data UnclaimedActivityRecord_DsoExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-unclaimedactivityrecorddsoexpireresult-28805"></span>
+
+- `UnclaimedActivityRecord_DsoExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid UnclaimedActivityRecord_DsoExpireResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedRewardCid UnclaimedActivityRecord_DsoExpireResult (ContractId UnclaimedReward)`
+- `instance HasExercise UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult`
+- `instance HasFromAnyChoice UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult`
+- `instance HasToAnyChoice UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult`
+
+<span id="type-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-41727"></span>
+
+### `data ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-51782"></span>
+
+- `ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+(no fields)
+
+Instances:
+
+- `instance HasExercise ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult`
+- `instance HasFromAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult`
+- `instance HasToAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+<span id="type-splice-amulet-validatorrewardcoupondsoexpireresult-94761"></span>
+
+### `data ValidatorRewardCoupon_DsoExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-validatorrewardcoupondsoexpireresult-92822"></span>
+
+- `ValidatorRewardCoupon_DsoExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amount | Decimal |  |
+
+Instances:
+
+- `instance GetField amount ValidatorRewardCoupon_DsoExpireResult Decimal`
+- `instance SetField amount ValidatorRewardCoupon_DsoExpireResult Decimal`
+- `instance HasExercise ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult`
+- `instance HasToAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult`
+
+<span id="type-splice-amulet-validatorrightarchiveasuserresult-3193"></span>
+
+### `data ValidatorRight_ArchiveAsUserResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-validatorrightarchiveasuserresult-47620"></span>
+
+- `ValidatorRight_ArchiveAsUserResult`
+
+Instances:
+
+- `instance HasExercise ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult`
+- `instance HasFromAnyChoice ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult`
+- `instance HasToAnyChoice ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult`
+
+<span id="type-splice-amulet-validatorrightarchiveasvalidatorresult-59299"></span>
+
+### `data ValidatorRight_ArchiveAsValidatorResult`
+
+Constructors:
+
+<span id="constr-splice-amulet-validatorrightarchiveasvalidatorresult-93588"></span>
+
+- `ValidatorRight_ArchiveAsValidatorResult`
+
+Instances:
+
+- `instance HasExercise ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult`
+- `instance HasFromAnyChoice ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult`
+- `instance HasToAnyChoice ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult`
 
 ## Functions
 
-<div id="function-splice-amulet-amuletmetadata-81241">
+<span id="function-splice-amulet-amuletmetadata-81241"></span>
 
-amuletMetadata
-: Amulet -\> Metadata
+### `amuletMetadata`
 
-</div>
+```daml
+amuletMetadata : Amulet -> Metadata
+```
 
-<div id="function-splice-amulet-validateapprewardbeneficiaries-84669">
+<span id="function-splice-amulet-validateapprewardbeneficiaries-84669"></span>
 
-validateAppRewardBeneficiaries
-: \[AppRewardBeneficiary\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+### `validateAppRewardBeneficiaries`
 
-</div>
+```daml
+validateAppRewardBeneficiaries : [AppRewardBeneficiary] -> Update ()
+```
 
-<div id="function-splice-amulet-validateapprewardbeneficiariesv2-38479">
+<span id="function-splice-amulet-validateapprewardbeneficiariesv2-38479"></span>
 
-validateAppRewardBeneficiariesV2
-: \[AppRewardBeneficiary\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+### `validateAppRewardBeneficiariesV2`
 
-</div>
+```daml
+validateAppRewardBeneficiariesV2 : [AppRewardBeneficiary] -> Update ()
+```
 
-<div id="function-splice-amulet-requireamuletexpiredforallrounds-81885">
+<span id="function-splice-amulet-requireamuletexpiredforallrounds-81885"></span>
 
-requireAmuletExpiredForAllRounds
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState -\> Amulet -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+### `requireAmuletExpiredForAllRounds`
 
-</div>
+```daml
+requireAmuletExpiredForAllRounds : ContractId ExternalPartyConfigState -> ContractId ExternalPartyConfigState -> Amulet -> Update ()
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-amulet-amulet-63582"></span>
+
+### Template `Amulet`
+
+A amulet, which can be locked and whose amount expires over time.
+
+The expiry serves to charge an inactivity fee, and thereby ensures that the
+SVs can reclaim the corresponding storage space at some point in the future.
+
+Signatories: `dso`, `owner`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| owner | Party |  |
+| amount | ExpiringAmount |  |
+
+Interface Instances:
+- `Holding` for `Amulet`
+
+Choices:
+
+<span id="type-splice-amulet-amuletexpire-87297"></span>
+
+#### Choice `Amulet_Expire`
+
+Controllers: `dso`
+
+Returns: `Amulet_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| roundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amulet-amuletexpirev2-59227"></span>
+
+#### Choice `Amulet_ExpireV2`
+
+Controllers: `dso`
+
+Returns: `Amulet_ExpireV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigState0Cid | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigState1Cid | ContractId ExternalPartyConfigState |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`, `owner`
+
+Returns: `()`
+
+<span id="type-splice-amulet-apprewardcoupon-57229"></span>
+
+### Template `AppRewardCoupon`
+
+A coupon for receiving app rewards proportional to the usage fee paid as part of a
+Amulet transfer coordinated by the app of a provider.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| provider | Party | Application provider |
+| featured | Bool |  |
+| amount | Decimal |  |
+| round | Round |  |
+| beneficiary | Optional Party | The party that can mint this reward.<br/><br/>If not set, this is the provider |
+
+Choices:
+
+<span id="type-splice-amulet-apprewardcoupondsoexpire-84081"></span>
+
+#### Choice `AppRewardCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `AppRewardCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-developmentfundcoupon-75673"></span>
+
+### Template `DevelopmentFundCoupon`
+
+A coupon recording an emission for the Development Fund under CIP-0082,
+which can be collected by the designated beneficiary.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| beneficiary | Party | The owner of the `Amulet` to be minted. |
+| fundManager | Party | The party that executed the assignment of the coupon to the beneficiary<br/><br/>so they can mint from the development fund. |
+| amount | Decimal | The total amount of `Amulet` to mint on collection. |
+| expiresAt | Time | Until when the minting can be completed. |
+| reason | Text | Reason for the emission of the coupon. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-developmentfundcoupondsoexpire-7301"></span>
+
+#### Choice `DevelopmentFundCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `DevelopmentFundCoupon_DsoExpireResult`
+
+<span id="type-splice-amulet-developmentfundcouponreject-89668"></span>
+
+#### Choice `DevelopmentFundCoupon_Reject`
+
+Controllers: `beneficiary`
+
+Returns: `DevelopmentFundCoupon_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text | Reason for rejecting the coupon. |
+
+<span id="type-splice-amulet-developmentfundcouponwithdraw-58125"></span>
+
+#### Choice `DevelopmentFundCoupon_Withdraw`
+
+Controllers: `fundManager`
+
+Returns: `DevelopmentFundCoupon_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text | Reason for withdrawing the coupon. |
+
+<span id="type-splice-amulet-featuredappactivitymarker-16451"></span>
+
+### Template `FeaturedAppActivityMarker`
+
+A marker created by a featured application for activity generated from that app. This is used
+to record activity other than amulet transfers where regular AppRewardCoupons are not created directly.
+
+Will be converted to a AppRewardCoupon through automation run by the SVs and can then be
+minted as part of the normal minting process.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| provider | Party | The featured app provider that created the activity marker. |
+| beneficiary | Party | The party that has the right to mint the reward. |
+| weight | Decimal | The weight of the marker. This is used to split the rewards<br/><br/>for a single action, e.g., multiple parties collaborating to enable<br/><br/>a transfer,<br/><br/>by creating several FeaturedAppActivityMarkers with different<br/><br/>beneficiaries such that the weights add up to 1.0. |
+
+Interface Instances:
+- `FeaturedAppActivityMarker` for `FeaturedAppActivityMarker`
+- `FeaturedAppActivityMarker` for `FeaturedAppActivityMarker`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-featuredappright-765"></span>
+
+### Template `FeaturedAppRight`
+
+The right for an application provider to earn featured app rewards.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| provider | Party |  |
+
+Interface Instances:
+- `FeaturedAppRight` for `FeaturedAppRight`
+- `FeaturedAppRight` for `FeaturedAppRight`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-featuredapprightcancel-96535"></span>
+
+#### Choice `FeaturedAppRight_Cancel`
+
+Controllers: `provider`
+
+Returns: `FeaturedAppRight_CancelResult`
+
+<span id="type-splice-amulet-featuredapprightwithdraw-8217"></span>
+
+#### Choice `FeaturedAppRight_Withdraw`
+
+Controllers: `dso`
+
+Returns: `FeaturedAppRight_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<span id="type-splice-amulet-lockedamulet-7030"></span>
+
+### Template `LockedAmulet`
+
+Signatories: `(DA.Internal.Record.getField @"holders" lock)`, `signatory amulet`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | Amulet |  |
+| lock | TimeLock |  |
+
+Interface Instances:
+- `Holding` for `LockedAmulet`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"holders" lock)`, `signatory amulet`
+
+Returns: `()`
+
+<span id="type-splice-amulet-lockedamuletexpireamulet-28333"></span>
+
+#### Choice `LockedAmulet_ExpireAmulet`
+
+Controllers: `(DA.Internal.Record.getField @"dso" amulet)`
+
+Returns: `LockedAmulet_ExpireAmuletResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| roundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amulet-lockedamuletexpireamuletv2-51335"></span>
+
+#### Choice `LockedAmulet_ExpireAmuletV2`
+
+Controllers: `(DA.Internal.Record.getField @"dso" amulet)`
+
+Returns: `LockedAmulet_ExpireAmuletV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigState0Cid | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigState1Cid | ContractId ExternalPartyConfigState |  |
+
+<span id="type-splice-amulet-lockedamuletownerexpirelock-79102"></span>
+
+#### Choice `LockedAmulet_OwnerExpireLock`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet)`
+
+Returns: `LockedAmulet_OwnerExpireLockResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amulet-lockedamuletownerexpirelockv2-20152"></span>
+
+#### Choice `LockedAmulet_OwnerExpireLockV2`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet)`
+
+Returns: `LockedAmulet_OwnerExpireLockV2Result`
+
+<span id="type-splice-amulet-lockedamuletunlock-59352"></span>
+
+#### Choice `LockedAmulet_Unlock`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)`
+
+Returns: `LockedAmulet_UnlockResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amulet-lockedamuletunlockv2-31390"></span>
+
+#### Choice `LockedAmulet_UnlockV2`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)`
+
+Returns: `LockedAmulet_UnlockV2Result`
+
+<span id="type-splice-amulet-svrewardcoupon-68580"></span>
+
+### Template `SvRewardCoupon`
+
+A coupon for a beneficiary to receive part of the SV issuance for a specific SV node and round.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party | The party identifying the SV node for which the reward is issued. |
+| beneficiary | Party | The beneficiary allowed to receive the reward. |
+| round | Round |  |
+| weight | Int | Coupons receive a share of the SV issuance proportional to their weight. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-svrewardcouponarchiveasbeneficiary-26109"></span>
+
+#### Choice `SvRewardCoupon_ArchiveAsBeneficiary`
+
+Controllers: `beneficiary`
+
+Returns: `SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+<span id="type-splice-amulet-svrewardcoupondsoexpire-92140"></span>
+
+#### Choice `SvRewardCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `SvRewardCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<span id="type-splice-amulet-unclaimedactivityrecord-97331"></span>
+
+### Template `UnclaimedActivityRecord`
+
+A record of activity that can be minted by the beneficiary.
+Note that these do not come out of the per-round issuance but are instead created by burning
+UnclaimedRewardCoupon as defined through a vote by the SVs. That's also why expiry is a separate
+time-based expiry instead of being tied to a round like the other activity records.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| beneficiary | Party | The owner of the `Amulet` to be minted. |
+| amount | Decimal | The amount of `Amulet` to be minted. |
+| reason | Text | A reason to mint the `Amulet`. |
+| expiresAt | Time | Selected timestamp defining the lifetime of the contract. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-unclaimedactivityrecorddsoexpire-41307"></span>
+
+#### Choice `UnclaimedActivityRecord_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `UnclaimedActivityRecord_DsoExpireResult`
+
+<span id="type-splice-amulet-unclaimeddevelopmentfundcoupon-41000"></span>
+
+### Template `UnclaimedDevelopmentFundCoupon`
+
+A coupon recording an emission for the Development Fund from CIP-0082 that
+was not yet assigned to a specific beneficiary.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| amount | Decimal | The total amount of `Amulet` to mint on collection. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-unclaimedreward-7814"></span>
+
+### Template `UnclaimedReward`
+
+Rewards that have not been claimed and are thus at the disposal of the foundation.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| amount | Decimal |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-validatorrewardcoupon-76808"></span>
+
+### Template `ValidatorRewardCoupon`
+
+A coupon for receiving validator rewards proportional to the usage fee paid by a user
+hosted by a validator operator.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| amount | Decimal |  |
+| round | Round |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amulet-validatorrewardcouponarchiveasvalidator-99406"></span>
+
+#### Choice `ValidatorRewardCoupon_ArchiveAsValidator`
+
+This choice is used by validators to archive the burn receipt upon claiming its corresponding issuance.
+
+Controllers: `dso`, `validator`
+
+Returns: `ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validator | Party |  |
+| rightCid | ContractId ValidatorRight |  |
+
+<span id="type-splice-amulet-validatorrewardcoupondsoexpire-85552"></span>
+
+#### Choice `ValidatorRewardCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `ValidatorRewardCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<span id="type-splice-amulet-validatorright-15964"></span>
+
+### Template `ValidatorRight`
+
+The right to claim amulet issuances for a user's burns as their validator.
+
+Signatories: `user`, `validator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| validator | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `user`, `validator`
+
+Returns: `()`
+
+<span id="type-splice-amulet-validatorrightarchiveasuser-43276"></span>
+
+#### Choice `ValidatorRight_ArchiveAsUser`
+
+Controllers: `user`
+
+Returns: `ValidatorRight_ArchiveAsUserResult`
+
+<span id="type-splice-amulet-validatorrightarchiveasvalidator-83210"></span>
+
+#### Choice `ValidatorRight_ArchiveAsValidator`
+
+Controllers: `validator`
+
+Returns: `ValidatorRight_ArchiveAsValidatorResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation.mdx
@@ -1,86 +1,93 @@
 ---
 title: "Splice.AmuletAllocation"
-description: "Documentation for Splice.AmuletAllocation"
+description: "Reference documentation for Daml module Splice.AmuletAllocation."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletAllocation.rst" tag="0.6.4" hash="2dd0a06d" */}
+<span id="module-splice-amuletallocation-77292"></span>
 
-## Templates
+# Splice.AmuletAllocation
 
-<div id="type-splice-amuletallocation-amuletallocation-39850">
+## Module Snapshot
 
-**template** AmuletAllocation
-
-</div>
-
-> Amulet allocated in locked form to a trade.
->
-> Signatory: allocationInstrumentAdmin allocation, (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))
->
-> | Field        | Type                                                                                                                                       | Description                                           |
-> |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-> | lockedAmulet | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet | Locked amulet that holds the funds for the allocation |
-> | allocation   | AllocationSpecification                                                                                                                    |                                                       |
->
-> - <div id="type-splice-amuletallocation-amuletallocationdsoexpire-72174">
->
->   **Choice** AmuletAllocation_DsoExpire
->
->   </div>
->
->   Controller: allocationInstrumentAdmin allocation
->
->   Returns: AmuletAllocation_DsoExpireResult
->
->   | Field      | Type                                                                                                         | Description |
->   |------------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | expireLock | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) |             |
->
-> - **Choice** Archive
->
->   Controller: allocationInstrumentAdmin allocation, (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-amuletallocation-amuletallocationdsoexpireresult-36603">
+<span id="type-splice-amuletallocation-amuletallocationdsoexpireresult-36603"></span>
 
-**data** AmuletAllocation_DsoExpireResult
+### `data AmuletAllocation_DsoExpireResult`
 
-</div>
+Instances:
 
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletAllocation_DsoExpireResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletAllocation_DsoExpireResult
->
-> **instance** GetField "meta" AmuletAllocation_DsoExpireResult Metadata
->
-> **instance** GetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
->
-> **instance** GetField "senderHoldingCids" AmuletAllocation_DsoExpireResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
->
-> **instance** SetField "meta" AmuletAllocation_DsoExpireResult Metadata
->
-> **instance** SetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
->
-> **instance** SetField "senderHoldingCids" AmuletAllocation_DsoExpireResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult
+- `instance Eq AmuletAllocation_DsoExpireResult`
+- `instance Show AmuletAllocation_DsoExpireResult`
+- `instance GetField meta AmuletAllocation_DsoExpireResult Metadata`
+- `instance GetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance GetField senderHoldingCids AmuletAllocation_DsoExpireResult [ContractId Holding]`
+- `instance SetField meta AmuletAllocation_DsoExpireResult Metadata`
+- `instance SetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance SetField senderHoldingCids AmuletAllocation_DsoExpireResult [ContractId Holding]`
+- `instance HasExercise AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult`
+- `instance HasFromAnyChoice AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult`
+- `instance HasToAnyChoice AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult`
 
 ## Functions
 
-<div id="function-splice-amuletallocation-allocationtotwosteptransfer-63709">
+<span id="function-splice-amuletallocation-allocationtotwosteptransfer-63709"></span>
 
-allocationToTwoStepTransfer
-: AllocationSpecification -\> TwoStepTransfer
+### `allocationToTwoStepTransfer`
 
-</div>
+```daml
+allocationToTwoStepTransfer : AllocationSpecification -> TwoStepTransfer
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-amuletallocation-amuletallocation-39850"></span>
+
+### Template `AmuletAllocation`
+
+Amulet allocated in locked form to a trade.
+
+Signatories: `allocationInstrumentAdmin allocation`, `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| lockedAmulet | ContractId LockedAmulet | Locked amulet that holds the funds for the allocation |
+| allocation | AllocationSpecification |  |
+
+Choices:
+
+<span id="type-splice-amuletallocation-amuletallocationdsoexpire-72174"></span>
+
+#### Choice `AmuletAllocation_DsoExpire`
+
+Controllers: `allocationInstrumentAdmin allocation`
+
+Returns: `AmuletAllocation_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireLock | Bool |  |
+
+#### Choice `Archive`
+
+Controllers: `allocationInstrumentAdmin allocation`, `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig.mdx
@@ -1,395 +1,321 @@
 ---
 title: "Splice.AmuletConfig"
-description: "Documentation for Splice.AmuletConfig"
+description: "Reference documentation for Daml module Splice.AmuletConfig."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletConfig.rst" tag="0.6.4" hash="29e34f10" */}
+<span id="module-splice-amuletconfig-30440"></span>
+
+# Splice.AmuletConfig
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-amuletconfig-amulet-69874">
+<span id="type-splice-amuletconfig-amulet-69874"></span>
 
-**data** Amulet
+### `data Amulet`
 
-</div>
+Deprecated type for specifying amounts and fees in units of Amulet. Use Splice.Amulet.Amulet directly instead.
 
-> Deprecated type for specifying amounts and fees in units of Amulet. Use Splice.Amulet.Amulet directly instead.
->
-> <div id="constr-splice-amuletconfig-amulet-76435">
->
-> Amulet
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Amulet
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Amulet
+Constructors:
 
-<div id="type-splice-amuletconfig-amuletconfig-37414">
+<span id="constr-splice-amuletconfig-amulet-76435"></span>
 
-**data** AmuletConfig unit
+- `Amulet`
 
-</div>
+Instances:
 
-> Configuration includes TransferConfig, issuance curve and tickDuration
->
-> See Splice.Scripts.Parameters for concrete values.
->
-> <div id="constr-splice-amuletconfig-amuletconfig-91595">
->
-> AmuletConfig
->
-> </div>
->
-> > | Field                                | Type                                                                                                                                                                                                                                                  | Description                                                                                                                                                                                                                                                                                       |
-> > |--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | transferConfig                       | TransferConfig unit                                                                                                                                                                                                                                   | Configuration determining the fees and limits for Amulet transfers                                                                                                                                                                                                                                |
-> > | issuanceCurve                        | Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig                                                                                                        | Issuance curve to use.                                                                                                                                                                                                                                                                            |
-> > | decentralizedSynchronizer            | AmuletDecentralizedSynchronizerConfig                                                                                                                                                                                                                 | Configuration for the decentralized synchronizer and its fees. TODO(M4-85): the values in here are likely quite large (several URls and long synchronizerIds) and not required for executing transfers. Split this part of the config out into a separate contract as a performance optimization. |
-> > | tickDuration                         | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | Duration of a tick, which is the duration of half a round.                                                                                                                                                                                                                                        |
-> > | packageConfig                        | PackageConfig                                                                                                                                                                                                                                         | Configuration determining the version of each package that should be used for command submissions.                                                                                                                                                                                                |
-> > | transferPreapprovalFee               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     | Fee for keeping a transfer pre-approval around.                                                                                                                                                                                                                                                   |
-> > | featuredAppActivityMarkerAmount      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     | \$-amount used for the conversion from FeaturedAppActivityMarker -\> AppRewardCoupon                                                                                                                                                                                                              |
-> > | optDevelopmentFundManager            | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)    | Party authorized to manage and allocate minting rights from the Development Fund.                                                                                                                                                                                                                 |
-> > | externalPartyConfigStateTickDuration | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Half the lifetime of an `ExternalPartyConfigState` contract and the overlap between two successive contracts. Default: 24h.                                                                                                                                                                       |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (AmuletConfig unit)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (AmuletConfig unit)
->
-> **instance** GetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** GetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
->
-> **instance** GetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
->
-> **instance** GetField "externalPartyConfigStateTickDuration" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
->
-> **instance** GetField "featuredAppActivityMarkerAmount" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
->
-> **instance** GetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** GetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** GetField "optDevelopmentFundManager" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
->
-> **instance** GetField "packageConfig" (AmuletConfig unit) PackageConfig
->
-> **instance** GetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** GetField "tickDuration" (AmuletConfig unit) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
->
-> **instance** GetField "transferPreapprovalFee" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** SetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
->
-> **instance** SetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
->
-> **instance** SetField "externalPartyConfigStateTickDuration" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
->
-> **instance** SetField "featuredAppActivityMarkerAmount" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
->
-> **instance** SetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** SetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** SetField "optDevelopmentFundManager" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
->
-> **instance** SetField "packageConfig" (AmuletConfig unit) PackageConfig
->
-> **instance** SetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** SetField "tickDuration" (AmuletConfig unit) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
->
-> **instance** SetField "transferPreapprovalFee" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** Patchable (AmuletConfig USD)
+- `instance Eq Amulet`
+- `instance Show Amulet`
 
-<div id="type-splice-amuletconfig-packageconfig-59903">
+<span id="type-splice-amuletconfig-amuletconfig-37414"></span>
 
-**data** PackageConfig
+### `data AmuletConfig unit`
 
-</div>
+Configuration includes TransferConfig, issuance curve and tickDuration
 
-> The package config defines for each daml package (identified by name) the package version that should be used for command submissions at that point.
->
-> <div id="constr-splice-amuletconfig-packageconfig-69032">
->
-> PackageConfig
->
-> </div>
->
-> > | Field              | Type                                                                                                         | Description |
-> > |--------------------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | amulet             | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-> > | amuletNameService  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-> > | dsoGovernance      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-> > | validatorLifecycle | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-> > | wallet             | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-> > | walletPayments     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PackageConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PackageConfig
->
-> **instance** GetField "amulet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "amuletNameService" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "dsoGovernance" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "packageConfig" (AmuletConfig unit) PackageConfig
->
-> **instance** GetField "validatorLifecycle" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "wallet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "walletPayments" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "amulet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "amuletNameService" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dsoGovernance" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "packageConfig" (AmuletConfig unit) PackageConfig
->
-> **instance** SetField "validatorLifecycle" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "wallet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "walletPayments" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** Patchable PackageConfig
+See Splice.Scripts.Parameters for concrete values.
 
-<div id="type-splice-amuletconfig-transferconfig-45691">
+Constructors:
 
-**data** TransferConfig unit
+<span id="constr-splice-amuletconfig-amuletconfig-91595"></span>
 
-</div>
+- `AmuletConfig`
 
-> Configuration determining the fees and limits for Amulet transfers granted by the AmuletRules.
->
-> See Splice.Scripts.Parameters for concrete values.
->
-> <div id="constr-splice-amuletconfig-transferconfig-20622">
->
-> TransferConfig
->
-> </div>
->
-> > | Field                        | Type                                                                                                               | Description                                                 |
-> > |------------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
-> > | createFee                    | FixedFee                                                                                                           | Fee to create a new amulet.                                 |
-> > | holdingFee                   | RatePerRound                                                                                                       | Fee for keeping an amulet around.                           |
-> > | transferFee                  | SteppedRate                                                                                                        | Fee for transferring some amount of amulet to a new owner.  |
-> > | lockHolderFee                | FixedFee                                                                                                           | Fee per lock holder of a locked amulet.                     |
-> > | extraFeaturedAppRewardAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Extra \$-amount of reward for featured apps.                |
-> > | maxNumInputs                 | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | Maximum number of batch inputs for a transfer.              |
-> > | maxNumOutputs                | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | Maximum number of batch outputs for a transfer.             |
-> > | maxNumLockHolders            | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | Maximum number of lock holders allowed for a locked amulet. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (TransferConfig unit)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (TransferConfig unit)
->
-> **instance** GetField "config" TransferContextSummary (TransferConfig Amulet)
->
-> **instance** GetField "createFee" (TransferConfig unit) FixedFee
->
-> **instance** GetField "extraFeaturedAppRewardAmount" (TransferConfig unit) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "holdingFee" (TransferConfig unit) RatePerRound
->
-> **instance** GetField "lockHolderFee" (TransferConfig unit) FixedFee
->
-> **instance** GetField "maxNumInputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumLockHolders" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumOutputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
->
-> **instance** GetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
->
-> **instance** GetField "transferFee" (TransferConfig unit) SteppedRate
->
-> **instance** SetField "config" TransferContextSummary (TransferConfig Amulet)
->
-> **instance** SetField "createFee" (TransferConfig unit) FixedFee
->
-> **instance** SetField "extraFeaturedAppRewardAmount" (TransferConfig unit) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "holdingFee" (TransferConfig unit) RatePerRound
->
-> **instance** SetField "lockHolderFee" (TransferConfig unit) FixedFee
->
-> **instance** SetField "maxNumInputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumLockHolders" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumOutputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
->
-> **instance** SetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
->
-> **instance** SetField "transferFee" (TransferConfig unit) SteppedRate
->
-> **instance** Patchable (TransferConfig USD)
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferConfig | TransferConfig unit | Configuration determining the fees and limits for Amulet transfers |
+| issuanceCurve | Schedule RelTime IssuanceConfig | Issuance curve to use. |
+| decentralizedSynchronizer | AmuletDecentralizedSynchronizerConfig | Configuration for the decentralized synchronizer and its fees.<br/><br/>TODO(M4-85): the values in here are likely quite large (several URls and long synchronizerIds) and not required for executing transfers. Split this part of the config out into a separate contract as a performance optimization. |
+| tickDuration | RelTime | Duration of a tick, which is the duration of half a round. |
+| packageConfig | PackageConfig | Configuration determining the version of each package<br/><br/>that should be used for command submissions. |
+| transferPreapprovalFee | Optional Decimal | Fee for keeping a transfer pre-approval around. |
+| featuredAppActivityMarkerAmount | Optional Decimal | $-amount used for the conversion from FeaturedAppActivityMarker -> AppRewardCoupon |
+| optDevelopmentFundManager | Optional Party | Party authorized to manage and allocate minting rights from the Development Fund. |
+| externalPartyConfigStateTickDuration | Optional RelTime | Half the lifetime of an `ExternalPartyConfigState` contract and the overlap between two successive contracts. Default: 24h. |
 
-<div id="type-splice-amuletconfig-transferconfigv2-59993">
+Instances:
 
-**data** TransferConfigV2 unit
+- `instance Patchable (AmuletConfig USD)`
+- `instance Eq (AmuletConfig unit)`
+- `instance Show (AmuletConfig unit)`
+- `instance GetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance GetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance GetField externalPartyConfigStateTickDuration (AmuletConfig unit) (Optional RelTime)`
+- `instance GetField featuredAppActivityMarkerAmount (AmuletConfig unit) (Optional Decimal)`
+- `instance GetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance GetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField optDevelopmentFundManager (AmuletConfig unit) (Optional Party)`
+- `instance GetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance GetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField tickDuration (AmuletConfig unit) RelTime`
+- `instance GetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance GetField transferPreapprovalFee (AmuletConfig unit) (Optional Decimal)`
+- `instance SetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance SetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance SetField externalPartyConfigStateTickDuration (AmuletConfig unit) (Optional RelTime)`
+- `instance SetField featuredAppActivityMarkerAmount (AmuletConfig unit) (Optional Decimal)`
+- `instance SetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance SetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField optDevelopmentFundManager (AmuletConfig unit) (Optional Party)`
+- `instance SetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance SetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField tickDuration (AmuletConfig unit) RelTime`
+- `instance SetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance SetField transferPreapprovalFee (AmuletConfig unit) (Optional Decimal)`
 
-</div>
+<span id="type-splice-amuletconfig-packageconfig-59903"></span>
 
-> Stripped down TransferConfig after CIP 78 removed fees.
->
-> <div id="constr-splice-amuletconfig-transferconfigv2-42628">
->
-> TransferConfigV2
->
-> </div>
->
-> > | Field             | Type                                                                                                       | Description |
-> > |-------------------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | holdingFee        | RatePerRound                                                                                               |             |
-> > | maxNumInputs      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | maxNumOutputs     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | maxNumLockHolders | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (TransferConfigV2 unit)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (TransferConfigV2 unit)
->
-> **instance** GetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
->
-> **instance** GetField "holdingFee" (TransferConfigV2 unit) RatePerRound
->
-> **instance** GetField "maxNumInputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumLockHolders" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumOutputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
->
-> **instance** SetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
->
-> **instance** SetField "holdingFee" (TransferConfigV2 unit) RatePerRound
->
-> **instance** SetField "maxNumInputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumLockHolders" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumOutputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
+### `data PackageConfig`
 
-<div id="type-splice-amuletconfig-usd-42527">
+The package config defines for each daml package (identified by name)
+the package version that should be used for command submissions
+at that point.
 
-**data** USD
+Constructors:
 
-</div>
+<span id="constr-splice-amuletconfig-packageconfig-69032"></span>
 
-> <div id="constr-splice-amuletconfig-usd-28992">
->
-> USD
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) USD
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) USD
->
-> **instance** GetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** GetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
->
-> **instance** GetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** GetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** GetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** GetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
->
-> **instance** GetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
->
-> **instance** SetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** SetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
->
-> **instance** SetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
->
-> **instance** SetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** SetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
->
-> **instance** SetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
->
-> **instance** SetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
->
-> **instance** Patchable (AmuletConfig USD)
->
-> **instance** Patchable (TransferConfig USD)
+- `PackageConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | Text |  |
+| amuletNameService | Text |  |
+| dsoGovernance | Text |  |
+| validatorLifecycle | Text |  |
+| wallet | Text |  |
+| walletPayments | Text |  |
+
+Instances:
+
+- `instance Patchable PackageConfig`
+- `instance Eq PackageConfig`
+- `instance Show PackageConfig`
+- `instance GetField amulet PackageConfig Text`
+- `instance GetField amuletNameService PackageConfig Text`
+- `instance GetField dsoGovernance PackageConfig Text`
+- `instance GetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance GetField validatorLifecycle PackageConfig Text`
+- `instance GetField wallet PackageConfig Text`
+- `instance GetField walletPayments PackageConfig Text`
+- `instance SetField amulet PackageConfig Text`
+- `instance SetField amuletNameService PackageConfig Text`
+- `instance SetField dsoGovernance PackageConfig Text`
+- `instance SetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance SetField validatorLifecycle PackageConfig Text`
+- `instance SetField wallet PackageConfig Text`
+- `instance SetField walletPayments PackageConfig Text`
+
+<span id="type-splice-amuletconfig-transferconfig-45691"></span>
+
+### `data TransferConfig unit`
+
+Configuration determining the fees and limits for Amulet transfers granted by
+the AmuletRules.
+
+See Splice.Scripts.Parameters for concrete values.
+
+Constructors:
+
+<span id="constr-splice-amuletconfig-transferconfig-20622"></span>
+
+- `TransferConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| createFee | FixedFee | Fee to create a new amulet. |
+| holdingFee | RatePerRound | Fee for keeping an amulet around. |
+| transferFee | SteppedRate | Fee for transferring some amount of amulet to a new owner. |
+| lockHolderFee | FixedFee | Fee per lock holder of a locked amulet. |
+| extraFeaturedAppRewardAmount | Decimal | Extra $-amount of reward for featured apps. |
+| maxNumInputs | Int | Maximum number of batch inputs for a transfer. |
+| maxNumOutputs | Int | Maximum number of batch outputs for a transfer. |
+| maxNumLockHolders | Int | Maximum number of lock holders allowed for a locked amulet. |
+
+Instances:
+
+- `instance Patchable (TransferConfig USD)`
+- `instance Eq (TransferConfig unit)`
+- `instance Show (TransferConfig unit)`
+- `instance GetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance GetField createFee (TransferConfig unit) FixedFee`
+- `instance GetField extraFeaturedAppRewardAmount (TransferConfig unit) Decimal`
+- `instance GetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance GetField lockHolderFee (TransferConfig unit) FixedFee`
+- `instance GetField maxNumInputs (TransferConfig unit) Int`
+- `instance GetField maxNumLockHolders (TransferConfig unit) Int`
+- `instance GetField maxNumOutputs (TransferConfig unit) Int`
+- `instance GetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance GetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+- `instance GetField transferFee (TransferConfig unit) SteppedRate`
+- `instance SetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance SetField createFee (TransferConfig unit) FixedFee`
+- `instance SetField extraFeaturedAppRewardAmount (TransferConfig unit) Decimal`
+- `instance SetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance SetField lockHolderFee (TransferConfig unit) FixedFee`
+- `instance SetField maxNumInputs (TransferConfig unit) Int`
+- `instance SetField maxNumLockHolders (TransferConfig unit) Int`
+- `instance SetField maxNumOutputs (TransferConfig unit) Int`
+- `instance SetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance SetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+- `instance SetField transferFee (TransferConfig unit) SteppedRate`
+
+<span id="type-splice-amuletconfig-transferconfigv2-59993"></span>
+
+### `data TransferConfigV2 unit`
+
+Stripped down TransferConfig after CIP 78 removed fees.
+
+Constructors:
+
+<span id="constr-splice-amuletconfig-transferconfigv2-42628"></span>
+
+- `TransferConfigV2`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| holdingFee | RatePerRound |  |
+| maxNumInputs | Int |  |
+| maxNumOutputs | Int |  |
+| maxNumLockHolders | Int |  |
+
+Instances:
+
+- `instance Eq (TransferConfigV2 unit)`
+- `instance Show (TransferConfigV2 unit)`
+- `instance GetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance GetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance GetField maxNumInputs (TransferConfigV2 unit) Int`
+- `instance GetField maxNumLockHolders (TransferConfigV2 unit) Int`
+- `instance GetField maxNumOutputs (TransferConfigV2 unit) Int`
+- `instance GetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+- `instance SetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance SetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance SetField maxNumInputs (TransferConfigV2 unit) Int`
+- `instance SetField maxNumLockHolders (TransferConfigV2 unit) Int`
+- `instance SetField maxNumOutputs (TransferConfigV2 unit) Int`
+- `instance SetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+
+<span id="type-splice-amuletconfig-usd-42527"></span>
+
+### `data USD`
+
+Constructors:
+
+<span id="constr-splice-amuletconfig-usd-28992"></span>
+
+- `USD`
+
+Instances:
+
+- `instance Patchable (AmuletConfig USD)`
+- `instance Patchable (TransferConfig USD)`
+- `instance Eq USD`
+- `instance Show USD`
+- `instance GetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance GetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+- `instance GetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+- `instance SetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance SetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+- `instance SetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
 
 ## Functions
 
-<div id="function-splice-amuletconfig-transferconfigtotransferconfigv2-63497">
+<span id="function-splice-amuletconfig-transferconfigtotransferconfigv2-63497"></span>
 
-transferConfigToTransferConfigV2
-: TransferConfig unit -\> TransferConfigV2 unit
+### `transferConfigToTransferConfigV2`
 
-</div>
+```daml
+transferConfigToTransferConfigV2 : TransferConfig unit -> TransferConfigV2 unit
+```
 
-<div id="function-splice-amuletconfig-getexternalpartyconfigstatetickduration-34672">
+<span id="function-splice-amuletconfig-getexternalpartyconfigstatetickduration-34672"></span>
 
-getExternalPartyConfigStateTickDuration
-: AmuletConfig a -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+### `getExternalPartyConfigStateTickDuration`
 
-</div>
+```daml
+getExternalPartyConfigStateTickDuration : AmuletConfig a -> RelTime
+```
 
-<div id="function-splice-amuletconfig-defaulttransferpreapprovalfee-76073">
+<span id="function-splice-amuletconfig-defaulttransferpreapprovalfee-76073"></span>
 
-defaultTransferPreapprovalFee
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `defaultTransferPreapprovalFee`
 
-</div>
+```daml
+defaultTransferPreapprovalFee : Decimal
+```
 
-<div id="function-splice-amuletconfig-validamuletconfig-8963">
+<span id="function-splice-amuletconfig-validamuletconfig-8963"></span>
 
-validAmuletConfig
-: AmuletConfig unit -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validAmuletConfig`
 
-</div>
+```daml
+validAmuletConfig : AmuletConfig unit -> Bool
+```
 
-<div id="function-splice-amuletconfig-validtransferconfig-77162">
+<span id="function-splice-amuletconfig-validtransferconfig-77162"></span>
 
-validTransferConfig
-: TransferConfig unit -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validTransferConfig`
 
-</div>
+```daml
+validTransferConfig : TransferConfig unit -> Bool
+```
 
-<div id="function-splice-amuletconfig-validpackageconfig-27952">
+<span id="function-splice-amuletconfig-validpackageconfig-27952"></span>
 
-validPackageConfig
-: PackageConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validPackageConfig`
 
-Package configs are not constrained at the Daml level to maximize flexibility. In particular, empty packages versions might be used in the future to indicate that no version of that package should be vetted.
+```daml
+validPackageConfig : PackageConfig -> Bool
+```
 
-</div>
-
-{/* COPIED_END */}
+Package configs are not constrained at the Daml level to maximize flexibility.
+In particular, empty packages versions might be used in the future to indicate that
+no version of that package should be vetted.

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules.mdx
@@ -1,3056 +1,2621 @@
 ---
 title: "Splice.AmuletRules"
-description: "Documentation for Splice.AmuletRules"
+description: "Reference documentation for Daml module Splice.AmuletRules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletRules.rst" tag="0.6.4" hash="7bf8da92" */}
+<span id="module-splice-amuletrules-25638"></span>
 
-## Templates
+# Splice.AmuletRules
 
-<div id="type-splice-amuletrules-amuletrules-32426">
+## Module Snapshot
 
-**template** AmuletRules
-
-</div>
-
-> The rules governing how Amulet users can modify the Amulet state managed by the DSO party.
->
-> Signatory: dso
->
-> | Field                      | Type                                                                                                                                                                                                                                      | Description |
-> |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                       |             |
-> | configSchedule             | Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD)                                                                                             |             |
-> | isDevNet                   | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                              |             |
-> | contractStateSchemaVersion | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigschedule-17078">
->
->   **Choice** AmuletRules_AddFutureAmuletConfigSchedule
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_AddFutureAmuletConfigScheduleResult
->
->   | Field           | Type                                                                                                                                  | Description |
->   |-----------------|---------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | newScheduleItem | ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesadvanceopenminingrounds-86978">
->
->   **Choice** AmuletRules_AdvanceOpenMiningRounds
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_AdvanceOpenMiningRoundsResult
->
->   | Field             | Type                                                                                                                                          | Description |
->   |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletPrice       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
->   | roundToArchiveCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->   | middleRoundCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->   | latestRoundCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcoupon-20234">
->
->   **Choice** AmuletRules_AllocateDevelopmentFundCoupon
->
->   </div>
->
->   Allows the Development Fund manager to allocate a specified amount from a collection of UnclaimedDevelopmentFundCoupons to a beneficiary, generating a DevelopmentFundCoupon and producing a leftover unclaimed coupon if applicable.
->
->   Controller: fundManager
->
->   Returns: AmuletRules_AllocateDevelopmentFundCouponResult
->
->   | Field                              | Type                                                                                                                                                             | Description |
->   |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | unclaimedDevelopmentFundCouponCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon\] |             |
->   | beneficiary                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |             |
->   | amount                             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                               |             |
->   | expiresAt                          | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                |             |
->   | reason                             | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                     |             |
->   | fundManager                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructions-2487">
->
->   **Choice** AmuletRules_Amulet_ExpireTransferInstructions
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_Amulet_ExpireTransferInstructionsResult
->
->   | Field       | Type                                                                                                                    | Description |
->   |-------------|-------------------------------------------------------------------------------------------------------------------------|-------------|
->   | expectedDso | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
->   | inputs      | \[AmuletRules_ExpireTransferInstructionInput\]                                                                          |             |
->   | observers   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstate-17751">
->
->   **Choice** AmuletRules_BootstrapExternalPartyConfigState
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_BootstrapExternalPartyConfigStateResult
->
->   | Field                 | Type                                                                                                                | Description |
->   |-----------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | openMiningRoundTriple | OpenMiningRoundTriple                                                                                               |             |
->   | expectedDso           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesbootstraprounds-81536">
->
->   **Choice** AmuletRules_Bootstrap_Rounds
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_Bootstrap_RoundsResult
->
->   | Field          | Type                                                                                                                                                                                                                                      | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletPrice    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |             |
->   | round0Duration | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                    |             |
->   | initialRound   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesbuymembertraffic-66391">
->
->   **Choice** AmuletRules_BuyMemberTraffic
->
->   </div>
->
->   Controller: provider
->
->   Returns: AmuletRules_BuyMemberTrafficResult
->
->   | Field          | Type                                                                                                                                                                                                                                               | Description |
->   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | inputs         | \[TransferInput\]                                                                                                                                                                                                                                  |             |
->   | context        | TransferContext                                                                                                                                                                                                                                    |             |
->   | provider       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
->   | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
->   | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                         |             |
->   | trafficAmount  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                         |             |
->   | expectedDso    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesclaimexpiredrewards-90526">
->
->   **Choice** AmuletRules_ClaimExpiredRewards
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_ClaimExpiredRewardsResult
->
->   | Field                                  | Type                                                                                                                                                                                                                                                                                             | Description |
->   |----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid                         | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound                                                                                                                                                  |             |
->   | validatorRewardCouponCids              | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRewardCoupon\]                                                                                                                                          |             |
->   | appCouponCids                          | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\]                                                                                                                                                |             |
->   | svRewardCouponCids                     | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\]                                                                                                                                                 |             |
->   | optValidatorFaucetCouponCids           | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon\]           |             |
->   | optValidatorLivenessActivityRecordCids | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord\] |             |
->
-> - <div id="type-splice-amuletrules-amuletrulescomputefees-56243">
->
->   **Choice** AmuletRules_ComputeFees
->
->   </div>
->
->   Compute the output fees for transfer against the given context
->
->   Controller: sender
->
->   Returns: AmuletRules_ComputeFeesResult
->
->   | Field       | Type                                                                                                                                                                                                                                               | Description |
->   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | context     | TransferContext                                                                                                                                                                                                                                    |             |
->   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | outputs     | \[TransferOutput\]                                                                                                                                                                                                                                 |             |
->   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkers-99721">
->
->   **Choice** AmuletRules_ConvertFeaturedAppActivityMarkers
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
->   | Field              | Type                                                                                                                                                                                                                                                   | Description                                                                                                                                       |
->   |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
->   | markerCids         | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]                                                                                            |                                                                                                                                                   |
->   | openMiningRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                          |                                                                                                                                                   |
->   | observers          | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] | A list of choice observers. This is expected to be set to the union of all providers and beneficiaries to ensure that this creates only one view. |
->
-> - <div id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposal-53882">
->
->   **Choice** AmuletRules_CreateExternalPartySetupProposal
->
->   </div>
->
->   Propose to host an external party The provider pre-pays the fees for the creation of a TransferPreapproval contract on behalf of the external party when exercising this choice
->
->   Controller: validator
->
->   Returns: AmuletRules_CreateExternalPartySetupProposalResult
->
->   | Field                | Type                                                                                                                                                                                                                                               | Description |
->   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | context              | PaymentTransferContext                                                                                                                                                                                                                             |             |
->   | inputs               | \[TransferInput\]                                                                                                                                                                                                                                  |             |
->   | user                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | validator            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | preapprovalExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                  |             |
->   | expectedDso          | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulescreatetransferpreapproval-31932">
->
->   **Choice** AmuletRules_CreateTransferPreapproval
->
->   </div>
->
->   Pre-approve incoming amulet transfers
->
->   Controller: provider, receiver
->
->   Returns: AmuletRules_CreateTransferPreapprovalResult
->
->   | Field       | Type                                                                                                                                                                                                                                               | Description |
->   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | context     | PaymentTransferContext                                                                                                                                                                                                                             |             |
->   | inputs      | \[TransferInput\]                                                                                                                                                                                                                                  |             |
->   | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                  |             |
->   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesdevnetfeatureapp-42587">
->
->   **Choice** AmuletRules_DevNet_FeatureApp
->
->   </div>
->
->   Controller: provider
->
->   Returns: AmuletRules_DevNet_FeatureAppResult
->
->   | Field    | Type                                                                                                                | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesdevnettap-82572">
->
->   **Choice** AmuletRules_DevNet_Tap
->
->   </div>
->
->   Controller: receiver
->
->   Returns: AmuletRules_DevNet_TapResult
->
->   | Field     | Type                                                                                                                                          | Description |
->   |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | receiver  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                           |             |
->   | amount    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
->   | openRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesfetch-60873">
->
->   **Choice** AmuletRules_Fetch
->
->   </div>
->
->   Controller: p
->
->   Returns: AmuletRules
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesmergemembertrafficcontracts-58585">
->
->   **Choice** AmuletRules_MergeMemberTrafficContracts
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_MergeMemberTrafficContractsResult
->
->   | Field       | Type                                                                                                                                            | Description |
->   |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | trafficCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic\] |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcoupons-89321">
->
->   **Choice** AmuletRules_MergeUnclaimedDevelopmentFundCoupons
->
->   </div>
->
->   Batch merge of unclaimed development fund coupons
->
->   Controller: dso
->
->   Returns: AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
->
->   | Field                              | Type                                                                                                                                                             | Description |
->   |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | unclaimedDevelopmentFundCouponCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon\] |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesmergeunclaimedrewards-76493">
->
->   **Choice** AmuletRules_MergeUnclaimedRewards
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_MergeUnclaimedRewardsResult
->
->   | Field               | Type                                                                                                                                              | Description |
->   |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | unclaimedRewardCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward\] |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesminingroundarchive-33308">
->
->   **Choice** AmuletRules_MiningRound_Archive
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_MiningRound_ArchiveResult
->
->   | Field          | Type                                                                                                                                            | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesminingroundclose-27964">
->
->   **Choice** AmuletRules_MiningRound_Close
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_MiningRound_CloseResult
->
->   | Field           | Type                                                                                                                                             | Description |
->   |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | issuingRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesminingroundstartissuing-80649">
->
->   **Choice** AmuletRules_MiningRound_StartIssuing
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_MiningRound_StartIssuingResult
->
->   | Field          | Type                                                                                                                                                 | Description |
->   |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | miningRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound |             |
->   | summary        | OpenMiningRoundSummary                                                                                                                               |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesmint-76046">
->
->   **Choice** AmuletRules_Mint
->
->   </div>
->
->   Controller: dso, receiver
->
->   Returns: AmuletRules_MintResult
->
->   | Field     | Type                                                                                                                                          | Description |
->   |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | receiver  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                           |             |
->   | amount    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
->   | openRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigschedule-69936">
->
->   **Choice** AmuletRules_RemoveFutureAmuletConfigSchedule
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_RemoveFutureAmuletConfigScheduleResult
->
->   | Field        | Type                                                                                                              | Description |
->   |--------------|-------------------------------------------------------------------------------------------------------------------|-------------|
->   | scheduleTime | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulessetconfig-85439">
->
->   **Choice** AmuletRules_SetConfig
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_SetConfigResult
->
->   | Field      | Type             | Description |
->   |------------|------------------|-------------|
->   | newConfig  | AmuletConfig USD |             |
->   | baseConfig | AmuletConfig USD |             |
->
-> - <div id="type-splice-amuletrules-amuletrulestransfer-23235">
->
->   **Choice** AmuletRules_Transfer
->
->   </div>
->
->   Controller: Set.toList (transferControllers transfer)
->
->   Returns: TransferResult
->
->   | Field       | Type                                                                                                                                                                                                                                               | Description |
->   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | transfer    | Transfer                                                                                                                                                                                                                                           |             |
->   | context     | TransferContext                                                                                                                                                                                                                                    |             |
->   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstates-76929">
->
->   **Choice** AmuletRules_UpdateExternalPartyConfigStates
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_UpdateExternalPartyConfigStatesResult
->
->   | Field                        | Type                                                                                                                                                   | Description |
->   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | externalPartyConfigStateCid0 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->   | externalPartyConfigStateCid1 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->   | openMiningRoundTriple        | OpenMiningRoundTriple                                                                                                                                  |             |
->
-> - <div id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigschedule-15159">
->
->   **Choice** AmuletRules_UpdateFutureAmuletConfigSchedule
->
->   </div>
->
->   Controller: dso
->
->   Returns: AmuletRules_UpdateFutureAmuletConfigScheduleResult
->
->   | Field        | Type                                                                                                                                  | Description |
->   |--------------|---------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | scheduleItem | ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD) |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-amuletrules-externalpartysetupproposal-90414">
-
-**template** ExternalPartySetupProposal
-
-</div>
-
-> Signatory: validator, dso
->
-> | Field                | Type                                                                                                                | Description |
-> |----------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | validator            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | user                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | dso                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | createdAt            | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
-> | preapprovalExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
->
-> - **Choice** Archive
->
->   Controller: validator, dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amuletrules-externalpartysetupproposalaccept-68720">
->
->   **Choice** ExternalPartySetupProposal_Accept
->
->   </div>
->
->   Controller: user
->
->   Returns: ExternalPartySetupProposal_AcceptResult
->
->   (no fields)
->
-> - <div id="type-splice-amuletrules-externalpartysetupproposalreject-30733">
->
->   **Choice** ExternalPartySetupProposal_Reject
->
->   </div>
->
->   Controller: user
->
->   Returns: ExternalPartySetupProposal_RejectResult
->
->   | Field  | Type                                                                                                         | Description |
->   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - <div id="type-splice-amuletrules-externalpartysetupproposalwithdraw-43220">
->
->   **Choice** ExternalPartySetupProposal_Withdraw
->
->   </div>
->
->   Controller: validator
->
->   Returns: ExternalPartySetupProposal_WithdrawResult
->
->   | Field  | Type                                                                                                         | Description |
->   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-
-<div id="type-splice-amuletrules-transferpreapproval-36220">
-
-**template** TransferPreapproval
-
-</div>
-
-> A pre-approval by a receiver to receive Amulet from anybody.
->
-> Pre-approvals are indexed by the SVs and served from scan for easy discovery until they expire. The cost of providing this discovery service is charged by burning Amulet.
->
-> Receivers can either purchase and renew these pre-approvals by themselves, or have an app provider do so for them in exchange for the app rewards for the amulet transfers completed via the managed pre-approval.
->
-> Signatory: receiver, provider, dso
->
-> | Field         | Type                                                                                                                | Description                                                                                                            |
-> |---------------|---------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-> | dso           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                        |
-> | receiver      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The receiver party                                                                                                     |
-> | provider      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider that manages the pre-approval for the receiver. Equal to the receiver for self-managed pre-approvals. |
-> | validFrom     | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | This timestamp marks the start of the period for which fees were paid for the pre-approval. Preserved across renewals. |
-> | lastRenewedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When the pre-approval was last renewed. Set equal to `validFrom` on creation and updated on each renewal.              |
-> | expiresAt     | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Provider selected timestamp defining the lifetime of the contract. Can be extended by renewing the contract.           |
->
-> - **Choice** Archive
->
->   Controller: receiver, provider, dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-amuletrules-transferpreapprovalcancel-70216">
->
->   **Choice** TransferPreapproval_Cancel
->
->   </div>
->
->   Controller: p
->
->   Returns: TransferPreapproval_CancelResult
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-transferpreapprovalexpire-84167">
->
->   **Choice** TransferPreapproval_Expire
->
->   </div>
->
->   Controller: dso
->
->   Returns: TransferPreapproval_ExpireResult
->
->   (no fields)
->
-> - <div id="type-splice-amuletrules-transferpreapprovalfetch-15083">
->
->   **Choice** TransferPreapproval_Fetch
->
->   </div>
->
->   Controller: p
->
->   Returns: TransferPreapproval
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-amuletrules-transferpreapprovalrenew-31244">
->
->   **Choice** TransferPreapproval_Renew
->
->   </div>
->
->   Controller: provider
->
->   Returns: TransferPreapproval_RenewResult
->
->   | Field        | Type                                                                                                              | Description |
->   |--------------|-------------------------------------------------------------------------------------------------------------------|-------------|
->   | context      | PaymentTransferContext                                                                                            |             |
->   | inputs       | \[TransferInput\]                                                                                                 |             |
->   | newExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
->
-> - <div id="type-splice-amuletrules-transferpreapprovalsend-62554">
->
->   **Choice** TransferPreapproval_Send
->
->   </div>
->
->   Deprecated: Use TransferPreapproval_SendV2 instead.
->
->   Controller: sender
->
->   Returns: TransferPreapproval_SendResult
->
->   | Field       | Type                                                                                                                                                                                                                                        | Description |
->   |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | context     | PaymentTransferContext                                                                                                                                                                                                                      |             |
->   | inputs      | \[TransferInput\]                                                                                                                                                                                                                           |             |
->   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                          |             |
->   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
->   | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - <div id="type-splice-amuletrules-transferpreapprovalsendv2-66036">
->
->   **Choice** TransferPreapproval_SendV2
->
->   </div>
->
->   Controller: sender
->
->   Returns: TransferPreapproval_SendV2Result
->
->   | Field       | Type                                                                                                                                                                                                                                        | Description |
->   |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | context     | ExternalPartyTransferContext                                                                                                                                                                                                                |             |
->   | inputs      | \[TransferInput\]                                                                                                                                                                                                                           |             |
->   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                          |             |
->   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
->   | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-28167">
-
-**data** AmuletRules_AddFutureAmuletConfigScheduleResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-43322">
->
-> AmuletRules_AddFutureAmuletConfigScheduleResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                      | Description |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->
-> **instance** GetField "newAmuletRules" AmuletRules_AddFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "newAmuletRules" AmuletRules_AddFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult
-
-<div id="type-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-46823">
-
-**data** AmuletRules_AdvanceOpenMiningRoundsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-34806">
->
-> AmuletRules_AdvanceOpenMiningRoundsResult
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                 | Description |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | summarizingRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound |             |
-> > | openRoundCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound        |             |
->
-> **instance** GetField "openRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** GetField "summarizingRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
->
-> **instance** SetField "openRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "summarizingRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult
-
-<div id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-49827">
-
-**data** AmuletRules_AllocateDevelopmentFundCouponResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-81038">
->
-> AmuletRules_AllocateDevelopmentFundCouponResult
->
-> </div>
->
-> > | Field                                | Type                                                                                                                                                                                                                                                                                          | Description |
-> > |--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | developmentFundCouponCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon                                                                                                                                           |             |
-> > | optUnclaimedDevelopmentFundCouponCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon) |             |
->
-> **instance** GetField "developmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon)
->
-> **instance** GetField "optUnclaimedDevelopmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
->
-> **instance** SetField "developmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon)
->
-> **instance** SetField "optUnclaimedDevelopmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult
-
-<div id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-58846">
-
-**data** AmuletRules_Amulet_ExpireTransferInstructionsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-66147">
->
-> AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> </div>
->
-> > | Field   | Type                          | Description |
-> > |---------|-------------------------------|-------------|
-> > | results | \[TransferInstructionResult\] |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** GetField "results" AmuletRules_Amulet_ExpireTransferInstructionsResult \[TransferInstructionResult\]
->
-> **instance** SetField "results" AmuletRules_Amulet_ExpireTransferInstructionsResult \[TransferInstructionResult\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult
-
-<div id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-72638">
-
-**data** AmuletRules_BootstrapExternalPartyConfigStateResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-91611">
->
-> AmuletRules_BootstrapExternalPartyConfigStateResult
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_BootstrapExternalPartyConfigStateResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_BootstrapExternalPartyConfigStateResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult
-
-<div id="type-splice-amuletrules-amuletrulesbootstraproundsresult-84997">
-
-**data** AmuletRules_Bootstrap_RoundsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesbootstraproundsresult-21662">
->
-> AmuletRules_Bootstrap_RoundsResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | openMiningRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
-> > | initialRound       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round          |             |
->
-> **instance** GetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
->
-> **instance** GetField "openMiningRoundCid" AmuletRules_Bootstrap_RoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
->
-> **instance** SetField "openMiningRoundCid" AmuletRules_Bootstrap_RoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult
-
-<div id="type-splice-amuletrules-amuletrulesbuymembertrafficresult-65734">
-
-**data** AmuletRules_BuyMemberTrafficResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesbuymembertrafficresult-62493">
->
-> AmuletRules_BuyMemberTrafficResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                                                                                                                                                  | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | round              | Round                                                                                                                                                                                                                                                                 |             |
-> > | summary            | TransferSummary                                                                                                                                                                                                                                                       |             |
-> > | amuletPaid         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                                    |             |
-> > | purchasedTraffic   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic                                                                                                                           |             |
-> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
-> > | meta               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                                                                                                                               |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_BuyMemberTrafficResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_BuyMemberTrafficResult
->
-> **instance** GetField "amuletPaid" AmuletRules_BuyMemberTrafficResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "meta" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** GetField "purchasedTraffic" AmuletRules_BuyMemberTrafficResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
->
-> **instance** GetField "round" AmuletRules_BuyMemberTrafficResult Round
->
-> **instance** GetField "senderChangeAmulet" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
->
-> **instance** SetField "amuletPaid" AmuletRules_BuyMemberTrafficResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "meta" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "purchasedTraffic" AmuletRules_BuyMemberTrafficResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
->
-> **instance** SetField "round" AmuletRules_BuyMemberTrafficResult Round
->
-> **instance** SetField "senderChangeAmulet" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult
-
-<div id="type-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-1315">
-
-**data** AmuletRules_ClaimExpiredRewardsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-54946">
->
-> AmuletRules_ClaimExpiredRewardsResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                                                                                                                                                           | Description |
-> > |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedRewardCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward) |             |
->
-> **instance** GetField "unclaimedRewardCid" AmuletRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
->
-> **instance** SetField "unclaimedRewardCid" AmuletRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult
-
-<div id="type-splice-amuletrules-amuletrulescomputefeesresult-44934">
-
-**data** AmuletRules_ComputeFeesResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulescomputefeesresult-49467">
->
-> AmuletRules_ComputeFeesResult
->
-> </div>
->
-> > | Field | Type                                                                                                                   | Description |
-> > |-------|------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | fees  | \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\] |             |
->
-> **instance** GetField "fees" AmuletRules_ComputeFeesResult \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
->
-> **instance** SetField "fees" AmuletRules_ComputeFeesResult \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult
-
-<div id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-77612">
-
-**data** AmuletRules_ConvertFeaturedAppActivityMarkersResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-46141">
->
-> AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> </div>
->
-> > | Field               | Type                                                                                                                                              | Description |
-> > |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | appRewardCouponCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\] |             |
->
-> **instance** GetField "appRewardCouponCids" AmuletRules_ConvertFeaturedAppActivityMarkersResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\]
->
-> **instance** SetField "appRewardCouponCids" AmuletRules_ConvertFeaturedAppActivityMarkersResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult
-
-<div id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-7515">
-
-**data** AmuletRules_CreateExternalPartySetupProposalResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-29120">
->
-> AmuletRules_CreateExternalPartySetupProposalResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                                     | Description |
-> > |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | proposalCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal |             |
-> > | user           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                      |             |
-> > | validator      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                      |             |
-> > | transferResult | TransferResult                                                                                                                                           |             |
-> > | amuletPaid     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                       |             |
-> > | meta           | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                  |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_CreateExternalPartySetupProposalResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_CreateExternalPartySetupProposalResult
->
-> **instance** GetField "amuletPaid" AmuletRules_CreateExternalPartySetupProposalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "meta" AmuletRules_CreateExternalPartySetupProposalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** GetField "proposalCid" AmuletRules_CreateExternalPartySetupProposalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal)
->
-> **instance** GetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
->
-> **instance** GetField "user" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "validator" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "amuletPaid" AmuletRules_CreateExternalPartySetupProposalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "meta" AmuletRules_CreateExternalPartySetupProposalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "proposalCid" AmuletRules_CreateExternalPartySetupProposalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal)
->
-> **instance** SetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
->
-> **instance** SetField "user" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "validator" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult
-
-<div id="type-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-96401">
-
-**data** AmuletRules_CreateTransferPreapprovalResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-40608">
->
-> AmuletRules_CreateTransferPreapprovalResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                              | Description |
-> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
-> > | transferResult         | TransferResult                                                                                                                                    |             |
-> > | amuletPaid             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |             |
-> > | meta                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata           |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_CreateTransferPreapprovalResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_CreateTransferPreapprovalResult
->
-> **instance** GetField "amuletPaid" AmuletRules_CreateTransferPreapprovalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "meta" AmuletRules_CreateTransferPreapprovalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** GetField "transferPreapprovalCid" AmuletRules_CreateTransferPreapprovalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
->
-> **instance** GetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
->
-> **instance** SetField "amuletPaid" AmuletRules_CreateTransferPreapprovalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "meta" AmuletRules_CreateTransferPreapprovalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "transferPreapprovalCid" AmuletRules_CreateTransferPreapprovalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
->
-> **instance** SetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult
-
-<div id="type-splice-amuletrules-amuletrulesdevnetfeatureappresult-75066">
-
-**data** AmuletRules_DevNet_FeatureAppResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesdevnetfeatureappresult-18203">
->
-> AmuletRules_DevNet_FeatureAppResult
->
-> </div>
->
-> > | Field               | Type                                                                                                                                           | Description |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
->
-> **instance** GetField "featuredAppRightCid" AmuletRules_DevNet_FeatureAppResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** SetField "featuredAppRightCid" AmuletRules_DevNet_FeatureAppResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult
-
-<div id="type-splice-amuletrules-amuletrulesdevnettapresult-1845">
-
-**data** AmuletRules_DevNet_TapResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesdevnettapresult-50542">
->
-> AmuletRules_DevNet_TapResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
-> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                    |             |
->
-> **instance** GetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "meta" AmuletRules_DevNet_TapResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "meta" AmuletRules_DevNet_TapResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult
-
-<div id="type-splice-amuletrules-amuletrulesexpiretransferinstructioninput-68344">
-
-**data** AmuletRules_ExpireTransferInstructionInput
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesexpiretransferinstructioninput-66803">
->
-> AmuletRules_ExpireTransferInstructionInput
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                              | Description |
-> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | transferInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
-> > | expireLock             | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                      |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_ExpireTransferInstructionInput
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_ExpireTransferInstructionInput
->
-> **instance** GetField "expireLock" AmuletRules_ExpireTransferInstructionInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** GetField "inputs" AmuletRules_Amulet_ExpireTransferInstructions \[AmuletRules_ExpireTransferInstructionInput\]
->
-> **instance** GetField "transferInstructionCid" AmuletRules_ExpireTransferInstructionInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
->
-> **instance** SetField "expireLock" AmuletRules_ExpireTransferInstructionInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "inputs" AmuletRules_Amulet_ExpireTransferInstructions \[AmuletRules_ExpireTransferInstructionInput\]
->
-> **instance** SetField "transferInstructionCid" AmuletRules_ExpireTransferInstructionInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
-
-<div id="type-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-2448">
-
-**data** AmuletRules_MergeMemberTrafficContractsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-32033">
->
-> AmuletRules_MergeMemberTrafficContractsResult
->
-> </div>
->
-> > | Field            | Type                                                                                                                                        | Description |
-> > |------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | mergedTrafficCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic |             |
->
-> **instance** GetField "mergedTrafficCid" AmuletRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
->
-> **instance** SetField "mergedTrafficCid" AmuletRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult
-
-<div id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-42676">
-
-**data** AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-50551">
->
-> AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> </div>
->
-> > | Field                             | Type                                                                                                                                                         | Description |
-> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
->
-> **instance** GetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** SetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
-
-<div id="type-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-41840">
-
-**data** AmuletRules_MergeUnclaimedRewardsResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-46793">
->
-> AmuletRules_MergeUnclaimedRewardsResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedRewardCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
->
-> **instance** GetField "unclaimedRewardCid" AmuletRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** SetField "unclaimedRewardCid" AmuletRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult
-
-<div id="type-splice-amuletrules-amuletrulesminingroundarchiveresult-65797">
-
-**data** AmuletRules_MiningRound_ArchiveResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesminingroundarchiveresult-73420">
->
-> AmuletRules_MiningRound_ArchiveResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult
-
-<div id="type-splice-amuletrules-amuletrulesminingroundcloseresult-67441">
-
-**data** AmuletRules_MiningRound_CloseResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesminingroundcloseresult-19004">
->
-> AmuletRules_MiningRound_CloseResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                            | Description |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
->
-> **instance** GetField "closedRoundCid" AmuletRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
->
-> **instance** SetField "closedRoundCid" AmuletRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult
-
-<div id="type-splice-amuletrules-amuletrulesminingroundstartissuingresult-26220">
-
-**data** AmuletRules_MiningRound_StartIssuingResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesminingroundstartissuingresult-95691">
->
-> AmuletRules_MiningRound_StartIssuingResult
->
-> </div>
->
-> > | Field                             | Type                                                                                                                                                                                                                                                                                          | Description |
-> > |-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | issuingRoundCid                   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound                                                                                                                                              |             |
-> > | unclaimedDevelopmentFundCouponCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon) |             |
->
-> **instance** GetField "issuingRoundCid" AmuletRules_MiningRound_StartIssuingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound)
->
-> **instance** GetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MiningRound_StartIssuingResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
->
-> **instance** SetField "issuingRoundCid" AmuletRules_MiningRound_StartIssuingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound)
->
-> **instance** SetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MiningRound_StartIssuingResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult
-
-<div id="type-splice-amuletrules-amuletrulesmintresult-5311">
-
-**data** AmuletRules_MintResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesmintresult-82812">
->
-> AmuletRules_MintResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Mint AmuletRules_MintResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Mint AmuletRules_MintResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Mint AmuletRules_MintResult
-
-<div id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-69237">
-
-**data** AmuletRules_RemoveFutureAmuletConfigScheduleResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-56166">
->
-> AmuletRules_RemoveFutureAmuletConfigScheduleResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                      | Description |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->
-> **instance** GetField "newAmuletRules" AmuletRules_RemoveFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "newAmuletRules" AmuletRules_RemoveFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult
-
-<div id="type-splice-amuletrules-amuletrulessetconfigresult-68086">
-
-**data** AmuletRules_SetConfigResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulessetconfigresult-73787">
->
-> AmuletRules_SetConfigResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                      | Description |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->
-> **instance** GetField "newAmuletRules" AmuletRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "newAmuletRules" AmuletRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult
-
-<div id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25160">
-
-**data** AmuletRules_UpdateExternalPartyConfigStatesResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25761">
->
-> AmuletRules_UpdateExternalPartyConfigStatesResult
->
-> </div>
->
-> > | Field                          | Type                                                                                                                                                   | Description |
-> > |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newExternalPartyConfigStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** GetField "newExternalPartyConfigStateCid" AmuletRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
->
-> **instance** SetField "newExternalPartyConfigStateCid" AmuletRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult
-
-<div id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-96070">
-
-**data** AmuletRules_UpdateFutureAmuletConfigScheduleResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-12117">
->
-> AmuletRules_UpdateFutureAmuletConfigScheduleResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                      | Description |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->
-> **instance** GetField "newAmuletRules" AmuletRules_UpdateFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "newAmuletRules" AmuletRules_UpdateFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult
-
-<div id="type-splice-amuletrules-apptransfercontext-68083">
-
-**data** AppTransferContext
-
-</div>
-
-> <div id="constr-splice-amuletrules-apptransfercontext-19128">
->
-> AppTransferContext
->
-> </div>
->
-> > | Field            | Type                                                                                                                                                                                                                                                                            | Description |
-> > |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletRules      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                                                       |             |
-> > | openMiningRound  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                                                   |             |
-> > | featuredAppRight | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AppTransferContext
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AppTransferContext
->
-> **instance** GetField "amuletRules" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** GetField "featuredAppRight" AppTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
->
-> **instance** GetField "openMiningRound" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "amuletRules" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "featuredAppRight" AppTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
->
-> **instance** SetField "openMiningRound" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
-
-<div id="type-splice-amuletrules-balancechange-24411">
-
-**data** BalanceChange
-
-</div>
-
-> <div id="constr-splice-amuletrules-balancechange-6762">
->
-> BalanceChange
->
-> </div>
->
-> > | Field                              | Type                                                                                                               | Description                                                                                                                                                                                            |
-> > |------------------------------------|--------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | changeToInitialAmountAsOfRoundZero | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The change to the total balance introduced by this balance change, normalized to round zero, i.e., a amulet created in round 3 is treated as a amulet created in round 0 with a higher initial amount. |
-> > | changeToHoldingFeesRate            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The change of total holding fees introduced by this balance change.                                                                                                                                    |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BalanceChange
->
-> **instance** [Additive](/appdev/reference/daml-standard-library/prelude#class-ghc-num-additive-25881) BalanceChange
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BalanceChange
->
-> **instance** GetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
->
-> **instance** GetField "changeToHoldingFeesRate" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "changeToInitialAmountAsOfRoundZero" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
->
-> **instance** SetField "changeToHoldingFeesRate" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "changeToInitialAmountAsOfRoundZero" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
-
-<div id="type-splice-amuletrules-createdamulet-4205">
-
-**data** CreatedAmulet
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferresultamulet-871">
->
-> TransferResultAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-transferresultlockedamulet-28147">
->
-> TransferResultLockedAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-extcreatedamulet-9390">
->
-> ExtCreatedAmulet
->
-> </div>
->
-> > | Field          | Type | Description                                                                                             |
-> > |----------------|------|---------------------------------------------------------------------------------------------------------|
-> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CreatedAmulet
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) CreatedAmulet
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CreatedAmulet
->
-> **instance** GetField "createdAmulets" TransferResult \[CreatedAmulet\]
->
-> **instance** GetField "dummyUnitField" CreatedAmulet ()
->
-> **instance** SetField "createdAmulets" TransferResult \[CreatedAmulet\]
->
-> **instance** SetField "dummyUnitField" CreatedAmulet ()
-
-<div id="type-splice-amuletrules-externalpartysetupproposalacceptresult-45221">
-
-**data** ExternalPartySetupProposal_AcceptResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-externalpartysetupproposalacceptresult-28452">
->
-> ExternalPartySetupProposal_AcceptResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                              | Description |
-> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | validatorRightCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight      |             |
-> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartySetupProposal_AcceptResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartySetupProposal_AcceptResult
->
-> **instance** GetField "transferPreapprovalCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
->
-> **instance** GetField "validatorRightCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight)
->
-> **instance** SetField "transferPreapprovalCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
->
-> **instance** SetField "validatorRightCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult
-
-<div id="type-splice-amuletrules-externalpartysetupproposalrejectresult-76848">
-
-**data** ExternalPartySetupProposal_RejectResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-externalpartysetupproposalrejectresult-73325">
->
-> ExternalPartySetupProposal_RejectResult
->
-> </div>
->
-> > | Field    | Type | Description |
-> > |----------|------|-------------|
-> > | dummyArg | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartySetupProposal_RejectResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartySetupProposal_RejectResult
->
-> **instance** GetField "dummyArg" ExternalPartySetupProposal_RejectResult ()
->
-> **instance** SetField "dummyArg" ExternalPartySetupProposal_RejectResult ()
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult
-
-<div id="type-splice-amuletrules-externalpartysetupproposalwithdrawresult-88253">
-
-**data** ExternalPartySetupProposal_WithdrawResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-externalpartysetupproposalwithdrawresult-17304">
->
-> ExternalPartySetupProposal_WithdrawResult
->
-> </div>
->
-> > | Field    | Type | Description |
-> > |----------|------|-------------|
-> > | dummyArg | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartySetupProposal_WithdrawResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartySetupProposal_WithdrawResult
->
-> **instance** GetField "dummyArg" ExternalPartySetupProposal_WithdrawResult ()
->
-> **instance** SetField "dummyArg" ExternalPartySetupProposal_WithdrawResult ()
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult
-
-<div id="type-splice-amuletrules-externalpartytransfercontext-70523">
-
-**data** ExternalPartyTransferContext
-
-</div>
-
-> Contracts that need to be passed in to a Transfer so that we can reference them by contract id instead of by key.
->
-> <div id="constr-splice-amuletrules-externalpartytransfercontext-43164">
->
-> ExternalPartyTransferContext
->
-> </div>
->
-> > | Field                    | Type                                                                                                                                                                                                                                                                            | Description                                                  |
-> > |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-> > | externalPartyConfigState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState                                                                                                                          |                                                              |
-> > | featuredAppRight         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) | Optional proof that the provider is a featured app provider. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyTransferContext
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyTransferContext
->
-> **instance** GetField "context" TransferPreapproval_SendV2 ExternalPartyTransferContext
->
-> **instance** GetField "externalPartyConfigState" ExternalPartyTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
->
-> **instance** GetField "featuredAppRight" ExternalPartyTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
->
-> **instance** SetField "context" TransferPreapproval_SendV2 ExternalPartyTransferContext
->
-> **instance** SetField "externalPartyConfigState" ExternalPartyTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
->
-> **instance** SetField "featuredAppRight" ExternalPartyTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
-
-<div id="type-splice-amuletrules-invalidtransferreason-16587">
-
-**data** InvalidTransferReason
-
-</div>
-
-> <div id="constr-splice-amuletrules-itrinsufficientfunds-49975">
->
-> ITR_InsufficientFunds
->
-> </div>
->
-> > | Field         | Type                                                                                                               | Description |
-> > |---------------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | missingAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
->
-> <div id="constr-splice-amuletrules-itrunknownsynchronizer-472">
->
-> ITR_UnknownSynchronizer
->
-> </div>
->
-> > | Field          | Type                                                                                                         | Description |
-> > |----------------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> <div id="constr-splice-amuletrules-itrinsufficienttopupamount-60775">
->
-> ITR_InsufficientTopupAmount
->
-> </div>
->
-> > | Field                | Type                                                                                                       | Description |
-> > |----------------------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | requestedTopupAmount | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | minTopupAmount       | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> <div id="constr-splice-amuletrules-itrother-36638">
->
-> ITR_Other
->
-> </div>
->
-> > | Field       | Type                                                                                                         | Description |
-> > |-------------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> <div id="constr-splice-amuletrules-extinvalidtransferreason-71060">
->
-> ExtInvalidTransferReason
->
-> </div>
->
-> > | Field          | Type | Description                                                                                             |
-> > |----------------|------|---------------------------------------------------------------------------------------------------------|
-> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) InvalidTransferReason
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) InvalidTransferReason
->
-> **instance** GetField "description" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "dummyUnitField" InvalidTransferReason ()
->
-> **instance** GetField "minTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "missingAmount" InvalidTransferReason [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "reason" TransferCommandResult InvalidTransferReason
->
-> **instance** GetField "requestedTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "synchronizerId" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "description" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dummyUnitField" InvalidTransferReason ()
->
-> **instance** SetField "minTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "missingAmount" InvalidTransferReason [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "reason" TransferCommandResult InvalidTransferReason
->
-> **instance** SetField "requestedTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "synchronizerId" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
-
-<div id="type-splice-amuletrules-openminingroundtriple-84091">
-
-**data** OpenMiningRoundTriple
-
-</div>
-
-> <div id="constr-splice-amuletrules-openminingroundtriple-73258">
->
-> OpenMiningRoundTriple
->
-> </div>
->
-> > | Field     | Type                                                                                                                                          | Description |
-> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | round0Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
-> > | round1Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
-> > | round2Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) OpenMiningRoundTriple
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) OpenMiningRoundTriple
->
-> **instance** GetField "openMiningRoundTriple" AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple
->
-> **instance** GetField "openMiningRoundTriple" AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple
->
-> **instance** GetField "round0Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** GetField "round1Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** GetField "round2Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "openMiningRoundTriple" AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple
->
-> **instance** SetField "openMiningRoundTriple" AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple
->
-> **instance** SetField "round0Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "round1Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "round2Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
-
-<div id="type-splice-amuletrules-paymenttransfercontext-72190">
-
-**data** PaymentTransferContext
-
-</div>
-
-> <div id="constr-splice-amuletrules-paymenttransfercontext-9413">
->
-> PaymentTransferContext
->
-> </div>
->
-> > | Field       | Type                                                                                                                                      | Description |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
-> > | context     | TransferContext                                                                                                                           |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PaymentTransferContext
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PaymentTransferContext
->
-> **instance** GetField "amuletRules" PaymentTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** GetField "context" AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext
->
-> **instance** GetField "context" AmuletRules_CreateTransferPreapproval PaymentTransferContext
->
-> **instance** GetField "context" PaymentTransferContext TransferContext
->
-> **instance** GetField "context" TransferPreapproval_Renew PaymentTransferContext
->
-> **instance** GetField "context" TransferPreapproval_Send PaymentTransferContext
->
-> **instance** GetField "context" TransferCommand_Send PaymentTransferContext
->
-> **instance** SetField "amuletRules" PaymentTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "context" AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext
->
-> **instance** SetField "context" AmuletRules_CreateTransferPreapproval PaymentTransferContext
->
-> **instance** SetField "context" PaymentTransferContext TransferContext
->
-> **instance** SetField "context" TransferPreapproval_Renew PaymentTransferContext
->
-> **instance** SetField "context" TransferPreapproval_Send PaymentTransferContext
->
-> **instance** SetField "context" TransferCommand_Send PaymentTransferContext
-
-<div id="type-splice-amuletrules-preprocessedtransferoutput-12209">
-
-**data** PreprocessedTransferOutput
-
-</div>
-
-> <div id="constr-splice-amuletrules-preprocessedtransferoutput-93914">
->
-> PreprocessedTransferOutput
->
-> </div>
->
-> > | Field     | Type                                                                                                                                    | Description                                                 |
-> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
-> > | owner     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     | Owner of the output                                         |
-> > | outputFee | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | Fee charged to create this output                           |
-> > | amount    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | Amount of amulet held by this output (after deducting fees) |
-> > | lock      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock | Whether to lock the amulet or not                           |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PreprocessedTransferOutput
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PreprocessedTransferOutput
->
-> **instance** GetField "amount" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** GetField "outputFee" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "owner" PreprocessedTransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "amount" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** SetField "outputFee" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "owner" PreprocessedTransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
-
-<div id="type-splice-amuletrules-rewardsissuanceconfig-37252">
-
-**data** RewardsIssuanceConfig
-
-</div>
-
-> An easy way to configure `exucuteTransfer` wrt what rewards to issue. We currently only use two configurations: but all of the options in here make sense, so we keep them.
->
-> <div id="constr-splice-amuletrules-rewardsissuanceconfig-46673">
->
-> RewardsIssuanceConfig
->
-> </div>
->
-> > | Field                 | Type                                                                                                         | Description |
-> > |-----------------------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | issueAppRewards       | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) |             |
-> > | issueValidatorRewards | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) |             |
->
-> **instance** GetField "issueAppRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** GetField "issueValidatorRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "issueAppRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "issueValidatorRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
-
-<div id="type-splice-amuletrules-transfer-72721">
-
-**data** Transfer
-
-</div>
-
-> Representation of a batch transfer.
->
-> <div id="constr-splice-amuletrules-transfer-1214">
->
-> Transfer
->
-> </div>
->
-> > | Field         | Type                                                                                                                                                    | Description                                          |
-> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-> > | sender        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                     |                                                      |
-> > | provider      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                     |                                                      |
-> > | inputs        | \[TransferInput\]                                                                                                                                       |                                                      |
-> > | outputs       | \[TransferOutput\]                                                                                                                                      |                                                      |
-> > | beneficiaries | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\] | Beneficiaries between which the app reward is split. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Transfer
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) Transfer
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Transfer
->
-> **instance** GetField "beneficiaries" Transfer ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\])
->
-> **instance** GetField "inputs" Transfer \[TransferInput\]
->
-> **instance** GetField "outputs" Transfer \[TransferOutput\]
->
-> **instance** GetField "provider" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "sender" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "transfer" AmuletRules_Transfer Transfer
->
-> **instance** SetField "beneficiaries" Transfer ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\])
->
-> **instance** SetField "inputs" Transfer \[TransferInput\]
->
-> **instance** SetField "outputs" Transfer \[TransferOutput\]
->
-> **instance** SetField "provider" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "sender" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "transfer" AmuletRules_Transfer Transfer
-
-<div id="type-splice-amuletrules-transfercontext-68991">
-
-**data** TransferContext
-
-</div>
-
-> Contracts that need to be passed in to a Transfer so that we can reference them by contract id instead of by key.
->
-> <div id="constr-splice-amuletrules-transfercontext-56806">
->
-> TransferContext
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                                                                                                                                                                                                                                               | Description                                                  |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-> > | openMiningRound     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                                                                                                                                                      |                                                              |
-> > | issuingMiningRounds | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound)                                                                                                           |                                                              |
-> > | validatorRights     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight) | Map from user to ValidatorRight contract.                    |
-> > | featuredAppRight    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)                                                                                                    | Optional proof that the provider is a featured app provider. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferContext
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferContext
->
-> **instance** GetField "context" AmuletRules_BuyMemberTraffic TransferContext
->
-> **instance** GetField "context" AmuletRules_ComputeFees TransferContext
->
-> **instance** GetField "context" AmuletRules_Transfer TransferContext
->
-> **instance** GetField "context" PaymentTransferContext TransferContext
->
-> **instance** GetField "featuredAppRight" TransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
->
-> **instance** GetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
->
-> **instance** GetField "openMiningRound" TransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** GetField "validatorRights" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
->
-> **instance** SetField "context" AmuletRules_BuyMemberTraffic TransferContext
->
-> **instance** SetField "context" AmuletRules_ComputeFees TransferContext
->
-> **instance** SetField "context" AmuletRules_Transfer TransferContext
->
-> **instance** SetField "context" PaymentTransferContext TransferContext
->
-> **instance** SetField "featuredAppRight" TransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
->
-> **instance** SetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
->
-> **instance** SetField "openMiningRound" TransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "validatorRights" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
-
-<div id="type-splice-amuletrules-transfercontextsummary-99392">
-
-**data** TransferContextSummary
-
-</div>
-
-> Deprecated: unused, we just can't remove it yet due to upgrading rules
->
-> <div id="constr-splice-amuletrules-transfercontextsummary-98359">
->
-> TransferContextSummary
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                                                                                                                                                                                                                                               | Description |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | featuredAppProvider | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                 |             |
-> > | config              | TransferConfig Amulet                                                                                                                                                                                                                                                                                                                                                              |             |
-> > | openRound           | OpenMiningRound                                                                                                                                                                                                                                                                                                                                                                    |             |
-> > | issuingMiningRounds | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound                                                                                                                                                                                                                                           |             |
-> > | validatorRights     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferContextSummary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferContextSummary
->
-> **instance** GetField "config" TransferContextSummary (TransferConfig Amulet)
->
-> **instance** GetField "featuredAppProvider" TransferContextSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
->
-> **instance** GetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** GetField "openRound" TransferContextSummary OpenMiningRound
->
-> **instance** GetField "validatorRights" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
->
-> **instance** SetField "config" TransferContextSummary (TransferConfig Amulet)
->
-> **instance** SetField "featuredAppProvider" TransferContextSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
->
-> **instance** SetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** SetField "openRound" TransferContextSummary OpenMiningRound
->
-> **instance** SetField "validatorRights" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
-
-<div id="type-splice-amuletrules-transfercontextsummaryv2-75114">
-
-**data** TransferContextSummaryV2
-
-</div>
-
-> <div id="constr-splice-amuletrules-transfercontextsummaryv2-63237">
->
-> TransferContextSummaryV2
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                                                                                                                                                                                                                                               | Description |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                                                                                                                                                |             |
-> > | featuredAppProvider | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                 |             |
-> > | config              | TransferConfigV2 Amulet                                                                                                                                                                                                                                                                                                                                                            |             |
-> > | openRoundNumber     | Round                                                                                                                                                                                                                                                                                                                                                                              |             |
-> > | amuletPrice         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                                                                                                                                                 |             |
-> > | issuingMiningRounds | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound                                                                                                                                                                                                                                           |             |
-> > | validatorRights     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferContextSummaryV2
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferContextSummaryV2
->
-> **instance** GetField "amuletPrice" TransferContextSummaryV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
->
-> **instance** GetField "dso" TransferContextSummaryV2 [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "featuredAppProvider" TransferContextSummaryV2 ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
->
-> **instance** GetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** GetField "openRoundNumber" TransferContextSummaryV2 Round
->
-> **instance** GetField "validatorRights" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
->
-> **instance** SetField "amuletPrice" TransferContextSummaryV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
->
-> **instance** SetField "dso" TransferContextSummaryV2 [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "featuredAppProvider" TransferContextSummaryV2 ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
->
-> **instance** SetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** SetField "openRoundNumber" TransferContextSummaryV2 Round
->
-> **instance** SetField "validatorRights" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
-
-<div id="type-splice-amuletrules-transferinput-61796">
-
-**data** TransferInput
-
-</div>
-
-> An individual input for a batch transfer.
->
-> <div id="constr-splice-amuletrules-inputapprewardcoupon-60885">
->
-> InputAppRewardCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-inputvalidatorrewardcoupon-18692">
->
-> InputValidatorRewardCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRewardCoupon)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-inputsvrewardcoupon-94444">
->
-> InputSvRewardCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-inputamulet-35826">
->
-> InputAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-exttransferinput-5819">
->
-> ExtTransferInput
->
-> </div>
->
-> > | Field                         | Type                                                                                                                                                                                                                                                                                 | Description                                                                                             |
-> > |-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-> > | dummyUnitField                | ()                                                                                                                                                                                                                                                                                   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
-> > | optInputValidatorFaucetCoupon | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon) | Added in CIP-3. Optional validator faucet coupon input into this transfer.                              |
->
-> <div id="constr-splice-amuletrules-inputvalidatorlivenessactivityrecord-59154">
->
-> InputValidatorLivenessActivityRecord ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-inputunclaimedactivityrecord-17727">
->
-> InputUnclaimedActivityRecord ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord)
->
-> </div>
->
-> <div id="constr-splice-amuletrules-inputdevelopmentfundcoupon-48881">
->
-> InputDevelopmentFundCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon)
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferInput
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) TransferInput
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferInput
->
-> **instance** GetField "dummyUnitField" TransferInput ()
->
-> **instance** GetField "inputs" AmuletRules_BuyMemberTraffic \[TransferInput\]
->
-> **instance** GetField "inputs" AmuletRules_CreateExternalPartySetupProposal \[TransferInput\]
->
-> **instance** GetField "inputs" AmuletRules_CreateTransferPreapproval \[TransferInput\]
->
-> **instance** GetField "inputs" Transfer \[TransferInput\]
->
-> **instance** GetField "inputs" TransferPreapproval_Renew \[TransferInput\]
->
-> **instance** GetField "inputs" TransferPreapproval_Send \[TransferInput\]
->
-> **instance** GetField "inputs" TransferPreapproval_SendV2 \[TransferInput\]
->
-> **instance** GetField "inputs" TransferCommand_Send \[TransferInput\]
->
-> **instance** GetField "optInputValidatorFaucetCoupon" TransferInput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon))
->
-> **instance** SetField "dummyUnitField" TransferInput ()
->
-> **instance** SetField "inputs" AmuletRules_BuyMemberTraffic \[TransferInput\]
->
-> **instance** SetField "inputs" AmuletRules_CreateExternalPartySetupProposal \[TransferInput\]
->
-> **instance** SetField "inputs" AmuletRules_CreateTransferPreapproval \[TransferInput\]
->
-> **instance** SetField "inputs" Transfer \[TransferInput\]
->
-> **instance** SetField "inputs" TransferPreapproval_Renew \[TransferInput\]
->
-> **instance** SetField "inputs" TransferPreapproval_Send \[TransferInput\]
->
-> **instance** SetField "inputs" TransferPreapproval_SendV2 \[TransferInput\]
->
-> **instance** SetField "inputs" TransferCommand_Send \[TransferInput\]
->
-> **instance** SetField "optInputValidatorFaucetCoupon" TransferInput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon))
-
-<div id="type-splice-amuletrules-transferinputssummary-46693">
-
-**data** TransferInputsSummary
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferinputssummary-65268">
->
-> TransferInputsSummary
->
-> </div>
->
-> > | Field                              | Type                                                                                                                                                                                                                                              | Description                                                                                                                                                       |
-> > |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | totalAmuletAmount                  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | totalAppRewardAmount               | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | totalValidatorRewardAmount         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | totalValidatorFaucetAmount         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Note that the validator faucet amount does not need to be optional in this type, as it is not stored on the ledger.                                               |
-> > | totalSvRewardAmount                | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | totalHoldingFees                   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | amountArchivedAsOfRoundZero        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | changeToHoldingFeesRate            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
-> > | totalUnclaimedActivityRecordAmount | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Note: Made optional as the addition of this field is checked by the upgrade checker on package upload because `TransferInputsSummary` is serializable.            |
-> > | totalDevelopmentFundAmount         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Note: Same rationale as above — made optional to ensure compatibility with the upgrade checker on package upload because `TransferInputsSummary` is serializable. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferInputsSummary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferInputsSummary
->
-> **instance** GetField "amountArchivedAsOfRoundZero" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "changeToHoldingFeesRate" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalAmuletAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalAppRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalDevelopmentFundAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "totalHoldingFees" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalSvRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalUnclaimedActivityRecordAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "totalValidatorFaucetAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalValidatorRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amountArchivedAsOfRoundZero" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "changeToHoldingFeesRate" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalAmuletAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalAppRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalDevelopmentFundAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "totalHoldingFees" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalSvRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalUnclaimedActivityRecordAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "totalValidatorFaucetAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalValidatorRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
-
-<div id="type-splice-amuletrules-transferoutput-70512">
-
-**data** TransferOutput
-
-</div>
-
-> An individual output for a batch transfer.
->
-> <div id="constr-splice-amuletrules-transferoutput-68311">
->
-> TransferOutput
->
-> </div>
->
-> > | Field            | Type                                                                                                                                    | Description                                                                                                                                                                                                                                                                                      |
-> > |------------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | receiver         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     | The receiver who will own the created output amulet.                                                                                                                                                                                                                                             |
-> > | receiverFeeRatio | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | The ratio of the output fee paid from receiver's output amount. 1.0 means the whole fee is deducted from the specified output amount, 0.0 the whole fee is deducted from the sender's input balance. If a receiver's fee is not covered by the specified output amount, the transfer is aborted. |
-> > | amount           | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | The amount of amulet to receive, before deducting the receiver's part of the output fee.                                                                                                                                                                                                         |
-> > | lock             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock | The lock to be added, if any.                                                                                                                                                                                                                                                                    |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferOutput
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) TransferOutput
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferOutput
->
-> **instance** GetField "amount" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** GetField "outputs" AmuletRules_ComputeFees \[TransferOutput\]
->
-> **instance** GetField "outputs" Transfer \[TransferOutput\]
->
-> **instance** GetField "receiver" TransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "receiverFeeRatio" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amount" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** SetField "outputs" AmuletRules_ComputeFees \[TransferOutput\]
->
-> **instance** SetField "outputs" Transfer \[TransferOutput\]
->
-> **instance** SetField "receiver" TransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "receiverFeeRatio" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
-
-<div id="type-splice-amuletrules-transferoutputssummary-22405">
-
-**type** TransferOutputsSummary
-= \[PreprocessedTransferOutput\]
-
-</div>
-
-<div id="type-splice-amuletrules-transferpreapprovalcancelresult-51361">
-
-**data** TransferPreapproval_CancelResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferpreapprovalcancelresult-83086">
->
-> TransferPreapproval_CancelResult
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_CancelResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_CancelResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult
-
-<div id="type-splice-amuletrules-transferpreapprovalexpireresult-89274">
-
-**data** TransferPreapproval_ExpireResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferpreapprovalexpireresult-36569">
->
-> TransferPreapproval_ExpireResult
->
-> </div>
->
-> > (no fields)
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_ExpireResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_ExpireResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult
-
-<div id="type-splice-amuletrules-transferpreapprovalrenewresult-23849">
-
-**data** TransferPreapproval_RenewResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferpreapprovalrenewresult-61232">
->
-> TransferPreapproval_RenewResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                              | Description |
-> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
-> > | transferResult         | TransferResult                                                                                                                                    |             |
-> > | receiver               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
-> > | provider               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
-> > | amuletPaid             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |             |
-> > | meta                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata           |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_RenewResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_RenewResult
->
-> **instance** GetField "amuletPaid" TransferPreapproval_RenewResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "meta" TransferPreapproval_RenewResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** GetField "provider" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "receiver" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "transferPreapprovalCid" TransferPreapproval_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
->
-> **instance** GetField "transferResult" TransferPreapproval_RenewResult TransferResult
->
-> **instance** SetField "amuletPaid" TransferPreapproval_RenewResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "meta" TransferPreapproval_RenewResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "provider" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "receiver" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "transferPreapprovalCid" TransferPreapproval_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
->
-> **instance** SetField "transferResult" TransferPreapproval_RenewResult TransferResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult
-
-<div id="type-splice-amuletrules-transferpreapprovalsendresult-68419">
-
-**data** TransferPreapproval_SendResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferpreapprovalsendresult-67472">
->
-> TransferPreapproval_SendResult
->
-> </div>
->
-> > | Field  | Type                                                                                                                                    | Description |
-> > |--------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | result | TransferResult                                                                                                                          |             |
-> > | meta   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_SendResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_SendResult
->
-> **instance** GetField "meta" TransferPreapproval_SendResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** GetField "result" TransferPreapproval_SendResult TransferResult
->
-> **instance** SetField "meta" TransferPreapproval_SendResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "result" TransferPreapproval_SendResult TransferResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult
-
-<div id="type-splice-amuletrules-transferpreapprovalsendv2result-94909">
-
-**data** TransferPreapproval_SendV2Result
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferpreapprovalsendv2result-33038">
->
-> TransferPreapproval_SendV2Result
->
-> </div>
->
-> > | Field  | Type           | Description |
-> > |--------|----------------|-------------|
-> > | result | TransferResult |             |
-> > | meta   | Metadata       |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_SendV2Result
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_SendV2Result
->
-> **instance** GetField "meta" TransferPreapproval_SendV2Result Metadata
->
-> **instance** GetField "result" TransferPreapproval_SendV2Result TransferResult
->
-> **instance** SetField "meta" TransferPreapproval_SendV2Result Metadata
->
-> **instance** SetField "result" TransferPreapproval_SendV2Result TransferResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result
-
-<div id="type-splice-amuletrules-transferresult-93164">
-
-**data** TransferResult
-
-</div>
-
-> <div id="constr-splice-amuletrules-transferresult-68399">
->
-> TransferResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                                                                                                                                                  | Description                                                                                                                                                                |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | round              | Round                                                                                                                                                                                                                                                                 | Round for which this transfer was registered.                                                                                                                              |
-> > | summary            | TransferSummary                                                                                                                                                                                                                                                       | Summary of amount input and outputs, and fees paid.                                                                                                                        |
-> > | createdAmulets     | \[CreatedAmulet\]                                                                                                                                                                                                                                                     | References to the created output amulets.                                                                                                                                  |
-> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) | Optional reference to the amulet for the change returned to the sender. Only created if there was some change to be returned after deducting the fee for returning change. |
-> > | meta               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                                                                                                                               |                                                                                                                                                                            |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferResult
->
-> **instance** GetField "createdAmulets" TransferResult \[CreatedAmulet\]
->
-> **instance** GetField "meta" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** GetField "result" TransferPreapproval_SendResult TransferResult
->
-> **instance** GetField "result" TransferPreapproval_SendV2Result TransferResult
->
-> **instance** GetField "result" TransferCommandResult TransferResult
->
-> **instance** GetField "round" TransferResult Round
->
-> **instance** GetField "senderChangeAmulet" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "summary" TransferResult TransferSummary
->
-> **instance** GetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
->
-> **instance** GetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
->
-> **instance** GetField "transferResult" TransferPreapproval_RenewResult TransferResult
->
-> **instance** SetField "createdAmulets" TransferResult \[CreatedAmulet\]
->
-> **instance** SetField "meta" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
->
-> **instance** SetField "result" TransferPreapproval_SendResult TransferResult
->
-> **instance** SetField "result" TransferPreapproval_SendV2Result TransferResult
->
-> **instance** SetField "result" TransferCommandResult TransferResult
->
-> **instance** SetField "round" TransferResult Round
->
-> **instance** SetField "senderChangeAmulet" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "summary" TransferResult TransferSummary
->
-> **instance** SetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
->
-> **instance** SetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
->
-> **instance** SetField "transferResult" TransferPreapproval_RenewResult TransferResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Transfer TransferResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Transfer TransferResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Transfer TransferResult
-
-<div id="type-splice-amuletrules-transfersummary-17366">
-
-**data** TransferSummary
-
-</div>
-
-> Summary of input and output amounts and fees paid. This summary is intended to be used together with the `Transfer` specification used to initiate the transfer when displaying a transaction summary. Its fields are intended to provide shortcuts for key numbers that are complex to compute off-ledger.
->
-> All amounts are denominated in Splice.
->
-> <div id="constr-splice-amuletrules-transfersummary-72851">
->
-> TransferSummary
->
-> </div>
->
-> > | Field                              | Type                                                                                                                                                                                                                                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-> > |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | inputAppRewardAmount               | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total amount of app reward coupon issunace input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-> > | inputValidatorRewardAmount         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total amount of validator rewards coupon issuance input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-> > | inputSvRewardAmount                | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total amount of SV reward coupon issuance input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-> > | inputAmuletAmount                  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total input amount of amulet input into this transfer, before deducting holding fees.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-> > | balanceChanges                     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange | Balance changes per party                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-> > | holdingFees                        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Holding fees paid by the sender on their input amulets.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-> > | outputFees                         | \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]                                                                                                                            | Fees paid for the individual output amulets in the order they were specified.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-> > | senderChangeFee                    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Fee charged for returning change to the sender, which is the smaller of the left-over balance after paying for all outputs or one amulet create fee. In case the left-over balance after paying for all outputs is smaller than a create fee, all of that balance is consumed by the fee for returning change, and no actual amulet is created for the sender, i.e., the `senderChangeAmount` is zero. The transfer does though succeed. For transfers that do not allow returning change to the sender, the left-over balance after paying for all outputs must be zero, and thus the `senderChangeFee` must be zero as well. |
-> > | senderChangeAmount                 | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | The final amount of amulet returned to the sender after paying for all outputs and fees. If it is zero, then no amulet is created for the sender.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-> > | amuletPrice                        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | The amulet price at the round this transfer was executed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-> > | inputValidatorFaucetAmount         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Added in CIP-3. Total amount of validator faucet coupon issuance input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-> > | inputUnclaimedActivityRecordAmount | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Total amount of unclaimed activity record issuance input into this transfer. Note: Made optional as the addition of this field is checked by the upgrade checker.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-> > | inputDevelopmentFundAmount         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Total amount of development fund coupon issuance input into this transfer. Note: Made optional as the addition of this field is checked by the upgrade checker.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferSummary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferSummary
->
-> **instance** GetField "amuletPrice" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
->
-> **instance** GetField "holdingFees" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "inputAmuletAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "inputAppRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "inputDevelopmentFundAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "inputSvRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "inputUnclaimedActivityRecordAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "inputValidatorFaucetAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "inputValidatorRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "outputFees" TransferSummary \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
->
-> **instance** GetField "senderChangeAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "senderChangeFee" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
->
-> **instance** GetField "summary" TransferResult TransferSummary
->
-> **instance** SetField "amuletPrice" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
->
-> **instance** SetField "holdingFees" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "inputAmuletAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "inputAppRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "inputDevelopmentFundAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "inputSvRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "inputUnclaimedActivityRecordAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "inputValidatorFaucetAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "inputValidatorRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "outputFees" TransferSummary \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
->
-> **instance** SetField "senderChangeAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "senderChangeFee" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
->
-> **instance** SetField "summary" TransferResult TransferSummary
-
-<div id="type-splice-amuletrules-validatedopenminingrounds-3458">
-
-**data** ValidatedOpenMiningRounds
-
-</div>
-
-> <div id="constr-splice-amuletrules-validatedopenminingrounds-35727">
->
-> ValidatedOpenMiningRounds
->
-> </div>
->
-> > | Field             | Type            | Description |
-> > |-------------------|-----------------|-------------|
-> > | oldestRound       | OpenMiningRound |             |
-> > | latestUsableRound | OpenMiningRound |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ValidatedOpenMiningRounds
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ValidatedOpenMiningRounds
->
-> **instance** GetField "latestUsableRound" ValidatedOpenMiningRounds OpenMiningRound
->
-> **instance** GetField "oldestRound" ValidatedOpenMiningRounds OpenMiningRound
->
-> **instance** SetField "latestUsableRound" ValidatedOpenMiningRounds OpenMiningRound
->
-> **instance** SetField "oldestRound" ValidatedOpenMiningRounds OpenMiningRound
+<span id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-28167"></span>
+
+### `data AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-43322"></span>
+
+- `AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_AddFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_AddFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+<span id="type-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-46823"></span>
+
+### `data AmuletRules_AdvanceOpenMiningRoundsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-34806"></span>
+
+- `AmuletRules_AdvanceOpenMiningRoundsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| summarizingRoundCid | ContractId SummarizingMiningRound |  |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+Instances:
+
+- `instance GetField openRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance GetField summarizingRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance SetField openRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance SetField summarizingRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance HasExercise AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult`
+
+<span id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-49827"></span>
+
+### `data AmuletRules_AllocateDevelopmentFundCouponResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-81038"></span>
+
+- `AmuletRules_AllocateDevelopmentFundCouponResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| developmentFundCouponCid | ContractId DevelopmentFundCoupon |  |
+| optUnclaimedDevelopmentFundCouponCid | Optional (ContractId UnclaimedDevelopmentFundCoupon) |  |
+
+Instances:
+
+- `instance GetField developmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (ContractId DevelopmentFundCoupon)`
+- `instance GetField optUnclaimedDevelopmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance SetField developmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (ContractId DevelopmentFundCoupon)`
+- `instance SetField optUnclaimedDevelopmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance HasExercise AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult`
+
+<span id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-58846"></span>
+
+### `data AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-66147"></span>
+
+- `AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [TransferInstructionResult] |  |
+
+Instances:
+
+- `instance Eq AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance Show AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance GetField results AmuletRules_Amulet_ExpireTransferInstructionsResult [TransferInstructionResult]`
+- `instance SetField results AmuletRules_Amulet_ExpireTransferInstructionsResult [TransferInstructionResult]`
+- `instance HasExercise AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+<span id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-72638"></span>
+
+### `data AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-91611"></span>
+
+- `AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+Instances:
+
+- `instance Eq AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance Show AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasExercise AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+<span id="type-splice-amuletrules-amuletrulesbootstraproundsresult-84997"></span>
+
+### `data AmuletRules_Bootstrap_RoundsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesbootstraproundsresult-21662"></span>
+
+- `AmuletRules_Bootstrap_RoundsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openMiningRoundCid | ContractId OpenMiningRound |  |
+| initialRound | Optional Round |  |
+
+Instances:
+
+- `instance GetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance GetField openMiningRoundCid AmuletRules_Bootstrap_RoundsResult (ContractId OpenMiningRound)`
+- `instance SetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance SetField openMiningRoundCid AmuletRules_Bootstrap_RoundsResult (ContractId OpenMiningRound)`
+- `instance HasExercise AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult`
+
+<span id="type-splice-amuletrules-amuletrulesbuymembertrafficresult-65734"></span>
+
+### `data AmuletRules_BuyMemberTrafficResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesbuymembertrafficresult-62493"></span>
+
+- `AmuletRules_BuyMemberTrafficResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| round | Round |  |
+| summary | TransferSummary |  |
+| amuletPaid | Decimal |  |
+| purchasedTraffic | ContractId MemberTraffic |  |
+| senderChangeAmulet | Optional (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq AmuletRules_BuyMemberTrafficResult`
+- `instance Show AmuletRules_BuyMemberTrafficResult`
+- `instance GetField amuletPaid AmuletRules_BuyMemberTrafficResult Decimal`
+- `instance GetField meta AmuletRules_BuyMemberTrafficResult (Optional Metadata)`
+- `instance GetField purchasedTraffic AmuletRules_BuyMemberTrafficResult (ContractId MemberTraffic)`
+- `instance GetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance GetField senderChangeAmulet AmuletRules_BuyMemberTrafficResult (Optional (ContractId Amulet))`
+- `instance GetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance SetField amuletPaid AmuletRules_BuyMemberTrafficResult Decimal`
+- `instance SetField meta AmuletRules_BuyMemberTrafficResult (Optional Metadata)`
+- `instance SetField purchasedTraffic AmuletRules_BuyMemberTrafficResult (ContractId MemberTraffic)`
+- `instance SetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance SetField senderChangeAmulet AmuletRules_BuyMemberTrafficResult (Optional (ContractId Amulet))`
+- `instance SetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance HasExercise AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult`
+
+<span id="type-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-1315"></span>
+
+### `data AmuletRules_ClaimExpiredRewardsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-54946"></span>
+
+- `AmuletRules_ClaimExpiredRewardsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | Optional (ContractId UnclaimedReward) |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid AmuletRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance SetField unclaimedRewardCid AmuletRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance HasExercise AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult`
+
+<span id="type-splice-amuletrules-amuletrulescomputefeesresult-44934"></span>
+
+### `data AmuletRules_ComputeFeesResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulescomputefeesresult-49467"></span>
+
+- `AmuletRules_ComputeFeesResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| fees | [Decimal] |  |
+
+Instances:
+
+- `instance GetField fees AmuletRules_ComputeFeesResult [Decimal]`
+- `instance SetField fees AmuletRules_ComputeFeesResult [Decimal]`
+- `instance HasExercise AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult`
+
+<span id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-77612"></span>
+
+### `data AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-46141"></span>
+
+- `AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| appRewardCouponCids | [ContractId AppRewardCoupon] |  |
+
+Instances:
+
+- `instance GetField appRewardCouponCids AmuletRules_ConvertFeaturedAppActivityMarkersResult [ContractId AppRewardCoupon]`
+- `instance SetField appRewardCouponCids AmuletRules_ConvertFeaturedAppActivityMarkersResult [ContractId AppRewardCoupon]`
+- `instance HasExercise AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+<span id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-7515"></span>
+
+### `data AmuletRules_CreateExternalPartySetupProposalResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-29120"></span>
+
+- `AmuletRules_CreateExternalPartySetupProposalResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| proposalCid | ContractId ExternalPartySetupProposal |  |
+| user | Party |  |
+| validator | Party |  |
+| transferResult | TransferResult |  |
+| amuletPaid | Decimal |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance Show AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance GetField amuletPaid AmuletRules_CreateExternalPartySetupProposalResult Decimal`
+- `instance GetField meta AmuletRules_CreateExternalPartySetupProposalResult (Optional Metadata)`
+- `instance GetField proposalCid AmuletRules_CreateExternalPartySetupProposalResult (ContractId ExternalPartySetupProposal)`
+- `instance GetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance GetField user AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance GetField validator AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance SetField amuletPaid AmuletRules_CreateExternalPartySetupProposalResult Decimal`
+- `instance SetField meta AmuletRules_CreateExternalPartySetupProposalResult (Optional Metadata)`
+- `instance SetField proposalCid AmuletRules_CreateExternalPartySetupProposalResult (ContractId ExternalPartySetupProposal)`
+- `instance SetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance SetField user AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance SetField validator AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance HasExercise AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult`
+
+<span id="type-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-96401"></span>
+
+### `data AmuletRules_CreateTransferPreapprovalResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-40608"></span>
+
+- `AmuletRules_CreateTransferPreapprovalResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| transferResult | TransferResult |  |
+| amuletPaid | Decimal |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq AmuletRules_CreateTransferPreapprovalResult`
+- `instance Show AmuletRules_CreateTransferPreapprovalResult`
+- `instance GetField amuletPaid AmuletRules_CreateTransferPreapprovalResult Decimal`
+- `instance GetField meta AmuletRules_CreateTransferPreapprovalResult (Optional Metadata)`
+- `instance GetField transferPreapprovalCid AmuletRules_CreateTransferPreapprovalResult (ContractId TransferPreapproval)`
+- `instance GetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance SetField amuletPaid AmuletRules_CreateTransferPreapprovalResult Decimal`
+- `instance SetField meta AmuletRules_CreateTransferPreapprovalResult (Optional Metadata)`
+- `instance SetField transferPreapprovalCid AmuletRules_CreateTransferPreapprovalResult (ContractId TransferPreapproval)`
+- `instance SetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance HasExercise AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult`
+
+<span id="type-splice-amuletrules-amuletrulesdevnetfeatureappresult-75066"></span>
+
+### `data AmuletRules_DevNet_FeatureAppResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesdevnetfeatureappresult-18203"></span>
+
+- `AmuletRules_DevNet_FeatureAppResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+
+Instances:
+
+- `instance GetField featuredAppRightCid AmuletRules_DevNet_FeatureAppResult (ContractId FeaturedAppRight)`
+- `instance SetField featuredAppRightCid AmuletRules_DevNet_FeatureAppResult (ContractId FeaturedAppRight)`
+- `instance HasExercise AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult`
+
+<span id="type-splice-amuletrules-amuletrulesdevnettapresult-1845"></span>
+
+### `data AmuletRules_DevNet_TapResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesdevnettapresult-50542"></span>
+
+- `AmuletRules_DevNet_TapResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField meta AmuletRules_DevNet_TapResult (Optional Metadata)`
+- `instance SetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField meta AmuletRules_DevNet_TapResult (Optional Metadata)`
+- `instance HasExercise AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult`
+
+<span id="type-splice-amuletrules-amuletrulesexpiretransferinstructioninput-68344"></span>
+
+### `data AmuletRules_ExpireTransferInstructionInput`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesexpiretransferinstructioninput-66803"></span>
+
+- `AmuletRules_ExpireTransferInstructionInput`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction |  |
+| expireLock | Bool |  |
+
+Instances:
+
+- `instance Eq AmuletRules_ExpireTransferInstructionInput`
+- `instance Show AmuletRules_ExpireTransferInstructionInput`
+- `instance GetField expireLock AmuletRules_ExpireTransferInstructionInput Bool`
+- `instance GetField inputs AmuletRules_Amulet_ExpireTransferInstructions [AmuletRules_ExpireTransferInstructionInput]`
+- `instance GetField transferInstructionCid AmuletRules_ExpireTransferInstructionInput (ContractId TransferInstruction)`
+- `instance SetField expireLock AmuletRules_ExpireTransferInstructionInput Bool`
+- `instance SetField inputs AmuletRules_Amulet_ExpireTransferInstructions [AmuletRules_ExpireTransferInstructionInput]`
+- `instance SetField transferInstructionCid AmuletRules_ExpireTransferInstructionInput (ContractId TransferInstruction)`
+
+<span id="type-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-2448"></span>
+
+### `data AmuletRules_MergeMemberTrafficContractsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-32033"></span>
+
+- `AmuletRules_MergeMemberTrafficContractsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mergedTrafficCid | ContractId MemberTraffic |  |
+
+Instances:
+
+- `instance GetField mergedTrafficCid AmuletRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance SetField mergedTrafficCid AmuletRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance HasExercise AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult`
+
+<span id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-42676"></span>
+
+### `data AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-50551"></span>
+
+- `AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+<span id="type-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-41840"></span>
+
+### `data AmuletRules_MergeUnclaimedRewardsResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-46793"></span>
+
+- `AmuletRules_MergeUnclaimedRewardsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid AmuletRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedRewardCid AmuletRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance HasExercise AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult`
+
+<span id="type-splice-amuletrules-amuletrulesminingroundarchiveresult-65797"></span>
+
+### `data AmuletRules_MiningRound_ArchiveResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesminingroundarchiveresult-73420"></span>
+
+- `AmuletRules_MiningRound_ArchiveResult`
+
+Instances:
+
+- `instance HasExercise AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult`
+
+<span id="type-splice-amuletrules-amuletrulesminingroundcloseresult-67441"></span>
+
+### `data AmuletRules_MiningRound_CloseResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesminingroundcloseresult-19004"></span>
+
+- `AmuletRules_MiningRound_CloseResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+Instances:
+
+- `instance GetField closedRoundCid AmuletRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance SetField closedRoundCid AmuletRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance HasExercise AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult`
+
+<span id="type-splice-amuletrules-amuletrulesminingroundstartissuingresult-26220"></span>
+
+### `data AmuletRules_MiningRound_StartIssuingResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesminingroundstartissuingresult-95691"></span>
+
+- `AmuletRules_MiningRound_StartIssuingResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issuingRoundCid | ContractId IssuingMiningRound |  |
+| unclaimedDevelopmentFundCouponCid | Optional (ContractId UnclaimedDevelopmentFundCoupon) |  |
+
+Instances:
+
+- `instance GetField issuingRoundCid AmuletRules_MiningRound_StartIssuingResult (ContractId IssuingMiningRound)`
+- `instance GetField unclaimedDevelopmentFundCouponCid AmuletRules_MiningRound_StartIssuingResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance SetField issuingRoundCid AmuletRules_MiningRound_StartIssuingResult (ContractId IssuingMiningRound)`
+- `instance SetField unclaimedDevelopmentFundCouponCid AmuletRules_MiningRound_StartIssuingResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance HasExercise AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult`
+
+<span id="type-splice-amuletrules-amuletrulesmintresult-5311"></span>
+
+### `data AmuletRules_MintResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesmintresult-82812"></span>
+
+- `AmuletRules_MintResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AmuletRules AmuletRules_Mint AmuletRules_MintResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Mint AmuletRules_MintResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Mint AmuletRules_MintResult`
+
+<span id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-69237"></span>
+
+### `data AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-56166"></span>
+
+- `AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_RemoveFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_RemoveFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+<span id="type-splice-amuletrules-amuletrulessetconfigresult-68086"></span>
+
+### `data AmuletRules_SetConfigResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulessetconfigresult-73787"></span>
+
+- `AmuletRules_SetConfigResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_SetConfigResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_SetConfigResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult`
+
+<span id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25160"></span>
+
+### `data AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25761"></span>
+
+- `AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newExternalPartyConfigStateCid | ContractId ExternalPartyConfigState |  |
+
+Instances:
+
+- `instance Eq AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance Show AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance GetField newExternalPartyConfigStateCid AmuletRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance SetField newExternalPartyConfigStateCid AmuletRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance HasExercise AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+<span id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-96070"></span>
+
+### `data AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-12117"></span>
+
+- `AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_UpdateFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_UpdateFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+<span id="type-splice-amuletrules-apptransfercontext-68083"></span>
+
+### `data AppTransferContext`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-apptransfercontext-19128"></span>
+
+- `AppTransferContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRules | ContractId AmuletRules |  |
+| openMiningRound | ContractId OpenMiningRound |  |
+| featuredAppRight | Optional (ContractId FeaturedAppRight) |  |
+
+Instances:
+
+- `instance Eq AppTransferContext`
+- `instance Show AppTransferContext`
+- `instance GetField amuletRules AppTransferContext (ContractId AmuletRules)`
+- `instance GetField featuredAppRight AppTransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance GetField openMiningRound AppTransferContext (ContractId OpenMiningRound)`
+- `instance SetField amuletRules AppTransferContext (ContractId AmuletRules)`
+- `instance SetField featuredAppRight AppTransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance SetField openMiningRound AppTransferContext (ContractId OpenMiningRound)`
+
+<span id="type-splice-amuletrules-balancechange-24411"></span>
+
+### `data BalanceChange`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-balancechange-6762"></span>
+
+- `BalanceChange`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| changeToInitialAmountAsOfRoundZero | Decimal | The change to the total balance introduced by this balance change, normalized to round zero, i.e.,<br/><br/>a amulet created in round 3 is treated as a amulet created in round 0 with a higher initial amount. |
+| changeToHoldingFeesRate | Decimal | The change of total holding fees introduced by this balance change. |
+
+Instances:
+
+- `instance Eq BalanceChange`
+- `instance Additive BalanceChange`
+- `instance Show BalanceChange`
+- `instance GetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance GetField changeToHoldingFeesRate BalanceChange Decimal`
+- `instance GetField changeToInitialAmountAsOfRoundZero BalanceChange Decimal`
+- `instance SetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance SetField changeToHoldingFeesRate BalanceChange Decimal`
+- `instance SetField changeToInitialAmountAsOfRoundZero BalanceChange Decimal`
+
+<span id="type-splice-amuletrules-createdamulet-4205"></span>
+
+### `data CreatedAmulet`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferresultamulet-871"></span>
+
+- `TransferResultAmulet (ContractId Amulet)`
+
+<span id="constr-splice-amuletrules-transferresultlockedamulet-28147"></span>
+
+- `TransferResultLockedAmulet (ContractId LockedAmulet)`
+
+<span id="constr-splice-amuletrules-extcreatedamulet-9390"></span>
+
+- `ExtCreatedAmulet`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+
+Instances:
+
+- `instance Eq CreatedAmulet`
+- `instance Ord CreatedAmulet`
+- `instance Show CreatedAmulet`
+- `instance GetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance GetField dummyUnitField CreatedAmulet ()`
+- `instance SetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance SetField dummyUnitField CreatedAmulet ()`
+
+<span id="type-splice-amuletrules-externalpartysetupproposalacceptresult-45221"></span>
+
+### `data ExternalPartySetupProposal_AcceptResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-externalpartysetupproposalacceptresult-28452"></span>
+
+- `ExternalPartySetupProposal_AcceptResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorRightCid | ContractId ValidatorRight |  |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+
+Instances:
+
+- `instance Eq ExternalPartySetupProposal_AcceptResult`
+- `instance Show ExternalPartySetupProposal_AcceptResult`
+- `instance GetField transferPreapprovalCid ExternalPartySetupProposal_AcceptResult (ContractId TransferPreapproval)`
+- `instance GetField validatorRightCid ExternalPartySetupProposal_AcceptResult (ContractId ValidatorRight)`
+- `instance SetField transferPreapprovalCid ExternalPartySetupProposal_AcceptResult (ContractId TransferPreapproval)`
+- `instance SetField validatorRightCid ExternalPartySetupProposal_AcceptResult (ContractId ValidatorRight)`
+- `instance HasExercise ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult`
+- `instance HasFromAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult`
+- `instance HasToAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult`
+
+<span id="type-splice-amuletrules-externalpartysetupproposalrejectresult-76848"></span>
+
+### `data ExternalPartySetupProposal_RejectResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-externalpartysetupproposalrejectresult-73325"></span>
+
+- `ExternalPartySetupProposal_RejectResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyArg | () |  |
+
+Instances:
+
+- `instance Eq ExternalPartySetupProposal_RejectResult`
+- `instance Show ExternalPartySetupProposal_RejectResult`
+- `instance GetField dummyArg ExternalPartySetupProposal_RejectResult ()`
+- `instance SetField dummyArg ExternalPartySetupProposal_RejectResult ()`
+- `instance HasExercise ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult`
+- `instance HasFromAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult`
+- `instance HasToAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult`
+
+<span id="type-splice-amuletrules-externalpartysetupproposalwithdrawresult-88253"></span>
+
+### `data ExternalPartySetupProposal_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-externalpartysetupproposalwithdrawresult-17304"></span>
+
+- `ExternalPartySetupProposal_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyArg | () |  |
+
+Instances:
+
+- `instance Eq ExternalPartySetupProposal_WithdrawResult`
+- `instance Show ExternalPartySetupProposal_WithdrawResult`
+- `instance GetField dummyArg ExternalPartySetupProposal_WithdrawResult ()`
+- `instance SetField dummyArg ExternalPartySetupProposal_WithdrawResult ()`
+- `instance HasExercise ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult`
+- `instance HasFromAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult`
+- `instance HasToAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult`
+
+<span id="type-splice-amuletrules-externalpartytransfercontext-70523"></span>
+
+### `data ExternalPartyTransferContext`
+
+Contracts that need to be passed in to a Transfer so that
+we can reference them by contract id instead of by key.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-externalpartytransfercontext-43164"></span>
+
+- `ExternalPartyTransferContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigState | ContractId ExternalPartyConfigState |  |
+| featuredAppRight | Optional (ContractId FeaturedAppRight) | Optional proof that the provider is a featured app provider. |
+
+Instances:
+
+- `instance Eq ExternalPartyTransferContext`
+- `instance Show ExternalPartyTransferContext`
+- `instance GetField context TransferPreapproval_SendV2 ExternalPartyTransferContext`
+- `instance GetField externalPartyConfigState ExternalPartyTransferContext (ContractId ExternalPartyConfigState)`
+- `instance GetField featuredAppRight ExternalPartyTransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance SetField context TransferPreapproval_SendV2 ExternalPartyTransferContext`
+- `instance SetField externalPartyConfigState ExternalPartyTransferContext (ContractId ExternalPartyConfigState)`
+- `instance SetField featuredAppRight ExternalPartyTransferContext (Optional (ContractId FeaturedAppRight))`
+
+<span id="type-splice-amuletrules-invalidtransferreason-16587"></span>
+
+### `data InvalidTransferReason`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-itrinsufficientfunds-49975"></span>
+
+- `ITR_InsufficientFunds`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| missingAmount | Decimal |  |
+
+<span id="constr-splice-amuletrules-itrunknownsynchronizer-472"></span>
+
+- `ITR_UnknownSynchronizer`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| synchronizerId | Text |  |
+
+<span id="constr-splice-amuletrules-itrinsufficienttopupamount-60775"></span>
+
+- `ITR_InsufficientTopupAmount`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestedTopupAmount | Int |  |
+| minTopupAmount | Int |  |
+
+<span id="constr-splice-amuletrules-itrother-36638"></span>
+
+- `ITR_Other`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| description | Text |  |
+
+<span id="constr-splice-amuletrules-extinvalidtransferreason-71060"></span>
+
+- `ExtInvalidTransferReason`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+
+Instances:
+
+- `instance Eq InvalidTransferReason`
+- `instance Show InvalidTransferReason`
+- `instance GetField description InvalidTransferReason Text`
+- `instance GetField dummyUnitField InvalidTransferReason ()`
+- `instance GetField minTopupAmount InvalidTransferReason Int`
+- `instance GetField missingAmount InvalidTransferReason Decimal`
+- `instance GetField reason TransferCommandResult InvalidTransferReason`
+- `instance GetField requestedTopupAmount InvalidTransferReason Int`
+- `instance GetField synchronizerId InvalidTransferReason Text`
+- `instance SetField description InvalidTransferReason Text`
+- `instance SetField dummyUnitField InvalidTransferReason ()`
+- `instance SetField minTopupAmount InvalidTransferReason Int`
+- `instance SetField missingAmount InvalidTransferReason Decimal`
+- `instance SetField reason TransferCommandResult InvalidTransferReason`
+- `instance SetField requestedTopupAmount InvalidTransferReason Int`
+- `instance SetField synchronizerId InvalidTransferReason Text`
+
+<span id="type-splice-amuletrules-openminingroundtriple-84091"></span>
+
+### `data OpenMiningRoundTriple`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-openminingroundtriple-73258"></span>
+
+- `OpenMiningRoundTriple`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| round0Cid | ContractId OpenMiningRound |  |
+| round1Cid | ContractId OpenMiningRound |  |
+| round2Cid | ContractId OpenMiningRound |  |
+
+Instances:
+
+- `instance Eq OpenMiningRoundTriple`
+- `instance Show OpenMiningRoundTriple`
+- `instance GetField openMiningRoundTriple AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple`
+- `instance GetField openMiningRoundTriple AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple`
+- `instance GetField round0Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance GetField round1Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance GetField round2Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance SetField openMiningRoundTriple AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple`
+- `instance SetField openMiningRoundTriple AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple`
+- `instance SetField round0Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance SetField round1Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance SetField round2Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+
+<span id="type-splice-amuletrules-paymenttransfercontext-72190"></span>
+
+### `data PaymentTransferContext`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-paymenttransfercontext-9413"></span>
+
+- `PaymentTransferContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRules | ContractId AmuletRules |  |
+| context | TransferContext |  |
+
+Instances:
+
+- `instance Eq PaymentTransferContext`
+- `instance Show PaymentTransferContext`
+- `instance GetField amuletRules PaymentTransferContext (ContractId AmuletRules)`
+- `instance GetField context AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext`
+- `instance GetField context AmuletRules_CreateTransferPreapproval PaymentTransferContext`
+- `instance GetField context PaymentTransferContext TransferContext`
+- `instance GetField context TransferPreapproval_Renew PaymentTransferContext`
+- `instance GetField context TransferPreapproval_Send PaymentTransferContext`
+- `instance GetField context TransferCommand_Send PaymentTransferContext`
+- `instance SetField amuletRules PaymentTransferContext (ContractId AmuletRules)`
+- `instance SetField context AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext`
+- `instance SetField context AmuletRules_CreateTransferPreapproval PaymentTransferContext`
+- `instance SetField context PaymentTransferContext TransferContext`
+- `instance SetField context TransferPreapproval_Renew PaymentTransferContext`
+- `instance SetField context TransferPreapproval_Send PaymentTransferContext`
+- `instance SetField context TransferCommand_Send PaymentTransferContext`
+
+<span id="type-splice-amuletrules-preprocessedtransferoutput-12209"></span>
+
+### `data PreprocessedTransferOutput`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-preprocessedtransferoutput-93914"></span>
+
+- `PreprocessedTransferOutput`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party | Owner of the output |
+| outputFee | Decimal | Fee charged to create this output |
+| amount | Decimal | Amount of amulet held by this output (after deducting fees) |
+| lock | Optional TimeLock | Whether to lock the amulet or not |
+
+Instances:
+
+- `instance Eq PreprocessedTransferOutput`
+- `instance Show PreprocessedTransferOutput`
+- `instance GetField amount PreprocessedTransferOutput Decimal`
+- `instance GetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance GetField outputFee PreprocessedTransferOutput Decimal`
+- `instance GetField owner PreprocessedTransferOutput Party`
+- `instance SetField amount PreprocessedTransferOutput Decimal`
+- `instance SetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance SetField outputFee PreprocessedTransferOutput Decimal`
+- `instance SetField owner PreprocessedTransferOutput Party`
+
+<span id="type-splice-amuletrules-rewardsissuanceconfig-37252"></span>
+
+### `data RewardsIssuanceConfig`
+
+An easy way to configure `exucuteTransfer` wrt what rewards to issue.
+We currently only use two configurations: but all of the options in here make sense, so we keep them.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-rewardsissuanceconfig-46673"></span>
+
+- `RewardsIssuanceConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issueAppRewards | Bool |  |
+| issueValidatorRewards | Bool |  |
+
+Instances:
+
+- `instance GetField issueAppRewards RewardsIssuanceConfig Bool`
+- `instance GetField issueValidatorRewards RewardsIssuanceConfig Bool`
+- `instance SetField issueAppRewards RewardsIssuanceConfig Bool`
+- `instance SetField issueValidatorRewards RewardsIssuanceConfig Bool`
+
+<span id="type-splice-amuletrules-transfer-72721"></span>
+
+### `data Transfer`
+
+Representation of a batch transfer.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transfer-1214"></span>
+
+- `Transfer`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| provider | Party |  |
+| inputs | [TransferInput] |  |
+| outputs | [TransferOutput] |  |
+| beneficiaries | Optional [AppRewardBeneficiary] | Beneficiaries between which the app reward is split. |
+
+Instances:
+
+- `instance Eq Transfer`
+- `instance Ord Transfer`
+- `instance Show Transfer`
+- `instance GetField beneficiaries Transfer (Optional [AppRewardBeneficiary])`
+- `instance GetField inputs Transfer [TransferInput]`
+- `instance GetField outputs Transfer [TransferOutput]`
+- `instance GetField provider Transfer Party`
+- `instance GetField sender Transfer Party`
+- `instance GetField transfer AmuletRules_Transfer Transfer`
+- `instance SetField beneficiaries Transfer (Optional [AppRewardBeneficiary])`
+- `instance SetField inputs Transfer [TransferInput]`
+- `instance SetField outputs Transfer [TransferOutput]`
+- `instance SetField provider Transfer Party`
+- `instance SetField sender Transfer Party`
+- `instance SetField transfer AmuletRules_Transfer Transfer`
+
+<span id="type-splice-amuletrules-transfercontext-68991"></span>
+
+### `data TransferContext`
+
+Contracts that need to be passed in to a Transfer so that
+we can reference them by contract id instead of by key.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transfercontext-56806"></span>
+
+- `TransferContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openMiningRound | ContractId OpenMiningRound |  |
+| issuingMiningRounds | Map Round (ContractId IssuingMiningRound) |  |
+| validatorRights | Map Party (ContractId ValidatorRight) | Map from user to ValidatorRight contract. |
+| featuredAppRight | Optional (ContractId FeaturedAppRight) | Optional proof that the provider is a featured app provider. |
+
+Instances:
+
+- `instance Eq TransferContext`
+- `instance Show TransferContext`
+- `instance GetField context AmuletRules_BuyMemberTraffic TransferContext`
+- `instance GetField context AmuletRules_ComputeFees TransferContext`
+- `instance GetField context AmuletRules_Transfer TransferContext`
+- `instance GetField context PaymentTransferContext TransferContext`
+- `instance GetField featuredAppRight TransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance GetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance GetField openMiningRound TransferContext (ContractId OpenMiningRound)`
+- `instance GetField validatorRights TransferContext (Map Party (ContractId ValidatorRight))`
+- `instance SetField context AmuletRules_BuyMemberTraffic TransferContext`
+- `instance SetField context AmuletRules_ComputeFees TransferContext`
+- `instance SetField context AmuletRules_Transfer TransferContext`
+- `instance SetField context PaymentTransferContext TransferContext`
+- `instance SetField featuredAppRight TransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance SetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance SetField openMiningRound TransferContext (ContractId OpenMiningRound)`
+- `instance SetField validatorRights TransferContext (Map Party (ContractId ValidatorRight))`
+
+<span id="type-splice-amuletrules-transfercontextsummary-99392"></span>
+
+### `data TransferContextSummary`
+
+Deprecated: unused, we just can't remove it yet due to upgrading rules
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transfercontextsummary-98359"></span>
+
+- `TransferContextSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppProvider | Optional Party |  |
+| config | TransferConfig Amulet |  |
+| openRound | OpenMiningRound |  |
+| issuingMiningRounds | Map Round IssuingMiningRound |  |
+| validatorRights | Map Party (ContractId ValidatorRight) |  |
+
+Instances:
+
+- `instance Eq TransferContextSummary`
+- `instance Show TransferContextSummary`
+- `instance GetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance GetField featuredAppProvider TransferContextSummary (Optional Party)`
+- `instance GetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance GetField openRound TransferContextSummary OpenMiningRound`
+- `instance GetField validatorRights TransferContextSummary (Map Party (ContractId ValidatorRight))`
+- `instance SetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance SetField featuredAppProvider TransferContextSummary (Optional Party)`
+- `instance SetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance SetField openRound TransferContextSummary OpenMiningRound`
+- `instance SetField validatorRights TransferContextSummary (Map Party (ContractId ValidatorRight))`
+
+<span id="type-splice-amuletrules-transfercontextsummaryv2-75114"></span>
+
+### `data TransferContextSummaryV2`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transfercontextsummaryv2-63237"></span>
+
+- `TransferContextSummaryV2`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| featuredAppProvider | Optional Party |  |
+| config | TransferConfigV2 Amulet |  |
+| openRoundNumber | Round |  |
+| amuletPrice | Decimal |  |
+| issuingMiningRounds | Map Round IssuingMiningRound |  |
+| validatorRights | Map Party (ContractId ValidatorRight) |  |
+
+Instances:
+
+- `instance Eq TransferContextSummaryV2`
+- `instance Show TransferContextSummaryV2`
+- `instance GetField amuletPrice TransferContextSummaryV2 Decimal`
+- `instance GetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance GetField dso TransferContextSummaryV2 Party`
+- `instance GetField featuredAppProvider TransferContextSummaryV2 (Optional Party)`
+- `instance GetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance GetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance GetField validatorRights TransferContextSummaryV2 (Map Party (ContractId ValidatorRight))`
+- `instance SetField amuletPrice TransferContextSummaryV2 Decimal`
+- `instance SetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance SetField dso TransferContextSummaryV2 Party`
+- `instance SetField featuredAppProvider TransferContextSummaryV2 (Optional Party)`
+- `instance SetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance SetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance SetField validatorRights TransferContextSummaryV2 (Map Party (ContractId ValidatorRight))`
+
+<span id="type-splice-amuletrules-transferinput-61796"></span>
+
+### `data TransferInput`
+
+An individual input for a batch transfer.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-inputapprewardcoupon-60885"></span>
+
+- `InputAppRewardCoupon (ContractId AppRewardCoupon)`
+
+<span id="constr-splice-amuletrules-inputvalidatorrewardcoupon-18692"></span>
+
+- `InputValidatorRewardCoupon (ContractId ValidatorRewardCoupon)`
+
+<span id="constr-splice-amuletrules-inputsvrewardcoupon-94444"></span>
+
+- `InputSvRewardCoupon (ContractId SvRewardCoupon)`
+
+<span id="constr-splice-amuletrules-inputamulet-35826"></span>
+
+- `InputAmulet (ContractId Amulet)`
+
+<span id="constr-splice-amuletrules-exttransferinput-5819"></span>
+
+- `ExtTransferInput`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+| optInputValidatorFaucetCoupon | Optional (ContractId ValidatorFaucetCoupon) | Added in CIP-3. Optional validator faucet coupon input into this transfer. |
+
+<span id="constr-splice-amuletrules-inputvalidatorlivenessactivityrecord-59154"></span>
+
+- `InputValidatorLivenessActivityRecord (ContractId ValidatorLivenessActivityRecord)`
+
+<span id="constr-splice-amuletrules-inputunclaimedactivityrecord-17727"></span>
+
+- `InputUnclaimedActivityRecord (ContractId UnclaimedActivityRecord)`
+
+<span id="constr-splice-amuletrules-inputdevelopmentfundcoupon-48881"></span>
+
+- `InputDevelopmentFundCoupon (ContractId DevelopmentFundCoupon)`
+
+Instances:
+
+- `instance Eq TransferInput`
+- `instance Ord TransferInput`
+- `instance Show TransferInput`
+- `instance GetField dummyUnitField TransferInput ()`
+- `instance GetField inputs AmuletRules_BuyMemberTraffic [TransferInput]`
+- `instance GetField inputs AmuletRules_CreateExternalPartySetupProposal [TransferInput]`
+- `instance GetField inputs AmuletRules_CreateTransferPreapproval [TransferInput]`
+- `instance GetField inputs Transfer [TransferInput]`
+- `instance GetField inputs TransferPreapproval_Renew [TransferInput]`
+- `instance GetField inputs TransferPreapproval_Send [TransferInput]`
+- `instance GetField inputs TransferPreapproval_SendV2 [TransferInput]`
+- `instance GetField inputs TransferCommand_Send [TransferInput]`
+- `instance GetField optInputValidatorFaucetCoupon TransferInput (Optional (ContractId ValidatorFaucetCoupon))`
+- `instance SetField dummyUnitField TransferInput ()`
+- `instance SetField inputs AmuletRules_BuyMemberTraffic [TransferInput]`
+- `instance SetField inputs AmuletRules_CreateExternalPartySetupProposal [TransferInput]`
+- `instance SetField inputs AmuletRules_CreateTransferPreapproval [TransferInput]`
+- `instance SetField inputs Transfer [TransferInput]`
+- `instance SetField inputs TransferPreapproval_Renew [TransferInput]`
+- `instance SetField inputs TransferPreapproval_Send [TransferInput]`
+- `instance SetField inputs TransferPreapproval_SendV2 [TransferInput]`
+- `instance SetField inputs TransferCommand_Send [TransferInput]`
+- `instance SetField optInputValidatorFaucetCoupon TransferInput (Optional (ContractId ValidatorFaucetCoupon))`
+
+<span id="type-splice-amuletrules-transferinputssummary-46693"></span>
+
+### `data TransferInputsSummary`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferinputssummary-65268"></span>
+
+- `TransferInputsSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| totalAmuletAmount | Decimal |  |
+| totalAppRewardAmount | Decimal |  |
+| totalValidatorRewardAmount | Decimal |  |
+| totalValidatorFaucetAmount | Decimal | Note that the validator faucet amount does not need to be optional in this type, as it is not stored on the ledger. |
+| totalSvRewardAmount | Decimal |  |
+| totalHoldingFees | Decimal |  |
+| amountArchivedAsOfRoundZero | Decimal |  |
+| changeToHoldingFeesRate | Decimal |  |
+| totalUnclaimedActivityRecordAmount | Optional Decimal | Note: Made optional as the addition of this field is checked by the upgrade checker<br/><br/>on package upload because `TransferInputsSummary` is serializable. |
+| totalDevelopmentFundAmount | Optional Decimal | Note: Same rationale as above — made optional to ensure compatibility with<br/><br/>the upgrade checker on package upload because `TransferInputsSummary` is serializable. |
+
+Instances:
+
+- `instance Eq TransferInputsSummary`
+- `instance Show TransferInputsSummary`
+- `instance GetField amountArchivedAsOfRoundZero TransferInputsSummary Decimal`
+- `instance GetField changeToHoldingFeesRate TransferInputsSummary Decimal`
+- `instance GetField totalAmuletAmount TransferInputsSummary Decimal`
+- `instance GetField totalAppRewardAmount TransferInputsSummary Decimal`
+- `instance GetField totalDevelopmentFundAmount TransferInputsSummary (Optional Decimal)`
+- `instance GetField totalHoldingFees TransferInputsSummary Decimal`
+- `instance GetField totalSvRewardAmount TransferInputsSummary Decimal`
+- `instance GetField totalUnclaimedActivityRecordAmount TransferInputsSummary (Optional Decimal)`
+- `instance GetField totalValidatorFaucetAmount TransferInputsSummary Decimal`
+- `instance GetField totalValidatorRewardAmount TransferInputsSummary Decimal`
+- `instance SetField amountArchivedAsOfRoundZero TransferInputsSummary Decimal`
+- `instance SetField changeToHoldingFeesRate TransferInputsSummary Decimal`
+- `instance SetField totalAmuletAmount TransferInputsSummary Decimal`
+- `instance SetField totalAppRewardAmount TransferInputsSummary Decimal`
+- `instance SetField totalDevelopmentFundAmount TransferInputsSummary (Optional Decimal)`
+- `instance SetField totalHoldingFees TransferInputsSummary Decimal`
+- `instance SetField totalSvRewardAmount TransferInputsSummary Decimal`
+- `instance SetField totalUnclaimedActivityRecordAmount TransferInputsSummary (Optional Decimal)`
+- `instance SetField totalValidatorFaucetAmount TransferInputsSummary Decimal`
+- `instance SetField totalValidatorRewardAmount TransferInputsSummary Decimal`
+
+<span id="type-splice-amuletrules-transferoutput-70512"></span>
+
+### `data TransferOutput`
+
+An individual output for a batch transfer.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferoutput-68311"></span>
+
+- `TransferOutput`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party | The receiver who will own the created output amulet. |
+| receiverFeeRatio | Decimal | The ratio of the output fee paid from receiver's output amount.<br/><br/>1.0 means the whole fee is deducted from the specified output amount,<br/><br/>0.0 the whole fee is deducted from the sender's input balance.<br/><br/>If a receiver's fee is not covered by the specified output amount, the transfer is aborted. |
+| amount | Decimal | The amount of amulet to receive, before deducting the receiver's part of the output fee. |
+| lock | Optional TimeLock | The lock to be added, if any. |
+
+Instances:
+
+- `instance Eq TransferOutput`
+- `instance Ord TransferOutput`
+- `instance Show TransferOutput`
+- `instance GetField amount TransferOutput Decimal`
+- `instance GetField lock TransferOutput (Optional TimeLock)`
+- `instance GetField outputs AmuletRules_ComputeFees [TransferOutput]`
+- `instance GetField outputs Transfer [TransferOutput]`
+- `instance GetField receiver TransferOutput Party`
+- `instance GetField receiverFeeRatio TransferOutput Decimal`
+- `instance SetField amount TransferOutput Decimal`
+- `instance SetField lock TransferOutput (Optional TimeLock)`
+- `instance SetField outputs AmuletRules_ComputeFees [TransferOutput]`
+- `instance SetField outputs Transfer [TransferOutput]`
+- `instance SetField receiver TransferOutput Party`
+- `instance SetField receiverFeeRatio TransferOutput Decimal`
+
+<span id="type-splice-amuletrules-transferoutputssummary-22405"></span>
+
+### `type TransferOutputsSummary = [PreprocessedTransferOutput]`
+
+<span id="type-splice-amuletrules-transferpreapprovalcancelresult-51361"></span>
+
+### `data TransferPreapproval_CancelResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferpreapprovalcancelresult-83086"></span>
+
+- `TransferPreapproval_CancelResult`
+
+Instances:
+
+- `instance Eq TransferPreapproval_CancelResult`
+- `instance Show TransferPreapproval_CancelResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult`
+
+<span id="type-splice-amuletrules-transferpreapprovalexpireresult-89274"></span>
+
+### `data TransferPreapproval_ExpireResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferpreapprovalexpireresult-36569"></span>
+
+- `TransferPreapproval_ExpireResult`
+
+(no fields)
+
+Instances:
+
+- `instance Eq TransferPreapproval_ExpireResult`
+- `instance Show TransferPreapproval_ExpireResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult`
+
+<span id="type-splice-amuletrules-transferpreapprovalrenewresult-23849"></span>
+
+### `data TransferPreapproval_RenewResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferpreapprovalrenewresult-61232"></span>
+
+- `TransferPreapproval_RenewResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| transferResult | TransferResult |  |
+| receiver | Party |  |
+| provider | Party |  |
+| amuletPaid | Decimal |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq TransferPreapproval_RenewResult`
+- `instance Show TransferPreapproval_RenewResult`
+- `instance GetField amuletPaid TransferPreapproval_RenewResult Decimal`
+- `instance GetField meta TransferPreapproval_RenewResult (Optional Metadata)`
+- `instance GetField provider TransferPreapproval_RenewResult Party`
+- `instance GetField receiver TransferPreapproval_RenewResult Party`
+- `instance GetField transferPreapprovalCid TransferPreapproval_RenewResult (ContractId TransferPreapproval)`
+- `instance GetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance SetField amuletPaid TransferPreapproval_RenewResult Decimal`
+- `instance SetField meta TransferPreapproval_RenewResult (Optional Metadata)`
+- `instance SetField provider TransferPreapproval_RenewResult Party`
+- `instance SetField receiver TransferPreapproval_RenewResult Party`
+- `instance SetField transferPreapprovalCid TransferPreapproval_RenewResult (ContractId TransferPreapproval)`
+- `instance SetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult`
+
+<span id="type-splice-amuletrules-transferpreapprovalsendresult-68419"></span>
+
+### `data TransferPreapproval_SendResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferpreapprovalsendresult-67472"></span>
+
+- `TransferPreapproval_SendResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferResult |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq TransferPreapproval_SendResult`
+- `instance Show TransferPreapproval_SendResult`
+- `instance GetField meta TransferPreapproval_SendResult (Optional Metadata)`
+- `instance GetField result TransferPreapproval_SendResult TransferResult`
+- `instance SetField meta TransferPreapproval_SendResult (Optional Metadata)`
+- `instance SetField result TransferPreapproval_SendResult TransferResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult`
+
+<span id="type-splice-amuletrules-transferpreapprovalsendv2result-94909"></span>
+
+### `data TransferPreapproval_SendV2Result`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferpreapprovalsendv2result-33038"></span>
+
+- `TransferPreapproval_SendV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferResult |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance Eq TransferPreapproval_SendV2Result`
+- `instance Show TransferPreapproval_SendV2Result`
+- `instance GetField meta TransferPreapproval_SendV2Result Metadata`
+- `instance GetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance SetField meta TransferPreapproval_SendV2Result Metadata`
+- `instance SetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result`
+
+<span id="type-splice-amuletrules-transferresult-93164"></span>
+
+### `data TransferResult`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transferresult-68399"></span>
+
+- `TransferResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| round | Round | Round for which this transfer was registered. |
+| summary | TransferSummary | Summary of amount input and outputs, and fees paid. |
+| createdAmulets | [CreatedAmulet] | References to the created output amulets. |
+| senderChangeAmulet | Optional (ContractId Amulet) | Optional reference to the amulet for the change returned to the sender.<br/><br/>Only created if there was some change to be returned after deducting the fee for returning change. |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq TransferResult`
+- `instance Show TransferResult`
+- `instance GetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance GetField meta TransferResult (Optional Metadata)`
+- `instance GetField result TransferPreapproval_SendResult TransferResult`
+- `instance GetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance GetField result TransferCommandResult TransferResult`
+- `instance GetField round TransferResult Round`
+- `instance GetField senderChangeAmulet TransferResult (Optional (ContractId Amulet))`
+- `instance GetField summary TransferResult TransferSummary`
+- `instance GetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance GetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance GetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance SetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance SetField meta TransferResult (Optional Metadata)`
+- `instance SetField result TransferPreapproval_SendResult TransferResult`
+- `instance SetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance SetField result TransferCommandResult TransferResult`
+- `instance SetField round TransferResult Round`
+- `instance SetField senderChangeAmulet TransferResult (Optional (ContractId Amulet))`
+- `instance SetField summary TransferResult TransferSummary`
+- `instance SetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance SetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance SetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance HasExercise AmuletRules AmuletRules_Transfer TransferResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Transfer TransferResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Transfer TransferResult`
+
+<span id="type-splice-amuletrules-transfersummary-17366"></span>
+
+### `data TransferSummary`
+
+Summary of input and output amounts and fees paid.
+This summary is intended to be used together with the `Transfer` specification
+used to initiate the transfer when displaying a transaction summary. Its fields are intended to
+provide shortcuts for key numbers that are complex to compute off-ledger.
+
+All amounts are denominated in Splice.
+
+Constructors:
+
+<span id="constr-splice-amuletrules-transfersummary-72851"></span>
+
+- `TransferSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputAppRewardAmount | Decimal | Total amount of app reward coupon issunace input into this transfer. |
+| inputValidatorRewardAmount | Decimal | Total amount of validator rewards coupon issuance input into this transfer. |
+| inputSvRewardAmount | Decimal | Total amount of SV reward coupon issuance input into this transfer. |
+| inputAmuletAmount | Decimal | Total input amount of amulet input into this transfer, before deducting holding fees. |
+| balanceChanges | Map Party BalanceChange | Balance changes per party |
+| holdingFees | Decimal | Holding fees paid by the sender on their input amulets. |
+| outputFees | [Decimal] | Fees paid for the individual output amulets in the order they were specified. |
+| senderChangeFee | Decimal | Fee charged for returning change to the sender, which is the smaller of the<br/><br/>left-over balance after paying for all outputs or one amulet create fee.<br/><br/>In case the left-over balance after paying for all outputs is smaller than a create fee,<br/><br/>all of that balance is consumed by the fee for returning change, and no actual amulet is<br/><br/>created for the sender, i.e., the `senderChangeAmount` is zero. The transfer does though succeed.<br/><br/>For transfers that do not allow returning change to the sender, the left-over balance<br/><br/>after paying for all outputs must be zero, and thus the `senderChangeFee` must be zero as well. |
+| senderChangeAmount | Decimal | The final amount of amulet returned to the sender after paying for all outputs and fees.<br/><br/>If it is zero, then no amulet is created for the sender. |
+| amuletPrice | Decimal | The amulet price at the round this transfer was executed. |
+| inputValidatorFaucetAmount | Optional Decimal | Added in CIP-3. Total amount of validator faucet coupon issuance input into this transfer. |
+| inputUnclaimedActivityRecordAmount | Optional Decimal | Total amount of unclaimed activity record issuance input into this transfer.<br/><br/>Note: Made optional as the addition of this field is checked by the upgrade checker. |
+| inputDevelopmentFundAmount | Optional Decimal | Total amount of development fund coupon issuance input into this transfer.<br/><br/>Note: Made optional as the addition of this field is checked by the upgrade checker. |
+
+Instances:
+
+- `instance Eq TransferSummary`
+- `instance Show TransferSummary`
+- `instance GetField amuletPrice TransferSummary Decimal`
+- `instance GetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance GetField holdingFees TransferSummary Decimal`
+- `instance GetField inputAmuletAmount TransferSummary Decimal`
+- `instance GetField inputAppRewardAmount TransferSummary Decimal`
+- `instance GetField inputDevelopmentFundAmount TransferSummary (Optional Decimal)`
+- `instance GetField inputSvRewardAmount TransferSummary Decimal`
+- `instance GetField inputUnclaimedActivityRecordAmount TransferSummary (Optional Decimal)`
+- `instance GetField inputValidatorFaucetAmount TransferSummary (Optional Decimal)`
+- `instance GetField inputValidatorRewardAmount TransferSummary Decimal`
+- `instance GetField outputFees TransferSummary [Decimal]`
+- `instance GetField senderChangeAmount TransferSummary Decimal`
+- `instance GetField senderChangeFee TransferSummary Decimal`
+- `instance GetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance GetField summary TransferResult TransferSummary`
+- `instance SetField amuletPrice TransferSummary Decimal`
+- `instance SetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance SetField holdingFees TransferSummary Decimal`
+- `instance SetField inputAmuletAmount TransferSummary Decimal`
+- `instance SetField inputAppRewardAmount TransferSummary Decimal`
+- `instance SetField inputDevelopmentFundAmount TransferSummary (Optional Decimal)`
+- `instance SetField inputSvRewardAmount TransferSummary Decimal`
+- `instance SetField inputUnclaimedActivityRecordAmount TransferSummary (Optional Decimal)`
+- `instance SetField inputValidatorFaucetAmount TransferSummary (Optional Decimal)`
+- `instance SetField inputValidatorRewardAmount TransferSummary Decimal`
+- `instance SetField outputFees TransferSummary [Decimal]`
+- `instance SetField senderChangeAmount TransferSummary Decimal`
+- `instance SetField senderChangeFee TransferSummary Decimal`
+- `instance SetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance SetField summary TransferResult TransferSummary`
+
+<span id="type-splice-amuletrules-validatedopenminingrounds-3458"></span>
+
+### `data ValidatedOpenMiningRounds`
+
+Constructors:
+
+<span id="constr-splice-amuletrules-validatedopenminingrounds-35727"></span>
+
+- `ValidatedOpenMiningRounds`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| oldestRound | OpenMiningRound |  |
+| latestUsableRound | OpenMiningRound |  |
+
+Instances:
+
+- `instance Eq ValidatedOpenMiningRounds`
+- `instance Show ValidatedOpenMiningRounds`
+- `instance GetField latestUsableRound ValidatedOpenMiningRounds OpenMiningRound`
+- `instance GetField oldestRound ValidatedOpenMiningRounds OpenMiningRound`
+- `instance SetField latestUsableRound ValidatedOpenMiningRounds OpenMiningRound`
+- `instance SetField oldestRound ValidatedOpenMiningRounds OpenMiningRound`
 
 ## Functions
 
-<div id="function-splice-amuletrules-validateopenminingroundtriple-43417">
+<span id="function-splice-amuletrules-validateopenminingroundtriple-43417"></span>
 
-validateOpenMiningRoundTriple
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> OpenMiningRoundTriple -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ValidatedOpenMiningRounds
+### `validateOpenMiningRoundTriple`
 
-</div>
+```daml
+validateOpenMiningRoundTriple : Party -> OpenMiningRoundTriple -> Update ValidatedOpenMiningRounds
+```
 
-<div id="function-splice-amuletrules-transfercontrollers-28233">
+<span id="function-splice-amuletrules-transfercontrollers-28233"></span>
 
-transferControllers
-: Transfer -\> Set [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+### `transferControllers`
+
+```daml
+transferControllers : Transfer -> Set Party
+```
 
 The controllers for a transfer.
 
-</div>
+<span id="function-splice-amuletrules-mkunknownsynchronizerfailure-15784"></span>
 
-<div id="function-splice-amuletrules-mkunknownsynchronizerfailure-15784">
+### `mkUnknownSynchronizerFailure`
 
-mkUnknownSynchronizerFailure
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatus
+```daml
+mkUnknownSynchronizerFailure : Text -> FailureStatus
+```
 
-</div>
+<span id="function-splice-amuletrules-mkinsufficienttopupamountfailure-2645"></span>
 
-<div id="function-splice-amuletrules-mkinsufficienttopupamountfailure-2645">
+### `mkInsufficientTopupAmountFailure`
 
-mkInsufficientTopupAmountFailure
-: [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> FailureStatus
+```daml
+mkInsufficientTopupAmountFailure : Int -> Int -> FailureStatus
+```
 
-</div>
+<span id="function-splice-amuletrules-mkmaximuminputsexceededfailure-60046"></span>
 
-<div id="function-splice-amuletrules-mkmaximuminputsexceededfailure-60046">
+### `mkMaximumInputsExceededFailure`
 
-mkMaximumInputsExceededFailure
-: FailureStatus
+```daml
+mkMaximumInputsExceededFailure : FailureStatus
+```
 
-</div>
+<span id="function-splice-amuletrules-mkmaximumoutputsexceededfailure-21438"></span>
 
-<div id="function-splice-amuletrules-mkmaximumoutputsexceededfailure-21438">
+### `mkMaximumOutputsExceededFailure`
 
-mkMaximumOutputsExceededFailure
-: FailureStatus
+```daml
+mkMaximumOutputsExceededFailure : FailureStatus
+```
 
-</div>
+<span id="function-splice-amuletrules-mkinsufficientfundsfailure-76389"></span>
 
-<div id="function-splice-amuletrules-mkinsufficientfundsfailure-76389">
+### `mkInsufficientFundsFailure`
 
-mkInsufficientFundsFailure
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> FailureStatus
+```daml
+mkInsufficientFundsFailure : Decimal -> FailureStatus
+```
 
-</div>
+<span id="function-splice-amuletrules-spliceerrorid-85022"></span>
 
-<div id="function-splice-amuletrules-spliceerrorid-85022">
+### `spliceErrorId`
 
-spliceErrorId
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+```daml
+spliceErrorId : Text -> Text
+```
 
-</div>
+<span id="function-splice-amuletrules-mkfailurestatus-89025"></span>
 
-<div id="function-splice-amuletrules-mkfailurestatus-89025">
+### `mkFailureStatus`
 
-mkFailureStatus
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureCategory -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatus
+```daml
+mkFailureStatus : Text -> FailureCategory -> Text -> TextMap Text -> FailureStatus
+```
 
-</div>
+<span id="function-splice-amuletrules-checktransferconstraints-43087"></span>
 
-<div id="function-splice-amuletrules-checktransferconstraints-43087">
+### `checkTransferConstraints`
 
-checkTransferConstraints
-: Transfer -\> TransferSummary -\> TransferConfigV2 unit -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) FailureStatus ()
+```daml
+checkTransferConstraints : Transfer -> TransferSummary -> TransferConfigV2 unit -> Either FailureStatus ()
+```
 
-</div>
+<span id="function-splice-amuletrules-executetransfer-52573"></span>
 
-<div id="function-splice-amuletrules-executetransfer-52573">
+### `executeTransfer`
 
-executeTransfer
-: RewardsIssuanceConfig -\> TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+```daml
+executeTransfer : RewardsIssuanceConfig -> TransferContext -> Party -> Transfer -> Update TransferResult
+```
 
 Execute a transfer.
 
-</div>
+<span id="function-splice-amuletrules-executeexternalpartytransfer-86681"></span>
 
-<div id="function-splice-amuletrules-executeexternalpartytransfer-86681">
+### `executeExternalPartyTransfer`
 
-executeExternalPartyTransfer
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> ExternalPartyTransferContext -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+```daml
+executeExternalPartyTransfer : Party -> ExternalPartyTransferContext -> Transfer -> Update TransferResult
+```
 
 Execute a transfer for external parties so that the prepared tx remains valid for 24h
 
-</div>
+<span id="function-splice-amuletrules-executetransfertick-55439"></span>
 
-<div id="function-splice-amuletrules-executetransfertick-55439">
+### `executeTransfer'`
 
-executeTransfer'
-: RewardsIssuanceConfig -\> TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+```daml
+executeTransfer' : RewardsIssuanceConfig -> TransferContextSummaryV2 -> Party -> Transfer -> Update TransferResult
+```
 
-</div>
+<span id="function-splice-amuletrules-summarizeandvalidatecontext-19960"></span>
 
-<div id="function-splice-amuletrules-summarizeandvalidatecontext-19960">
+### `summarizeAndValidateContext`
 
-summarizeAndValidateContext
-: TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferContextSummaryV2
+```daml
+summarizeAndValidateContext : TransferContext -> Party -> Transfer -> Update TransferContextSummaryV2
+```
 
-</div>
+<span id="function-splice-amuletrules-summarizeandvalidateexternalpartycontext-23832"></span>
 
-<div id="function-splice-amuletrules-summarizeandvalidateexternalpartycontext-23832">
+### `summarizeAndValidateExternalPartyContext`
 
-summarizeAndValidateExternalPartyContext
-: ExternalPartyTransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferContextSummaryV2
+```daml
+summarizeAndValidateExternalPartyContext : ExternalPartyTransferContext -> Party -> Transfer -> Update TransferContextSummaryV2
+```
 
-</div>
+<span id="function-splice-amuletrules-getvalidatorright-23495"></span>
 
-<div id="function-splice-amuletrules-getvalidatorright-23495">
+### `getValidatorRight`
 
-getValidatorRight
-: TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight)
+```daml
+getValidatorRight : TransferContextSummaryV2 -> Party -> Update (ContractId ValidatorRight)
+```
 
-</div>
+<span id="function-splice-amuletrules-getissuingmininground-54647"></span>
 
-<div id="function-splice-amuletrules-getissuingmininground-54647">
+### `getIssuingMiningRound`
 
-getIssuingMiningRound
-: TransferContextSummaryV2 -\> Round -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) IssuingMiningRound
+```daml
+getIssuingMiningRound : TransferContextSummaryV2 -> Round -> Update IssuingMiningRound
+```
 
-</div>
+<span id="function-splice-amuletrules-summarizeandconsumeinputs-14652"></span>
 
-<div id="function-splice-amuletrules-summarizeandconsumeinputs-14652">
+### `summarizeAndConsumeInputs`
 
-summarizeAndConsumeInputs
-: TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[TransferInput\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInputsSummary
+```daml
+summarizeAndConsumeInputs : TransferContextSummaryV2 -> Party -> Party -> [TransferInput] -> Update TransferInputsSummary
+```
 
-</div>
+<span id="function-splice-amuletrules-dedupoutputlockholders-88329"></span>
 
-<div id="function-splice-amuletrules-dedupoutputlockholders-88329">
+### `dedupOutputLockHolders`
 
-dedupOutputLockHolders
-: TransferOutput -\> TransferOutput
+```daml
+dedupOutputLockHolders : TransferOutput -> TransferOutput
+```
 
 Deduplicate lock-holders to store them and charge for them at most once
 
-</div>
+<span id="function-splice-amuletrules-preprocessoutputs-54475"></span>
 
-<div id="function-splice-amuletrules-preprocessoutputs-54475">
+### `preprocessOutputs`
 
-preprocessOutputs
-: TransferConfigV2 Amulet -\> \[TransferOutput\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferOutputsSummary
+```daml
+preprocessOutputs : TransferConfigV2 Amulet -> [TransferOutput] -> Update TransferOutputsSummary
+```
 
-</div>
+<span id="function-splice-amuletrules-summarizetransfer-82621"></span>
 
-<div id="function-splice-amuletrules-summarizetransfer-82621">
+### `summarizeTransfer`
 
-summarizeTransfer
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Round -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferConfigV2 Amulet -\> TransferInputsSummary -\> TransferOutputsSummary -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferSummary
+```daml
+summarizeTransfer : Party -> Round -> Decimal -> TransferConfigV2 Amulet -> TransferInputsSummary -> TransferOutputsSummary -> Update TransferSummary
+```
 
-</div>
+<span id="function-splice-amuletrules-issuerewards-17863"></span>
 
-<div id="function-splice-amuletrules-issuerewards-17863">
+### `issueRewards`
 
-issueRewards
-: RewardsIssuanceConfig -\> TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+issueRewards : RewardsIssuanceConfig -> TransferContextSummaryV2 -> Party -> Optional [AppRewardBeneficiary] -> Update ()
+```
 
-</div>
+<span id="function-splice-amuletrules-createtransferoutputs-14910"></span>
 
-<div id="function-splice-amuletrules-createtransferoutputs-14910">
+### `createTransferOutputs`
 
-createTransferOutputs
-: Round -\> TransferConfigV2 Amulet -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> TransferSummary -\> TransferOutputsSummary -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (\[CreatedAmulet\], [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+```daml
+createTransferOutputs : Round -> TransferConfigV2 Amulet -> Party -> Party -> TransferSummary -> TransferOutputsSummary -> Update ([CreatedAmulet], Optional (ContractId Amulet))
+```
 
-</div>
+<span id="function-splice-amuletrules-scalefees-202"></span>
 
-<div id="function-splice-amuletrules-scalefees-202">
+### `scaleFees`
 
-scaleFees
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferConfig USD -\> TransferConfig Amulet
+```daml
+scaleFees : Decimal -> TransferConfig USD -> TransferConfig Amulet
+```
 
 Scale the 'AmuletConfig' such that the fees charged are scaled by the same scale factor.
 
-</div>
+<span id="function-splice-amuletrules-scalefees2-95743"></span>
 
-<div id="function-splice-amuletrules-scalefees2-95743">
+### `scaleFees2`
 
-scaleFees2
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferConfigV2 USD -\> TransferConfigV2 Amulet
+```daml
+scaleFees2 : Decimal -> TransferConfigV2 USD -> TransferConfigV2 Amulet
+```
 
 Scale the 'TranserConfigV2' such that the fees charged are scaled by the same scale factor.
 
-</div>
+<span id="function-splice-amuletrules-transferconfigamuletfromopenround-39144"></span>
 
-<div id="function-splice-amuletrules-transferconfigamuletfromopenround-39144">
+### `transferConfigAmuletFromOpenRound`
 
-transferConfigAmuletFromOpenRound
-: OpenMiningRound -\> TransferConfig Amulet
+```daml
+transferConfigAmuletFromOpenRound : OpenMiningRound -> TransferConfig Amulet
+```
 
-</div>
+<span id="function-splice-amuletrules-validatebuymembertrafficinputs-62954"></span>
 
-<div id="function-splice-amuletrules-validatebuymembertrafficinputs-62954">
+### `validateBuyMemberTrafficInputs`
 
-validateBuyMemberTrafficInputs
-: AmuletConfig USD -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) FailureStatus ()
+```daml
+validateBuyMemberTrafficInputs : AmuletConfig USD -> Text -> Int -> Either FailureStatus ()
+```
 
-</div>
+<span id="function-splice-amuletrules-computesynchronizerfees-53837"></span>
 
-<div id="function-splice-amuletrules-computesynchronizerfees-53837">
+### `computeSynchronizerFees`
 
-computeSynchronizerFees
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> AmuletRules -\> TransferContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+```daml
+computeSynchronizerFees : Party -> Party -> Int -> AmuletRules -> TransferContext -> Update (Decimal, Decimal)
+```
 
 Computing synchronizer fees
 
-</div>
+<span id="function-splice-amuletrules-legacyamuletcreatesummary-16866"></span>
 
-<div id="function-splice-amuletrules-legacyamuletcreatesummary-16866">
+### `legacyAmuletCreateSummary`
 
-legacyAmuletCreateSummary
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+```daml
+legacyAmuletCreateSummary : Party -> Party -> ContractId OpenMiningRound -> ContractId Amulet -> Update (AmuletCreateSummary (ContractId Amulet))
+```
 
-</div>
+<span id="function-splice-amuletrules-checkexpecteddso-85182"></span>
 
-<div id="function-splice-amuletrules-checkexpecteddso-85182">
+### `checkExpectedDso`
 
-checkExpectedDso
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+checkExpectedDso : Party -> Optional Party -> Update ()
+```
 
-</div>
+<span id="function-splice-amuletrules-exerciseapptransfer-15159"></span>
 
-<div id="function-splice-amuletrules-exerciseapptransfer-15159">
+### `exerciseAppTransfer`
 
-exerciseAppTransfer
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> AppTransferContext -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+```daml
+exerciseAppTransfer : Party -> AppTransferContext -> Transfer -> Update TransferResult
+```
 
-</div>
+<span id="function-splice-amuletrules-exercisepaymenttransfer-78288"></span>
 
-<div id="function-splice-amuletrules-exercisepaymenttransfer-78288">
+### `exercisePaymentTransfer`
 
-exercisePaymentTransfer
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> PaymentTransferContext -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+```daml
+exercisePaymentTransfer : Party -> PaymentTransferContext -> Transfer -> Update TransferResult
+```
 
-</div>
+<span id="function-splice-amuletrules-amulettransfercontext-70307"></span>
 
-<div id="function-splice-amuletrules-amulettransfercontext-70307">
+### `amuletTransferContext`
 
-amuletTransferContext
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) -\> TransferContext
+```daml
+amuletTransferContext : ContractId OpenMiningRound -> Optional (ContractId FeaturedAppRight) -> TransferContext
+```
 
 Helper to construct transfer context with only amulet inputs
 
-</div>
+<span id="function-splice-amuletrules-createdamulettoholding-42008"></span>
 
-<div id="function-splice-amuletrules-createdamulettoholding-42008">
+### `createdAmuletToHolding`
 
-createdAmuletToHolding
-: CreatedAmulet -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding
+```daml
+createdAmuletToHolding : CreatedAmulet -> ContractId Holding
+```
 
-</div>
+<span id="function-splice-amuletrules-mkinputvalidatorfaucetcoupon-66284"></span>
 
-<div id="function-splice-amuletrules-mkinputvalidatorfaucetcoupon-66284">
+### `mkInputValidatorFaucetCoupon`
 
-mkInputValidatorFaucetCoupon
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon -\> TransferInput
+```daml
+mkInputValidatorFaucetCoupon : ContractId ValidatorFaucetCoupon -> TransferInput
+```
 
 Smart constructor for inputing validator faucet coupons into a transfer.
 
-</div>
+<span id="function-splice-amuletrules-computetransferpreapprovalfee-40643"></span>
 
-<div id="function-splice-amuletrules-computetransferpreapprovalfee-40643">
+### `computeTransferPreapprovalFee`
 
-computeTransferPreapprovalFee
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> AmuletConfig USD -\> TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+```daml
+computeTransferPreapprovalFee : RelTime -> AmuletConfig USD -> TransferContext -> Party -> Update (Decimal, Decimal)
+```
 
-</div>
+<span id="function-splice-amuletrules-splitandburn-28460"></span>
 
-<div id="function-splice-amuletrules-splitandburn-28460">
+### `splitAndBurn`
 
-splitAndBurn
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> \[TransferInput\] -\> TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (TransferResult, Metadata)
+```daml
+splitAndBurn : Party -> Decimal -> [TransferInput] -> TransferContext -> Party -> Text -> Update (TransferResult, Metadata)
+```
 
-</div>
+<span id="function-splice-amuletrules-totalburnfromsummary-61907"></span>
 
-<div id="function-splice-amuletrules-totalburnfromsummary-61907">
+### `totalBurnFromSummary`
 
-totalBurnFromSummary
-: TransferSummary -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+```daml
+totalBurnFromSummary : TransferSummary -> Decimal
+```
 
 Compute the total burn done as part of the transfer.
 
-</div>
+<span id="function-splice-amuletrules-externalpartytransferfromchoicecontext-27714"></span>
 
-<div id="function-splice-amuletrules-externalpartytransferfromchoicecontext-27714">
+### `externalPartyTransferFromChoiceContext`
 
-externalPartyTransferFromChoiceContext
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> ChoiceContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ExternalPartyTransferContext
+```daml
+externalPartyTransferFromChoiceContext : Party -> ChoiceContext -> Update ExternalPartyTransferContext
+```
 
-</div>
+<span id="function-splice-amuletrules-unfeaturedpaymentcontextfromchoicecontext-64473"></span>
 
-<div id="function-splice-amuletrules-unfeaturedpaymentcontextfromchoicecontext-64473">
+### `unfeaturedPaymentContextFromChoiceContext`
 
-unfeaturedPaymentContextFromChoiceContext
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> ChoiceContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ExternalPartyTransferContext
+```daml
+unfeaturedPaymentContextFromChoiceContext : Party -> ChoiceContext -> Update ExternalPartyTransferContext
+```
 
 Used when we want to ignore a featured app right, even if it is present in the context.
 
-</div>
+<span id="function-splice-amuletrules-bootstrapexternalpartyconfigstate-17433"></span>
 
-<div id="function-splice-amuletrules-bootstrapexternalpartyconfigstate-17433">
+### `bootstrapExternalPartyConfigState`
 
-bootstrapExternalPartyConfigState
-: AmuletRules -\> OpenMiningRoundTriple -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+bootstrapExternalPartyConfigState : AmuletRules -> OpenMiningRoundTriple -> Update ()
+```
 
-</div>
+## Templates
 
-{/* COPIED_END */}
+<span id="type-splice-amuletrules-amuletrules-32426"></span>
+
+### Template `AmuletRules`
+
+The rules governing how Amulet users can modify the Amulet state managed by the DSO party.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| configSchedule | Schedule Time (AmuletConfig USD) |  |
+| isDevNet | Bool |  |
+| contractStateSchemaVersion | Optional Int |  |
+
+Choices:
+
+<span id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigschedule-17078"></span>
+
+#### Choice `AmuletRules_AddFutureAmuletConfigSchedule`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newScheduleItem | (Time, AmuletConfig USD) |  |
+
+<span id="type-splice-amuletrules-amuletrulesadvanceopenminingrounds-86978"></span>
+
+#### Choice `AmuletRules_AdvanceOpenMiningRounds`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_AdvanceOpenMiningRoundsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletPrice | Decimal |  |
+| roundToArchiveCid | ContractId OpenMiningRound |  |
+| middleRoundCid | ContractId OpenMiningRound |  |
+| latestRoundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcoupon-20234"></span>
+
+#### Choice `AmuletRules_AllocateDevelopmentFundCoupon`
+
+Allows the Development Fund manager to allocate a specified amount from a
+collection of UnclaimedDevelopmentFundCoupons to a beneficiary, generating a
+DevelopmentFundCoupon and producing a leftover unclaimed coupon if applicable.
+
+Controllers: `fundManager`
+
+Returns: `AmuletRules_AllocateDevelopmentFundCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCids | [ContractId UnclaimedDevelopmentFundCoupon] |  |
+| beneficiary | Party |  |
+| amount | Decimal |  |
+| expiresAt | Time |  |
+| reason | Text |  |
+| fundManager | Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructions-2487"></span>
+
+#### Choice `AmuletRules_Amulet_ExpireTransferInstructions`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedDso | Party |  |
+| inputs | [AmuletRules_ExpireTransferInstructionInput] |  |
+| observers | [Party] |  |
+
+<span id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstate-17751"></span>
+
+#### Choice `AmuletRules_BootstrapExternalPartyConfigState`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+| expectedDso | Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesbootstraprounds-81536"></span>
+
+#### Choice `AmuletRules_Bootstrap_Rounds`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_Bootstrap_RoundsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletPrice | Decimal |  |
+| round0Duration | RelTime |  |
+| initialRound | Optional Int |  |
+
+<span id="type-splice-amuletrules-amuletrulesbuymembertraffic-66391"></span>
+
+#### Choice `AmuletRules_BuyMemberTraffic`
+
+Controllers: `provider`
+
+Returns: `AmuletRules_BuyMemberTrafficResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | TransferContext |  |
+| provider | Party |  |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+| trafficAmount | Int |  |
+| expectedDso | Optional Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesclaimexpiredrewards-90526"></span>
+
+#### Choice `AmuletRules_ClaimExpiredRewards`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_ClaimExpiredRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+| validatorRewardCouponCids | [ContractId ValidatorRewardCoupon] |  |
+| appCouponCids | [ContractId AppRewardCoupon] |  |
+| svRewardCouponCids | [ContractId SvRewardCoupon] |  |
+| optValidatorFaucetCouponCids | Optional [ContractId ValidatorFaucetCoupon] |  |
+| optValidatorLivenessActivityRecordCids | Optional [ContractId ValidatorLivenessActivityRecord] |  |
+
+<span id="type-splice-amuletrules-amuletrulescomputefees-56243"></span>
+
+#### Choice `AmuletRules_ComputeFees`
+
+Compute the output fees for transfer against the given context
+
+Controllers: `sender`
+
+Returns: `AmuletRules_ComputeFeesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | TransferContext |  |
+| sender | Party |  |
+| outputs | [TransferOutput] |  |
+| expectedDso | Optional Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkers-99721"></span>
+
+#### Choice `AmuletRules_ConvertFeaturedAppActivityMarkers`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| markerCids | [ContractId FeaturedAppActivityMarker] |  |
+| openMiningRoundCid | ContractId OpenMiningRound |  |
+| observers | Optional [Party] | A list of choice observers. This is expected to be set to the union of all providers and beneficiaries to ensure that this creates only one view. |
+
+<span id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposal-53882"></span>
+
+#### Choice `AmuletRules_CreateExternalPartySetupProposal`
+
+Propose to host an external party
+The provider pre-pays the fees for the creation of a TransferPreapproval contract
+on behalf of the external party when exercising this choice
+
+Controllers: `validator`
+
+Returns: `AmuletRules_CreateExternalPartySetupProposalResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| user | Party |  |
+| validator | Party |  |
+| preapprovalExpiresAt | Time |  |
+| expectedDso | Optional Party |  |
+
+<span id="type-splice-amuletrules-amuletrulescreatetransferpreapproval-31932"></span>
+
+#### Choice `AmuletRules_CreateTransferPreapproval`
+
+Pre-approve incoming amulet transfers
+
+Controllers: `provider`, `receiver`
+
+Returns: `AmuletRules_CreateTransferPreapprovalResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| receiver | Party |  |
+| provider | Party |  |
+| expiresAt | Time |  |
+| expectedDso | Optional Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesdevnetfeatureapp-42587"></span>
+
+#### Choice `AmuletRules_DevNet_FeatureApp`
+
+Controllers: `provider`
+
+Returns: `AmuletRules_DevNet_FeatureAppResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesdevnettap-82572"></span>
+
+#### Choice `AmuletRules_DevNet_Tap`
+
+Controllers: `receiver`
+
+Returns: `AmuletRules_DevNet_TapResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | Decimal |  |
+| openRound | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amuletrules-amuletrulesfetch-60873"></span>
+
+#### Choice `AmuletRules_Fetch`
+
+Controllers: `p`
+
+Returns: `AmuletRules`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesmergemembertrafficcontracts-58585"></span>
+
+#### Choice `AmuletRules_MergeMemberTrafficContracts`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MergeMemberTrafficContractsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trafficCids | [ContractId MemberTraffic] |  |
+
+<span id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcoupons-89321"></span>
+
+#### Choice `AmuletRules_MergeUnclaimedDevelopmentFundCoupons`
+
+Batch merge of unclaimed development fund coupons
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCids | [ContractId UnclaimedDevelopmentFundCoupon] |  |
+
+<span id="type-splice-amuletrules-amuletrulesmergeunclaimedrewards-76493"></span>
+
+#### Choice `AmuletRules_MergeUnclaimedRewards`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MergeUnclaimedRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCids | [ContractId UnclaimedReward] |  |
+
+<span id="type-splice-amuletrules-amuletrulesminingroundarchive-33308"></span>
+
+#### Choice `AmuletRules_MiningRound_Archive`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MiningRound_ArchiveResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<span id="type-splice-amuletrules-amuletrulesminingroundclose-27964"></span>
+
+#### Choice `AmuletRules_MiningRound_Close`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MiningRound_CloseResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issuingRoundCid | ContractId IssuingMiningRound |  |
+
+<span id="type-splice-amuletrules-amuletrulesminingroundstartissuing-80649"></span>
+
+#### Choice `AmuletRules_MiningRound_StartIssuing`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MiningRound_StartIssuingResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| miningRoundCid | ContractId SummarizingMiningRound |  |
+| summary | OpenMiningRoundSummary |  |
+
+<span id="type-splice-amuletrules-amuletrulesmint-76046"></span>
+
+#### Choice `AmuletRules_Mint`
+
+Controllers: `dso`, `receiver`
+
+Returns: `AmuletRules_MintResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | Decimal |  |
+| openRound | ContractId OpenMiningRound |  |
+
+<span id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigschedule-69936"></span>
+
+#### Choice `AmuletRules_RemoveFutureAmuletConfigSchedule`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| scheduleTime | Time |  |
+
+<span id="type-splice-amuletrules-amuletrulessetconfig-85439"></span>
+
+#### Choice `AmuletRules_SetConfig`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_SetConfigResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newConfig | AmuletConfig USD |  |
+| baseConfig | AmuletConfig USD |  |
+
+<span id="type-splice-amuletrules-amuletrulestransfer-23235"></span>
+
+#### Choice `AmuletRules_Transfer`
+
+Controllers: `Set.toList (transferControllers transfer)`
+
+Returns: `TransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transfer | Transfer |  |
+| context | TransferContext |  |
+| expectedDso | Optional Party |  |
+
+<span id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstates-76929"></span>
+
+#### Choice `AmuletRules_UpdateExternalPartyConfigStates`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigStateCid0 | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigStateCid1 | ContractId ExternalPartyConfigState |  |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+
+<span id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigschedule-15159"></span>
+
+#### Choice `AmuletRules_UpdateFutureAmuletConfigSchedule`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| scheduleItem | (Time, AmuletConfig USD) |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-amuletrules-externalpartysetupproposal-90414"></span>
+
+### Template `ExternalPartySetupProposal`
+
+Signatories: `validator`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validator | Party |  |
+| user | Party |  |
+| dso | Party |  |
+| createdAt | Time |  |
+| preapprovalExpiresAt | Time |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `validator`, `dso`
+
+Returns: `()`
+
+<span id="type-splice-amuletrules-externalpartysetupproposalaccept-68720"></span>
+
+#### Choice `ExternalPartySetupProposal_Accept`
+
+Controllers: `user`
+
+Returns: `ExternalPartySetupProposal_AcceptResult`
+
+<span id="type-splice-amuletrules-externalpartysetupproposalreject-30733"></span>
+
+#### Choice `ExternalPartySetupProposal_Reject`
+
+Controllers: `user`
+
+Returns: `ExternalPartySetupProposal_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<span id="type-splice-amuletrules-externalpartysetupproposalwithdraw-43220"></span>
+
+#### Choice `ExternalPartySetupProposal_Withdraw`
+
+Controllers: `validator`
+
+Returns: `ExternalPartySetupProposal_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<span id="type-splice-amuletrules-transferpreapproval-36220"></span>
+
+### Template `TransferPreapproval`
+
+A pre-approval by a receiver to receive Amulet from anybody.
+
+Pre-approvals are indexed by the SVs and served from scan for easy discovery until
+they expire. The cost of providing this discovery service is charged by burning Amulet.
+
+Receivers can either purchase and renew these pre-approvals by themselves,
+or have an app provider do so for them in exchange for the app rewards for
+the amulet transfers completed via the managed pre-approval.
+
+Signatories: `receiver`, `provider`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| receiver | Party | The receiver party |
+| provider | Party | The app provider that manages the pre-approval for the receiver. Equal to the receiver for self-managed pre-approvals. |
+| validFrom | Time | This timestamp marks the start of the period for which fees were paid for the pre-approval. Preserved across renewals. |
+| lastRenewedAt | Time | When the pre-approval was last renewed. Set equal to `validFrom` on creation and updated on each renewal. |
+| expiresAt | Time | Provider selected timestamp defining the lifetime of the contract. Can be extended by renewing the contract. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `receiver`, `provider`, `dso`
+
+Returns: `()`
+
+<span id="type-splice-amuletrules-transferpreapprovalcancel-70216"></span>
+
+#### Choice `TransferPreapproval_Cancel`
+
+Controllers: `p`
+
+Returns: `TransferPreapproval_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<span id="type-splice-amuletrules-transferpreapprovalexpire-84167"></span>
+
+#### Choice `TransferPreapproval_Expire`
+
+Controllers: `dso`
+
+Returns: `TransferPreapproval_ExpireResult`
+
+<span id="type-splice-amuletrules-transferpreapprovalfetch-15083"></span>
+
+#### Choice `TransferPreapproval_Fetch`
+
+Controllers: `p`
+
+Returns: `TransferPreapproval`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<span id="type-splice-amuletrules-transferpreapprovalrenew-31244"></span>
+
+#### Choice `TransferPreapproval_Renew`
+
+Controllers: `provider`
+
+Returns: `TransferPreapproval_RenewResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| newExpiresAt | Time |  |
+
+<span id="type-splice-amuletrules-transferpreapprovalsend-62554"></span>
+
+#### Choice `TransferPreapproval_Send`
+
+Deprecated: Use TransferPreapproval_SendV2 instead.
+
+Controllers: `sender`
+
+Returns: `TransferPreapproval_SendResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| amount | Decimal |  |
+| sender | Party |  |
+| description | Optional Text |  |
+
+<span id="type-splice-amuletrules-transferpreapprovalsendv2-66036"></span>
+
+#### Choice `TransferPreapproval_SendV2`
+
+Controllers: `sender`
+
+Returns: `TransferPreapproval_SendV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | ExternalPartyTransferContext |  |
+| inputs | [TransferInput] |  |
+| amount | Decimal |  |
+| sender | Party |  |
+| description | Optional Text |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction.mdx
@@ -1,42 +1,60 @@
 ---
 title: "Splice.AmuletTransferInstruction"
-description: "Documentation for Splice.AmuletTransferInstruction"
+description: "Reference documentation for Daml module Splice.AmuletTransferInstruction."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletTransferInstruction.rst" tag="0.6.4" hash="afde74aa" */}
+<span id="module-splice-amulettransferinstruction-51350"></span>
 
-## Templates
+# Splice.AmuletTransferInstruction
 
-<div id="type-splice-amulettransferinstruction-amulettransferinstruction-76678">
+## Module Snapshot
 
-**template** AmuletTransferInstruction
-
-</div>
-
-> A transfer instruction for transferring Amulet tokens pending on receiver acceptance.
->
-> Signatory: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer)), (DA.Internal.Record.getField @"sender" transfer)
->
-> | Field        | Type                                                                                                                                       | Description                                                                   |
-> |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-> | lockedAmulet | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet | Locked amulet that holds the funds for executing the transfer upon acceptance |
-> | transfer     | Transfer                                                                                                                                   |                                                                               |
->
-> - **Choice** Archive
->
->   Controller: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer)), (DA.Internal.Record.getField @"sender" transfer)
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Functions
 
-<div id="function-splice-amulettransferinstruction-standardtransfertotwosteptransfer-69205">
+<span id="function-splice-amulettransferinstruction-standardtransfertotwosteptransfer-69205"></span>
 
-standardTransferToTwoStepTransfer
-: Transfer -\> TwoStepTransfer
+### `standardTransferToTwoStepTransfer`
 
-</div>
+```daml
+standardTransferToTwoStepTransfer : Transfer -> TwoStepTransfer
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-amulettransferinstruction-amulettransferinstruction-76678"></span>
+
+### Template `AmuletTransferInstruction`
+
+A transfer instruction for transferring Amulet tokens pending on receiver
+acceptance.
+
+Signatories: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer))`, `(DA.Internal.Record.getField @"sender" transfer)`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| lockedAmulet | ContractId LockedAmulet | Locked amulet that holds the funds for executing the transfer upon acceptance |
+| transfer | Transfer |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer))`, `(DA.Internal.Record.getField @"sender" transfer)`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer.mdx
@@ -1,226 +1,207 @@
 ---
 title: "Splice.DecentralizedSynchronizer"
-description: "Documentation for Splice.DecentralizedSynchronizer"
+description: "Reference documentation for Daml module Splice.DecentralizedSynchronizer."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-DecentralizedSynchronizer.rst" tag="0.6.4" hash="26258f35" */}
+<span id="module-splice-decentralizedsynchronizer-23863"></span>
+
+# Splice.DecentralizedSynchronizer
 
 Types and contracts for managing synchronizer fees
 
-## Templates
+## Module Snapshot
 
-<div id="type-splice-decentralizedsynchronizer-membertraffic-74049">
-
-**template** MemberTraffic
-
-</div>
-
-> The state of the extra synchronizer traffic purchases of a sequencer sv.
->
-> Signatory: dso
->
-> | Field          | Type                                                                                                                | Description                                                                                   |
-> |----------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-> | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                               |
-> | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The id of the sequencer member (participant or mediator) for which traffic has been purchased |
-> | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The id of the synchronizer for which this contract tracks purchased extra traffic             |
-> | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The migration id of the synchronizer for which this contract tracks purchased extra traffic   |
-> | totalPurchased | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The number of bytes of extra traffic purchased                                                |
-> | numPurchases   | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | Number of times extra traffic has been purchased                                              |
-> | amuletSpent    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | Total Amulet spent on extra traffic                                                           |
-> | usdSpent       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | Total USD spent on extra traffic                                                              |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-15126">
+<span id="type-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-15126"></span>
 
-**data** AmuletDecentralizedSynchronizerConfig
+### `data AmuletDecentralizedSynchronizerConfig`
 
-</div>
+The configuration of the logical concept of a decentralized synchronizer, which consists over its lifetime
+of a series of actual synchronizers, which are introduced for handling the (rare) occasions of switching
+to a new synchronizer protocol version.
 
-> The configuration of the logical concept of a decentralized synchronizer, which consists over its lifetime of a series of actual synchronizers, which are introduced for handling the (rare) occasions of switching to a new synchronizer protocol version.
->
-> <div id="constr-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-80511">
->
-> AmuletDecentralizedSynchronizerConfig
->
-> </div>
->
-> > | Field                 | Type                                                                                                                                                                                                                      | Description                                                                                                                                                                      |
-> > |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | requiredSynchronizers | Set [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The synchronizer-ids of all synchronizers that Amulet and ANS users should be connected to.                                                                                      |
-> > | activeSynchronizer    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                              | The synchronizer-id of the synchronizer on which the SVs accepts transactions involving the AmuletRules and related contracts, which must be one of the `requiredSynchronizers`. |
-> > | fees                  | SynchronizerFeesConfig                                                                                                                                                                                                    | The fees charged for using the decentralized synchronizer. We use the same fees across all active decentralized synchronizers.                                                   |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletDecentralizedSynchronizerConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletDecentralizedSynchronizerConfig
->
-> **instance** GetField "activeSynchronizer" AmuletDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
->
-> **instance** GetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
->
-> **instance** GetField "requiredSynchronizers" AmuletDecentralizedSynchronizerConfig (Set [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
->
-> **instance** SetField "activeSynchronizer" AmuletDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
->
-> **instance** SetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
->
-> **instance** SetField "requiredSynchronizers" AmuletDecentralizedSynchronizerConfig (Set [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
->
-> **instance** Patchable AmuletDecentralizedSynchronizerConfig
+Constructors:
 
-<div id="type-splice-decentralizedsynchronizer-baseratetrafficlimits-64372">
+<span id="constr-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-80511"></span>
 
-**data** BaseRateTrafficLimits
+- `AmuletDecentralizedSynchronizerConfig`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requiredSynchronizers | Set Text | The synchronizer-ids of all synchronizers that Amulet and ANS users should be connected to. |
+| activeSynchronizer | Text | The synchronizer-id of the synchronizer on which the SVs accepts transactions involving the<br/><br/>AmuletRules and related contracts, which must be one of the `requiredSynchronizers`. |
+| fees | SynchronizerFeesConfig | The fees charged for using the decentralized synchronizer. We use the same fees across all active decentralized synchronizers. |
 
-> The limits defining the free base rate delivered by the synchronizer. It defines the base rate as allowing at most burstAmount of sequencing traffic within a window of burstWindow seconds.
->
-> <div id="constr-splice-decentralizedsynchronizer-baseratetrafficlimits-1937">
->
-> BaseRateTrafficLimits
->
-> </div>
->
-> > | Field       | Type                                                                                                                   | Description                                                                         |
-> > |-------------|------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-> > | burstAmount | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)             | The total burstAmount in bytes of sequencing traffic delivered over the burstWindow |
-> > | burstWindow | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Time window within which the burstAmount must not be exceeded                       |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BaseRateTrafficLimits
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BaseRateTrafficLimits
->
-> **instance** GetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
->
-> **instance** GetField "burstAmount" BaseRateTrafficLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "burstWindow" BaseRateTrafficLimits [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
->
-> **instance** SetField "burstAmount" BaseRateTrafficLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "burstWindow" BaseRateTrafficLimits [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** Patchable BaseRateTrafficLimits
+Instances:
 
-<div id="type-splice-decentralizedsynchronizer-formembertraffic-62879">
+- `instance Patchable AmuletDecentralizedSynchronizerConfig`
+- `instance Eq AmuletDecentralizedSynchronizerConfig`
+- `instance Show AmuletDecentralizedSynchronizerConfig`
+- `instance GetField activeSynchronizer AmuletDecentralizedSynchronizerConfig Text`
+- `instance GetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance GetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance GetField requiredSynchronizers AmuletDecentralizedSynchronizerConfig (Set Text)`
+- `instance SetField activeSynchronizer AmuletDecentralizedSynchronizerConfig Text`
+- `instance SetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance SetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance SetField requiredSynchronizers AmuletDecentralizedSynchronizerConfig (Set Text)`
 
-**data** ForMemberTraffic
+<span id="type-splice-decentralizedsynchronizer-baseratetrafficlimits-64372"></span>
 
-</div>
+### `data BaseRateTrafficLimits`
 
-> <div id="constr-splice-decentralizedsynchronizer-formembertraffic-24640">
->
-> ForMemberTraffic
->
-> </div>
->
-> > | Field          | Type                                                                                                                | Description |
-> > |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
-> > | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
-> > | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForMemberTraffic
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForMemberTraffic
->
-> **instance** GetField "dso" ForMemberTraffic [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "memberId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "migrationId" ForMemberTraffic [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "synchronizerId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dso" ForMemberTraffic [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "memberId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "migrationId" ForMemberTraffic [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "synchronizerId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** HasCheckedFetch MemberTraffic ForMemberTraffic
+The limits defining the free base rate delivered by the synchronizer.
+It defines the base rate as allowing at most burstAmount of sequencing traffic within a window of burstWindow seconds.
 
-<div id="type-splice-decentralizedsynchronizer-synchronizerfeesconfig-12142">
+Constructors:
 
-**data** SynchronizerFeesConfig
+<span id="constr-splice-decentralizedsynchronizer-baseratetrafficlimits-1937"></span>
 
-</div>
+- `BaseRateTrafficLimits`
 
-> Synchronizer fees related configuration to be tracked on the DsoRules contract
->
-> <div id="constr-splice-decentralizedsynchronizer-synchronizerfeesconfig-16293">
->
-> SynchronizerFeesConfig
->
-> </div>
->
-> > | Field                    | Type                                                                                                               | Description                                                                                                                                                                                                                                                                                                                                               |
-> > |--------------------------|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | baseRateTrafficLimits    | BaseRateTrafficLimits                                                                                              | Configuration limits for base rate traffic                                                                                                                                                                                                                                                                                                                |
-> > | extraTrafficPrice        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The price of extra traffic denominated in \$/MB                                                                                                                                                                                                                                                                                                           |
-> > | readVsWriteScalingFactor | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | How much the sending of a message to its recipient costs in terms of bytes written to the synchronizer. This factor is specified in parts per 10,000 (or per 10 mille) We charge for sending messages depending on the number of recipients, as delivering the message incurs a cost as well, albeit usually a much smaller one than the cost of a write. |
-> > | minTopupAmount           | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | The minimum amount of extra traffic (in bytes) that must be bought when buying extra traffic. This ensures that the SVs can amortize the cost of executing that transaction.                                                                                                                                                                              |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerFeesConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerFeesConfig
->
-> **instance** GetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
->
-> **instance** GetField "extraTrafficPrice" SynchronizerFeesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
->
-> **instance** GetField "minTopupAmount" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "readVsWriteScalingFactor" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
->
-> **instance** SetField "extraTrafficPrice" SynchronizerFeesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
->
-> **instance** SetField "minTopupAmount" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "readVsWriteScalingFactor" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** Patchable SynchronizerFeesConfig
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| burstAmount | Int | The total burstAmount in bytes of sequencing traffic delivered over the burstWindow |
+| burstWindow | RelTime | Time window within which the burstAmount must not be exceeded |
+
+Instances:
+
+- `instance Patchable BaseRateTrafficLimits`
+- `instance Eq BaseRateTrafficLimits`
+- `instance Show BaseRateTrafficLimits`
+- `instance GetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance GetField burstAmount BaseRateTrafficLimits Int`
+- `instance GetField burstWindow BaseRateTrafficLimits RelTime`
+- `instance SetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance SetField burstAmount BaseRateTrafficLimits Int`
+- `instance SetField burstWindow BaseRateTrafficLimits RelTime`
+
+<span id="type-splice-decentralizedsynchronizer-formembertraffic-62879"></span>
+
+### `data ForMemberTraffic`
+
+Constructors:
+
+<span id="constr-splice-decentralizedsynchronizer-formembertraffic-24640"></span>
+
+- `ForMemberTraffic`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+
+Instances:
+
+- `instance HasCheckedFetch MemberTraffic ForMemberTraffic`
+- `instance Eq ForMemberTraffic`
+- `instance Show ForMemberTraffic`
+- `instance GetField dso ForMemberTraffic Party`
+- `instance GetField memberId ForMemberTraffic Text`
+- `instance GetField migrationId ForMemberTraffic Int`
+- `instance GetField synchronizerId ForMemberTraffic Text`
+- `instance SetField dso ForMemberTraffic Party`
+- `instance SetField memberId ForMemberTraffic Text`
+- `instance SetField migrationId ForMemberTraffic Int`
+- `instance SetField synchronizerId ForMemberTraffic Text`
+
+<span id="type-splice-decentralizedsynchronizer-synchronizerfeesconfig-12142"></span>
+
+### `data SynchronizerFeesConfig`
+
+Synchronizer fees related configuration to be tracked on the DsoRules contract
+
+Constructors:
+
+<span id="constr-splice-decentralizedsynchronizer-synchronizerfeesconfig-16293"></span>
+
+- `SynchronizerFeesConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| baseRateTrafficLimits | BaseRateTrafficLimits | Configuration limits for base rate traffic |
+| extraTrafficPrice | Decimal | The price of extra traffic denominated in $/MB |
+| readVsWriteScalingFactor | Int | How much the sending of a message to its recipient costs in terms of bytes written to the synchronizer.<br/><br/>This factor is specified in parts per 10,000 (or per 10 mille)<br/><br/>We charge for sending messages depending on the number of recipients,<br/><br/>as delivering the message incurs a cost as well, albeit usually a much<br/><br/>smaller one than the cost of a write. |
+| minTopupAmount | Int | The minimum amount of extra traffic (in bytes) that must be bought when buying extra traffic.<br/><br/>This ensures that the SVs can amortize the cost of executing that transaction. |
+
+Instances:
+
+- `instance Patchable SynchronizerFeesConfig`
+- `instance Eq SynchronizerFeesConfig`
+- `instance Show SynchronizerFeesConfig`
+- `instance GetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance GetField extraTrafficPrice SynchronizerFeesConfig Decimal`
+- `instance GetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance GetField minTopupAmount SynchronizerFeesConfig Int`
+- `instance GetField readVsWriteScalingFactor SynchronizerFeesConfig Int`
+- `instance SetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance SetField extraTrafficPrice SynchronizerFeesConfig Decimal`
+- `instance SetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance SetField minTopupAmount SynchronizerFeesConfig Int`
+- `instance SetField readVsWriteScalingFactor SynchronizerFeesConfig Int`
 
 ## Functions
 
-<div id="function-splice-decentralizedsynchronizer-validamuletdecentralizedsynchronizerconfig-57759">
+<span id="function-splice-decentralizedsynchronizer-validamuletdecentralizedsynchronizerconfig-57759"></span>
 
-validAmuletDecentralizedSynchronizerConfig
-: AmuletDecentralizedSynchronizerConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validAmuletDecentralizedSynchronizerConfig`
 
-</div>
+```daml
+validAmuletDecentralizedSynchronizerConfig : AmuletDecentralizedSynchronizerConfig -> Bool
+```
 
-<div id="function-splice-decentralizedsynchronizer-initialmembertraffic-49736">
+<span id="function-splice-decentralizedsynchronizer-initialmembertraffic-49736"></span>
 
-initialMemberTraffic
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> MemberTraffic
+### `initialMemberTraffic`
 
-</div>
+```daml
+initialMemberTraffic : Party -> Text -> Text -> Int -> MemberTraffic
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-decentralizedsynchronizer-membertraffic-74049"></span>
+
+### Template `MemberTraffic`
+
+The state of the extra synchronizer traffic purchases of a sequencer sv.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| memberId | Text | The id of the sequencer member (participant or mediator) for which traffic has been purchased |
+| synchronizerId | Text | The id of the synchronizer for which this contract tracks purchased extra traffic |
+| migrationId | Int | The migration id of the synchronizer for which this contract tracks purchased extra traffic |
+| totalPurchased | Int | The number of bytes of extra traffic purchased |
+| numPurchases | Int | Number of times extra traffic has been purchased |
+| amuletSpent | Decimal | Total Amulet spent on extra traffic |
+| usdSpent | Decimal | Total USD spent on extra traffic |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry.mdx
@@ -1,148 +1,151 @@
 ---
 title: "Splice.Expiry"
-description: "Documentation for Splice.Expiry"
+description: "Reference documentation for Daml module Splice.Expiry."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Expiry.rst" tag="0.6.4" hash="c1e63c20" */}
+<span id="module-splice-expiry-80141"></span>
+
+# Splice.Expiry
 
 Functions for computing amulet and lock expiry times and conditions.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
-<div id="type-splice-expiry-boundedset-6748">
+<span id="type-splice-expiry-boundedset-6748"></span>
 
-**data** BoundedSet a
+### `data BoundedSet a`
 
-</div>
+A symbolic representation of a set of values of type `a` useful for computing upper-bounds.
 
-> A symbolic representation of a set of values of type `a` useful for computing upper-bounds.
->
-> <div id="constr-splice-expiry-singleton-7610">
->
-> Singleton a
->
-> </div>
->
-> > `Singleton x` represents the singleton set `{x}`
->
-> <div id="constr-splice-expiry-aftermaxbound-46101">
->
-> AfterMaxBound
->
-> </div>
->
-> > `AfterMaxBound` represents the set of all values larger than the maximal value that can be represented by type `a`
->
-> **instance** [Functor](/appdev/reference/daml-standard-library/prelude#class-ghc-base-functor-31205) BoundedSet
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (BoundedSet a)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (BoundedSet a)
+Constructors:
 
-<div id="type-splice-expiry-timelock-2221">
+<span id="constr-splice-expiry-singleton-7610"></span>
 
-**data** TimeLock
+- `Singleton a`
 
-</div>
+`Singleton x` represents the singleton set `{x}`
 
-> A lock held by multiple parties until its expiry.
->
-> <div id="constr-splice-expiry-timelock-44256">
->
-> TimeLock
->
-> </div>
->
-> > | Field      | Type                                                                                                                                                                                                                                        | Description                                                                                                                                                                                                                                                                       |
-> > |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | holders    | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                                                                                                                     |                                                                                                                                                                                                                                                                                   |
-> > | expiresAt  | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                           |                                                                                                                                                                                                                                                                                   |
-> > | optContext | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Short, human-readable description of the context in which the amulet is locked. Intended for wallets to inform the user about the reason for the lock. Consider what details to share about the context, as that might be private and the string here will be public information. |
->
-> **instance** FromAnyValue TimeLock
->
-> **instance** ToAnyValue TimeLock
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TimeLock
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) TimeLock
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TimeLock
->
-> **instance** GetField "expiresAt" TimeLock [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "holders" TimeLock \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
->
-> **instance** GetField "lock" LockedAmulet TimeLock
->
-> **instance** GetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** GetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** GetField "optContext" TimeLock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
->
-> **instance** SetField "expiresAt" TimeLock [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "holders" TimeLock \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
->
-> **instance** SetField "lock" LockedAmulet TimeLock
->
-> **instance** SetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** SetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
->
-> **instance** SetField "optContext" TimeLock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+<span id="constr-splice-expiry-aftermaxbound-46101"></span>
+
+- `AfterMaxBound`
+
+`AfterMaxBound` represents the set of all values larger than the maximal value that can be represented by type `a`
+
+Instances:
+
+- `instance Functor BoundedSet`
+- `instance Eq a => Eq (BoundedSet a)`
+- `instance Show a => Show (BoundedSet a)`
+
+<span id="type-splice-expiry-timelock-2221"></span>
+
+### `data TimeLock`
+
+A lock held by multiple parties until its expiry.
+
+Constructors:
+
+<span id="constr-splice-expiry-timelock-44256"></span>
+
+- `TimeLock`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| holders | [Party] |  |
+| expiresAt | Time |  |
+| optContext | Optional Text | Short, human-readable description of the context in which the amulet is locked.<br/><br/>Intended for wallets to inform the user about the reason for the lock.<br/><br/>Consider what details to share about the context, as that might be private and<br/><br/>the string here will be public information. |
+
+Instances:
+
+- `instance FromAnyValue TimeLock`
+- `instance ToAnyValue TimeLock`
+- `instance Eq TimeLock`
+- `instance Ord TimeLock`
+- `instance Show TimeLock`
+- `instance GetField expiresAt TimeLock Time`
+- `instance GetField holders TimeLock [Party]`
+- `instance GetField lock LockedAmulet TimeLock`
+- `instance GetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance GetField lock TransferOutput (Optional TimeLock)`
+- `instance GetField optContext TimeLock (Optional Text)`
+- `instance SetField expiresAt TimeLock Time`
+- `instance SetField holders TimeLock [Party]`
+- `instance SetField lock LockedAmulet TimeLock`
+- `instance SetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance SetField lock TransferOutput (Optional TimeLock)`
+- `instance SetField optContext TimeLock (Optional Text)`
 
 ## Functions
 
-<div id="function-splice-expiry-maxint-28108">
+<span id="function-splice-expiry-maxint-28108"></span>
 
-maxInt
-: [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+### `maxInt`
 
-</div>
+```daml
+maxInt : Int
+```
 
-<div id="function-splice-expiry-maxdecimaldiv10-64031">
+<span id="function-splice-expiry-maxdecimaldiv10-64031"></span>
 
-maxDecimalDiv10
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `maxDecimalDiv10`
 
-</div>
+```daml
+maxDecimalDiv10 : Decimal
+```
 
-<div id="function-splice-expiry-mintime-10075">
+<span id="function-splice-expiry-mintime-10075"></span>
 
-minTime
-: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+### `minTime`
+
+```daml
+minTime : Time
+```
 
 The smallest time point that can be represented by the `Time` type.
 
-</div>
+<span id="function-splice-expiry-maxtime-17293"></span>
 
-<div id="function-splice-expiry-maxtime-17293">
+### `maxTime`
 
-maxTime
-: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+```daml
+maxTime : Time
+```
 
 The largest time point that can be represented by the `Time` type.
 
-</div>
+<span id="function-splice-expiry-amountexpiresat-59287"></span>
 
-<div id="function-splice-expiry-amountexpiresat-59287">
+### `amountExpiresAt`
 
-amountExpiresAt
-: ExpiringAmount -\> BoundedSet Round
+```daml
+amountExpiresAt : ExpiringAmount -> BoundedSet Round
+```
 
 Compute the round where the amulet expires. i.e. the amulet is fully expired.
 
-</div>
+<span id="function-splice-expiry-isamuletexpired-66613"></span>
 
-<div id="function-splice-expiry-isamuletexpired-66613">
+### `isAmuletExpired`
 
-isAmuletExpired
-: Round -\> ExpiringAmount -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+isAmuletExpired : Round -> ExpiringAmount -> Bool
+```
 
-`isAmuletExpired openRound amuletAmount` computes whether the expiring `amuletAmount` is definitely expired in case the `openRound` is open.
-
-</div>
-
-{/* COPIED_END */}
+`isAmuletExpired openRound amuletAmount` computes whether the expiring `amuletAmount`
+is definitely expired in case the `openRound` is open.

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules.mdx
@@ -1,441 +1,406 @@
 ---
 title: "Splice.ExternalPartyAmuletRules"
-description: "Documentation for Splice.ExternalPartyAmuletRules"
+description: "Reference documentation for Daml module Splice.ExternalPartyAmuletRules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-ExternalPartyAmuletRules.rst" tag="0.6.4" hash="76e07229" */}
+<span id="module-splice-externalpartyamuletrules-66966"></span>
 
-## Templates
+# Splice.ExternalPartyAmuletRules
 
-<div id="type-splice-externalpartyamuletrules-externalpartyamuletrules-29682">
+## Module Snapshot
 
-**template** ExternalPartyAmuletRules
-
-</div>
-
-> Rules contract that can be used in transactions that require signatures from an external party. This is intended to get archived and recreated as rarely as possible to support long delays between preparing and signing a transaction.
->
-> Signatory: dso
->
-> | Field | Type                                                                                                                | Description |
-> |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommand-90877">
->
->   **Choice** ExternalPartyAmuletRules_CreateTransferCommand
->
->   </div>
->
->   Controller: sender
->
->   Returns: ExternalPartyAmuletRules_CreateTransferCommandResult
->
->   | Field       | Type                                                                                                                                                                                                                                               | Description |
->   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | delegate    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
->   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                 |             |
->   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                  |             |
->   | nonce       | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                         |             |
->   | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocations-38439">
->
->   **Choice** ExternalPartyAmuletRules_ExpireAmuletAllocations
->
->   </div>
->
->   Controller: dso
->
->   Returns: ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
->   | Field       | Type                                                                                                                    | Description |
->   |-------------|-------------------------------------------------------------------------------------------------------------------------|-------------|
->   | expectedDso | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
->   | inputs      | \[ExternalPartyAmuletRules_ExpireAmuletAllocationInput\]                                                                |             |
->   | observers   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
->
-> - **interface instance** AllocationFactory **for** ExternalPartyAmuletRules
->
-> - **interface instance** TransferFactory **for** ExternalPartyAmuletRules
-
-<div id="type-splice-externalpartyamuletrules-transfercommand-52429">
-
-**template** TransferCommand
-
-</div>
-
-> Deprecated: The token standard transfer APIs now support 24h signing delays so this contract is no longer required.
->
-> One-time delegation to execute a transfer to the given receiver for the given amount.
->
-> Signatory: sender, dso
->
-> | Field       | Type                                                                                                                                                                                                                                        | Description                                                                                                                                                                                         |
-> |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |                                                                                                                                                                                                     |
-> | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |                                                                                                                                                                                                     |
-> | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |                                                                                                                                                                                                     |
-> | delegate    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         | The delegate that actually executes the transfer                                                                                                                                                    |
-> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                          |                                                                                                                                                                                                     |
-> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                           | Expiry of the command until when TransferCommand_Send must be called                                                                                                                                |
-> | nonce       | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                  | Expected nonce value to order and deduplicate concurrent transfers. Starts at 0 and the next value to use can then be read from TransferCommandCounter and the in-flight TransferCommand contracts. |
-> | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |                                                                                                                                                                                                     |
->
-> - **Choice** Archive
->
->   Controller: sender, dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-externalpartyamuletrules-transfercommandexpire-28516">
->
->   **Choice** TransferCommand_Expire
->
->   </div>
->
->   Controller: p
->
->   Returns: TransferCommand_ExpireResult
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-externalpartyamuletrules-transfercommandsend-32409">
->
->   **Choice** TransferCommand_Send
->
->   </div>
->
->   Controller: delegate
->
->   Returns: TransferCommand_SendResult
->
->   | Field                   | Type                                                                                                                                                                                                                                                                               | Description |
->   |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | context                 | PaymentTransferContext                                                                                                                                                                                                                                                             |             |
->   | inputs                  | \[TransferInput\]                                                                                                                                                                                                                                                                  |             |
->   | transferPreapprovalCidO | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval) |             |
->   | transferCounterCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter                                                                                                                               |             |
->
-> - <div id="type-splice-externalpartyamuletrules-transfercommandwithdraw-90837">
->
->   **Choice** TransferCommand_Withdraw
->
->   </div>
->
->   Controller: sender
->
->   Returns: TransferCommand_WithdrawResult
->
->   (no fields)
-
-<div id="type-splice-externalpartyamuletrules-transfercommandcounter-30214">
-
-**template** TransferCommandCounter
-
-</div>
-
-> A contract tracking the number of completed TransferCommands per sender, which is used to determine the nonces used in TransferCommands for deduplication.
->
-> Signatory: dso
->
-> | Field     | Type                                                                                                                | Description |
-> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | sender    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | nextNonce | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-84908">
+<span id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-84908"></span>
 
-**data** ExternalPartyAmuletRules_CreateTransferCommandResult
+### `data ExternalPartyAmuletRules_CreateTransferCommandResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-32161">
->
-> ExternalPartyAmuletRules_CreateTransferCommandResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | transferCommandCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommand |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyAmuletRules_CreateTransferCommandResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyAmuletRules_CreateTransferCommandResult
->
-> **instance** GetField "transferCommandCid" ExternalPartyAmuletRules_CreateTransferCommandResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommand)
->
-> **instance** SetField "transferCommandCid" ExternalPartyAmuletRules_CreateTransferCommandResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommand)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult
+<span id="constr-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-32161"></span>
 
-<div id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-45980">
+- `ExternalPartyAmuletRules_CreateTransferCommandResult`
 
-**data** ExternalPartyAmuletRules_ExpireAmuletAllocationInput
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferCommandCid | ContractId TransferCommand |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-86145">
->
-> ExternalPartyAmuletRules_ExpireAmuletAllocationInput
->
-> </div>
->
-> > | Field         | Type                                                                                                                                           | Description |
-> > |---------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | allocationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletAllocation |             |
-> > | expireLock    | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyAmuletRules_ExpireAmuletAllocationInput
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyAmuletRules_ExpireAmuletAllocationInput
->
-> **instance** GetField "allocationCid" ExternalPartyAmuletRules_ExpireAmuletAllocationInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletAllocation)
->
-> **instance** GetField "expireLock" ExternalPartyAmuletRules_ExpireAmuletAllocationInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** GetField "inputs" ExternalPartyAmuletRules_ExpireAmuletAllocations \[ExternalPartyAmuletRules_ExpireAmuletAllocationInput\]
->
-> **instance** SetField "allocationCid" ExternalPartyAmuletRules_ExpireAmuletAllocationInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletAllocation)
->
-> **instance** SetField "expireLock" ExternalPartyAmuletRules_ExpireAmuletAllocationInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "inputs" ExternalPartyAmuletRules_ExpireAmuletAllocations \[ExternalPartyAmuletRules_ExpireAmuletAllocationInput\]
+- `instance Eq ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance Show ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance GetField transferCommandCid ExternalPartyAmuletRules_CreateTransferCommandResult (ContractId TransferCommand)`
+- `instance SetField transferCommandCid ExternalPartyAmuletRules_CreateTransferCommandResult (ContractId TransferCommand)`
+- `instance HasExercise ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance HasFromAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance HasToAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult`
 
-<div id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-57118">
+<span id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-45980"></span>
 
-**data** ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+### `data ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-31907">
->
-> ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> </div>
->
-> > | Field   | Type                                 | Description |
-> > |---------|--------------------------------------|-------------|
-> > | results | \[AmuletAllocation_DsoExpireResult\] |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> **instance** GetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
->
-> **instance** SetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+<span id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-86145"></span>
 
-<div id="type-splice-externalpartyamuletrules-transfercommandresult-23924">
+- `ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
 
-**data** TransferCommandResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationCid | ContractId AmuletAllocation |  |
+| expireLock | Bool |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-externalpartyamuletrules-transfercommandresultfailure-75214">
->
-> TransferCommandResultFailure
->
-> </div>
->
-> > | Field  | Type                  | Description |
-> > |--------|-----------------------|-------------|
-> > | reason | InvalidTransferReason |             |
->
-> <div id="constr-splice-externalpartyamuletrules-transfercommandresultsuccess-68641">
->
-> TransferCommandResultSuccess
->
-> </div>
->
-> > | Field  | Type           | Description |
-> > |--------|----------------|-------------|
-> > | result | TransferResult |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommandResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommandResult
->
-> **instance** GetField "reason" TransferCommandResult InvalidTransferReason
->
-> **instance** GetField "result" TransferCommandResult TransferResult
->
-> **instance** GetField "result" TransferCommand_SendResult TransferCommandResult
->
-> **instance** SetField "reason" TransferCommandResult InvalidTransferReason
->
-> **instance** SetField "result" TransferCommandResult TransferResult
->
-> **instance** SetField "result" TransferCommand_SendResult TransferCommandResult
+- `instance Eq ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
+- `instance Show ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
+- `instance GetField allocationCid ExternalPartyAmuletRules_ExpireAmuletAllocationInput (ContractId AmuletAllocation)`
+- `instance GetField expireLock ExternalPartyAmuletRules_ExpireAmuletAllocationInput Bool`
+- `instance GetField inputs ExternalPartyAmuletRules_ExpireAmuletAllocations [ExternalPartyAmuletRules_ExpireAmuletAllocationInput]`
+- `instance SetField allocationCid ExternalPartyAmuletRules_ExpireAmuletAllocationInput (ContractId AmuletAllocation)`
+- `instance SetField expireLock ExternalPartyAmuletRules_ExpireAmuletAllocationInput Bool`
+- `instance SetField inputs ExternalPartyAmuletRules_ExpireAmuletAllocations [ExternalPartyAmuletRules_ExpireAmuletAllocationInput]`
 
-<div id="type-splice-externalpartyamuletrules-transfercommandexpireresult-5229">
+<span id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-57118"></span>
 
-**data** TransferCommand_ExpireResult
+### `data ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-externalpartyamuletrules-transfercommandexpireresult-27948">
->
-> TransferCommand_ExpireResult
->
-> </div>
->
-> > | Field  | Type                                                                                                                | Description |
-> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | nonce  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommand_ExpireResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommand_ExpireResult
->
-> **instance** GetField "nonce" TransferCommand_ExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "sender" TransferCommand_ExpireResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "nonce" TransferCommand_ExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "sender" TransferCommand_ExpireResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferCommand TransferCommand_Expire TransferCommand_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferCommand TransferCommand_Expire TransferCommand_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferCommand TransferCommand_Expire TransferCommand_ExpireResult
+<span id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-31907"></span>
 
-<div id="type-splice-externalpartyamuletrules-transfercommandsendresult-21916">
+- `ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
 
-**data** TransferCommand_SendResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [AmuletAllocation_DsoExpireResult] |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-externalpartyamuletrules-transfercommandsendresult-15277">
->
-> TransferCommand_SendResult
->
-> </div>
->
-> > | Field  | Type                                                                                                                | Description |
-> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | result | TransferCommandResult                                                                                               |             |
-> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | nonce  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommand_SendResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommand_SendResult
->
-> **instance** GetField "nonce" TransferCommand_SendResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "result" TransferCommand_SendResult TransferCommandResult
->
-> **instance** GetField "sender" TransferCommand_SendResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "nonce" TransferCommand_SendResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "result" TransferCommand_SendResult TransferCommandResult
->
-> **instance** SetField "sender" TransferCommand_SendResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferCommand TransferCommand_Send TransferCommand_SendResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferCommand TransferCommand_Send TransferCommand_SendResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferCommand TransferCommand_Send TransferCommand_SendResult
+- `instance Eq ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance Show ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance GetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance SetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance HasExercise ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance HasFromAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance HasToAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
 
-<div id="type-splice-externalpartyamuletrules-transfercommandwithdrawresult-60664">
+<span id="type-splice-externalpartyamuletrules-transfercommandresult-23924"></span>
 
-**data** TransferCommand_WithdrawResult
+### `data TransferCommandResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-externalpartyamuletrules-transfercommandwithdrawresult-93393">
->
-> TransferCommand_WithdrawResult
->
-> </div>
->
-> > | Field  | Type                                                                                                                | Description |
-> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | nonce  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommand_WithdrawResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommand_WithdrawResult
->
-> **instance** GetField "nonce" TransferCommand_WithdrawResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "sender" TransferCommand_WithdrawResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "nonce" TransferCommand_WithdrawResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "sender" TransferCommand_WithdrawResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult
+<span id="constr-splice-externalpartyamuletrules-transfercommandresultfailure-75214"></span>
+
+- `TransferCommandResultFailure`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | InvalidTransferReason |  |
+
+<span id="constr-splice-externalpartyamuletrules-transfercommandresultsuccess-68641"></span>
+
+- `TransferCommandResultSuccess`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferResult |  |
+
+Instances:
+
+- `instance Eq TransferCommandResult`
+- `instance Show TransferCommandResult`
+- `instance GetField reason TransferCommandResult InvalidTransferReason`
+- `instance GetField result TransferCommandResult TransferResult`
+- `instance GetField result TransferCommand_SendResult TransferCommandResult`
+- `instance SetField reason TransferCommandResult InvalidTransferReason`
+- `instance SetField result TransferCommandResult TransferResult`
+- `instance SetField result TransferCommand_SendResult TransferCommandResult`
+
+<span id="type-splice-externalpartyamuletrules-transfercommandexpireresult-5229"></span>
+
+### `data TransferCommand_ExpireResult`
+
+Constructors:
+
+<span id="constr-splice-externalpartyamuletrules-transfercommandexpireresult-27948"></span>
+
+- `TransferCommand_ExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| nonce | Int |  |
+
+Instances:
+
+- `instance Eq TransferCommand_ExpireResult`
+- `instance Show TransferCommand_ExpireResult`
+- `instance GetField nonce TransferCommand_ExpireResult Int`
+- `instance GetField sender TransferCommand_ExpireResult Party`
+- `instance SetField nonce TransferCommand_ExpireResult Int`
+- `instance SetField sender TransferCommand_ExpireResult Party`
+- `instance HasExercise TransferCommand TransferCommand_Expire TransferCommand_ExpireResult`
+- `instance HasFromAnyChoice TransferCommand TransferCommand_Expire TransferCommand_ExpireResult`
+- `instance HasToAnyChoice TransferCommand TransferCommand_Expire TransferCommand_ExpireResult`
+
+<span id="type-splice-externalpartyamuletrules-transfercommandsendresult-21916"></span>
+
+### `data TransferCommand_SendResult`
+
+Constructors:
+
+<span id="constr-splice-externalpartyamuletrules-transfercommandsendresult-15277"></span>
+
+- `TransferCommand_SendResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferCommandResult |  |
+| sender | Party |  |
+| nonce | Int |  |
+
+Instances:
+
+- `instance Eq TransferCommand_SendResult`
+- `instance Show TransferCommand_SendResult`
+- `instance GetField nonce TransferCommand_SendResult Int`
+- `instance GetField result TransferCommand_SendResult TransferCommandResult`
+- `instance GetField sender TransferCommand_SendResult Party`
+- `instance SetField nonce TransferCommand_SendResult Int`
+- `instance SetField result TransferCommand_SendResult TransferCommandResult`
+- `instance SetField sender TransferCommand_SendResult Party`
+- `instance HasExercise TransferCommand TransferCommand_Send TransferCommand_SendResult`
+- `instance HasFromAnyChoice TransferCommand TransferCommand_Send TransferCommand_SendResult`
+- `instance HasToAnyChoice TransferCommand TransferCommand_Send TransferCommand_SendResult`
+
+<span id="type-splice-externalpartyamuletrules-transfercommandwithdrawresult-60664"></span>
+
+### `data TransferCommand_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-externalpartyamuletrules-transfercommandwithdrawresult-93393"></span>
+
+- `TransferCommand_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| nonce | Int |  |
+
+Instances:
+
+- `instance Eq TransferCommand_WithdrawResult`
+- `instance Show TransferCommand_WithdrawResult`
+- `instance GetField nonce TransferCommand_WithdrawResult Int`
+- `instance GetField sender TransferCommand_WithdrawResult Party`
+- `instance SetField nonce TransferCommand_WithdrawResult Int`
+- `instance SetField sender TransferCommand_WithdrawResult Party`
+- `instance HasExercise TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult`
+- `instance HasFromAnyChoice TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult`
+- `instance HasToAnyChoice TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult`
 
 ## Functions
 
-<div id="function-splice-externalpartyamuletrules-amulettransferfactorytransferimpl-9935">
+<span id="function-splice-externalpartyamuletrules-amulettransferfactorytransferimpl-9935"></span>
 
-amulet_transferFactory_transferImpl
-: ExternalPartyAmuletRules -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
+### `amulet_transferFactory_transferImpl`
 
-</div>
+```daml
+amulet_transferFactory_transferImpl : ExternalPartyAmuletRules -> ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult
+```
 
-<div id="function-splice-externalpartyamuletrules-amuletallocationfactoryallocateimpl-5710">
+<span id="function-splice-externalpartyamuletrules-amuletallocationfactoryallocateimpl-5710"></span>
 
-amulet_allocationFactory_allocateImpl
-: ExternalPartyAmuletRules -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
+### `amulet_allocationFactory_allocateImpl`
 
-</div>
+```daml
+amulet_allocationFactory_allocateImpl : ExternalPartyAmuletRules -> ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult
+```
 
-<div id="function-splice-externalpartyamuletrules-requireexpectedadminmatch-79926">
+<span id="function-splice-externalpartyamuletrules-requireexpectedadminmatch-79926"></span>
 
-requireExpectedAdminMatch
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+### `requireExpectedAdminMatch`
 
-</div>
+```daml
+requireExpectedAdminMatch : Party -> Party -> Update ()
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-externalpartyamuletrules-externalpartyamuletrules-29682"></span>
+
+### Template `ExternalPartyAmuletRules`
+
+Rules contract that can be used in transactions that require signatures
+from an external party. This is intended to get archived and recreated as rarely as possible
+to support long delays between preparing and signing a transaction.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+
+Interface Instances:
+- `AllocationFactory` for `ExternalPartyAmuletRules`
+- `TransferFactory` for `ExternalPartyAmuletRules`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommand-90877"></span>
+
+#### Choice `ExternalPartyAmuletRules_CreateTransferCommand`
+
+Controllers: `sender`
+
+Returns: `ExternalPartyAmuletRules_CreateTransferCommandResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| receiver | Party |  |
+| delegate | Party |  |
+| amount | Decimal |  |
+| expiresAt | Time |  |
+| nonce | Int |  |
+| description | Optional Text |  |
+| expectedDso | Optional Party |  |
+
+<span id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocations-38439"></span>
+
+#### Choice `ExternalPartyAmuletRules_ExpireAmuletAllocations`
+
+Controllers: `dso`
+
+Returns: `ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedDso | Party |  |
+| inputs | [ExternalPartyAmuletRules_ExpireAmuletAllocationInput] |  |
+| observers | [Party] |  |
+
+<span id="type-splice-externalpartyamuletrules-transfercommand-52429"></span>
+
+### Template `TransferCommand`
+
+Deprecated: The token standard transfer APIs now support 24h signing delays so this contract is no longer required.
+
+One-time delegation to execute a transfer to the given receiver
+for the given amount.
+
+Signatories: `sender`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+| receiver | Party |  |
+| delegate | Party | The delegate that actually executes the transfer |
+| amount | Decimal |  |
+| expiresAt | Time | Expiry of the command until when TransferCommand_Send must be called |
+| nonce | Int | Expected nonce value to order and deduplicate concurrent transfers.<br/><br/>Starts at 0 and the next value to use can then be read from TransferCommandCounter and the in-flight TransferCommand contracts. |
+| description | Optional Text |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sender`, `dso`
+
+Returns: `()`
+
+<span id="type-splice-externalpartyamuletrules-transfercommandexpire-28516"></span>
+
+#### Choice `TransferCommand_Expire`
+
+Controllers: `p`
+
+Returns: `TransferCommand_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<span id="type-splice-externalpartyamuletrules-transfercommandsend-32409"></span>
+
+#### Choice `TransferCommand_Send`
+
+Controllers: `delegate`
+
+Returns: `TransferCommand_SendResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| transferPreapprovalCidO | Optional (ContractId TransferPreapproval) |  |
+| transferCounterCid | ContractId TransferCommandCounter |  |
+
+<span id="type-splice-externalpartyamuletrules-transfercommandwithdraw-90837"></span>
+
+#### Choice `TransferCommand_Withdraw`
+
+Controllers: `sender`
+
+Returns: `TransferCommand_WithdrawResult`
+
+<span id="type-splice-externalpartyamuletrules-transfercommandcounter-30214"></span>
+
+### Template `TransferCommandCounter`
+
+A contract tracking the number of completed TransferCommands per sender,
+which is used to determine the nonces used in TransferCommands for deduplication.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+| nextNonce | Int |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate.mdx
@@ -1,38 +1,57 @@
 ---
 title: "Splice.ExternalPartyConfigState"
-description: "Documentation for Splice.ExternalPartyConfigState"
+description: "Reference documentation for Daml module Splice.ExternalPartyConfigState."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-ExternalPartyConfigState.rst" tag="0.6.4" hash="b2e0230d" */}
+<span id="module-splice-externalpartyconfigstate-24656"></span>
+
+# Splice.ExternalPartyConfigState
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Templates
 
-<div id="type-splice-externalpartyconfigstate-externalpartyconfigstate-1378">
+<span id="type-splice-externalpartyconfigstate-externalpartyconfigstate-1378"></span>
 
-**template** ExternalPartyConfigState
+### Template `ExternalPartyConfigState`
 
-</div>
+`ExternalPartyConfigState` stores the configuration required for transfer, allocations, traffic purchases and taps.
+While it exposes a subset of the information also available on `OpenMiningRound`, `ExternalPartyConfigState` contracts
+are active much longer allowing for a 24 delay between preparing and executing a transaction.
 
-> `ExternalPartyConfigState` stores the configuration required for transfer, allocations, traffic purchases and taps. While it exposes a subset of the information also available on `OpenMiningRound`, `ExternalPartyConfigState` contracts are active much longer allowing for a 24 delay between preparing and executing a transaction.
->
-> There are always two `ExternalPartyConfigState` contracts created approximately `externalPartyConfigStateTickDuration` apart from each other and each is active for `2 * externalPartyConfigStateTickDuration`.
->
-> Signatory: dso
->
-> | Field                      | Type                                                                                                                | Description                                                                               |
-> |----------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-> | dso                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                           |
-> | holdingFeesOpenRoundNumber | Round                                                                                                               | The round number to use for charging holding fees for newly created contracts.            |
-> | amuletPrice                | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | Amulet price at the time the config state was created.                                    |
-> | transferConfig             | TransferConfigV2 USD                                                                                                | Transfer config at the time the config state was created.                                 |
-> | targetArchiveAfter         | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Lower bound on the time the contract gets archived, not enforced as a strict upper bound. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+There are always two `ExternalPartyConfigState` contracts created approximately `externalPartyConfigStateTickDuration` apart from each other
+and each is active for `2 * externalPartyConfigStateTickDuration`.
 
-{/* COPIED_END */}
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| holdingFeesOpenRoundNumber | Round | The round number to use for charging holding fees for newly created contracts. |
+| amuletPrice | Decimal | Amulet price at the time the config state was created. |
+| transferConfig | TransferConfigV2 USD | Transfer config at the time the config state was created. |
+| targetArchiveAfter | Time | Lower bound on the time the contract gets archived, not enforced as a strict upper bound. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees.mdx
@@ -1,340 +1,336 @@
 ---
 title: "Splice.Fees"
-description: "Documentation for Splice.Fees"
+description: "Reference documentation for Daml module Splice.Fees."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Fees.rst" tag="0.6.4" hash="2bd77408" */}
+<span id="module-splice-fees-99189"></span>
+
+# Splice.Fees
 
 Utility functions for different kinds of fees.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
-<div id="type-splice-fees-expiringamount-39537">
+<span id="type-splice-fees-expiringamount-39537"></span>
 
-**data** ExpiringAmount
+### `data ExpiringAmount`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-fees-expiringamount-68564">
->
-> ExpiringAmount
->
-> </div>
->
-> > | Field         | Type                                                                                                               | Description |
-> > |---------------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | initialAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
-> > | createdAt     | Round                                                                                                              |             |
-> > | ratePerRound  | RatePerRound                                                                                                       |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExpiringAmount
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ExpiringAmount
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExpiringAmount
->
-> **instance** GetField "amount" Amulet ExpiringAmount
->
-> **instance** GetField "createdAt" ExpiringAmount Round
->
-> **instance** GetField "initialAmount" ExpiringAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "ratePerRound" ExpiringAmount RatePerRound
->
-> **instance** SetField "amount" Amulet ExpiringAmount
->
-> **instance** SetField "createdAt" ExpiringAmount Round
->
-> **instance** SetField "initialAmount" ExpiringAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "ratePerRound" ExpiringAmount RatePerRound
+<span id="constr-splice-fees-expiringamount-68564"></span>
 
-<div id="type-splice-fees-fixedfee-53985">
+- `ExpiringAmount`
 
-**data** FixedFee
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| initialAmount | Decimal |  |
+| createdAt | Round |  |
+| ratePerRound | RatePerRound |  |
 
-</div>
+Instances:
 
-> A fixed fee independent of the action being taken. TODO(M3-90): check whether this name matches usage in financial terms, it probably isn't. Should it be 'flat-fee', 'constantfee', ... ???
->
-> <div id="constr-splice-fees-fixedfee-53900">
->
-> FixedFee
->
-> </div>
->
-> > | Field | Type                                                                                                               | Description |
-> > |-------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | fee   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) FixedFee
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) FixedFee
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) FixedFee
->
-> **instance** GetField "createFee" (TransferConfig unit) FixedFee
->
-> **instance** GetField "fee" FixedFee [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "lockHolderFee" (TransferConfig unit) FixedFee
->
-> **instance** SetField "createFee" (TransferConfig unit) FixedFee
->
-> **instance** SetField "fee" FixedFee [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "lockHolderFee" (TransferConfig unit) FixedFee
->
-> **instance** Patchable FixedFee
+- `instance Eq ExpiringAmount`
+- `instance Ord ExpiringAmount`
+- `instance Show ExpiringAmount`
+- `instance GetField amount Amulet ExpiringAmount`
+- `instance GetField createdAt ExpiringAmount Round`
+- `instance GetField initialAmount ExpiringAmount Decimal`
+- `instance GetField ratePerRound ExpiringAmount RatePerRound`
+- `instance SetField amount Amulet ExpiringAmount`
+- `instance SetField createdAt ExpiringAmount Round`
+- `instance SetField initialAmount ExpiringAmount Decimal`
+- `instance SetField ratePerRound ExpiringAmount RatePerRound`
 
-<div id="type-splice-fees-rateperday-41902">
+<span id="type-splice-fees-fixedfee-53985"></span>
 
-**data** RatePerDay
+### `data FixedFee`
 
-</div>
+A fixed fee independent of the action being taken.
+TODO(M3-90): check whether this name matches usage in financial terms, it probably isn't. Should it be 'flat-fee', 'constantfee', ... ???
 
-> <div id="constr-splice-fees-rateperday-51003">
->
-> RatePerDay
->
-> </div>
->
-> > | Field | Type                                                                                                               | Description |
-> > |-------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | rate  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RatePerDay
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) RatePerDay
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RatePerDay
->
-> **instance** GetField "rate" RatePerDay [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "rate" RatePerDay [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+Constructors:
 
-<div id="type-splice-fees-rateperround-90570">
+<span id="constr-splice-fees-fixedfee-53900"></span>
 
-**data** RatePerRound
+- `FixedFee`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| fee | Decimal |  |
 
-> <div id="constr-splice-fees-rateperround-75691">
->
-> RatePerRound
->
-> </div>
->
-> > | Field | Type                                                                                                               | Description |
-> > |-------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | rate  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RatePerRound
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) RatePerRound
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RatePerRound
->
-> **instance** GetField "holdingFee" (TransferConfig unit) RatePerRound
->
-> **instance** GetField "holdingFee" (TransferConfigV2 unit) RatePerRound
->
-> **instance** GetField "rate" RatePerRound [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "ratePerRound" ExpiringAmount RatePerRound
->
-> **instance** SetField "holdingFee" (TransferConfig unit) RatePerRound
->
-> **instance** SetField "holdingFee" (TransferConfigV2 unit) RatePerRound
->
-> **instance** SetField "rate" RatePerRound [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "ratePerRound" ExpiringAmount RatePerRound
->
-> **instance** Patchable RatePerRound
+Instances:
 
-<div id="type-splice-fees-steppedrate-36691">
+- `instance Patchable FixedFee`
+- `instance Eq FixedFee`
+- `instance Ord FixedFee`
+- `instance Show FixedFee`
+- `instance GetField createFee (TransferConfig unit) FixedFee`
+- `instance GetField fee FixedFee Decimal`
+- `instance GetField lockHolderFee (TransferConfig unit) FixedFee`
+- `instance SetField createFee (TransferConfig unit) FixedFee`
+- `instance SetField fee FixedFee Decimal`
+- `instance SetField lockHolderFee (TransferConfig unit) FixedFee`
 
-**data** SteppedRate
+<span id="type-splice-fees-rateperday-41902"></span>
 
-</div>
+### `data RatePerDay`
 
-> A rate defined as a piecewise linear function, e.g., \`SteppedRate 0.01 \[(100.0, 0.001), (1000.0, 0.0001), (1000000, 0.00001)\] corresponds to 1% of the first 100, 0.1% between 100 and 1000, 0.01% between 1000 and 1000000 and 0.001% for everything above that.
->
-> <div id="constr-splice-fees-steppedrate-72856">
->
-> SteppedRate
->
-> </div>
->
-> > | Field       | Type                                                                                                                                                                                                                                         | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | initialRate | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                           |             |
-> > | steps       | \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\] |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SteppedRate
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) SteppedRate
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SteppedRate
->
-> **instance** GetField "initialRate" SteppedRate [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "steps" SteppedRate \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\]
->
-> **instance** GetField "transferFee" (TransferConfig unit) SteppedRate
->
-> **instance** SetField "initialRate" SteppedRate [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "steps" SteppedRate \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\]
->
-> **instance** SetField "transferFee" (TransferConfig unit) SteppedRate
->
-> **instance** Patchable SteppedRate
+Constructors:
+
+<span id="constr-splice-fees-rateperday-51003"></span>
+
+- `RatePerDay`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rate | Decimal |  |
+
+Instances:
+
+- `instance Eq RatePerDay`
+- `instance Ord RatePerDay`
+- `instance Show RatePerDay`
+- `instance GetField rate RatePerDay Decimal`
+- `instance SetField rate RatePerDay Decimal`
+
+<span id="type-splice-fees-rateperround-90570"></span>
+
+### `data RatePerRound`
+
+Constructors:
+
+<span id="constr-splice-fees-rateperround-75691"></span>
+
+- `RatePerRound`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rate | Decimal |  |
+
+Instances:
+
+- `instance Patchable RatePerRound`
+- `instance Eq RatePerRound`
+- `instance Ord RatePerRound`
+- `instance Show RatePerRound`
+- `instance GetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance GetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance GetField rate RatePerRound Decimal`
+- `instance GetField ratePerRound ExpiringAmount RatePerRound`
+- `instance SetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance SetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance SetField rate RatePerRound Decimal`
+- `instance SetField ratePerRound ExpiringAmount RatePerRound`
+
+<span id="type-splice-fees-steppedrate-36691"></span>
+
+### `data SteppedRate`
+
+A rate defined as a piecewise linear function, e.g.,
+`SteppedRate 0.01 [(100.0, 0.001), (1000.0, 0.0001), (1000000, 0.00001)]
+corresponds to 1% of the first 100, 0.1% between 100 and 1000, 0.01% between 1000 and 1000000
+and 0.001% for everything above that.
+
+Constructors:
+
+<span id="constr-splice-fees-steppedrate-72856"></span>
+
+- `SteppedRate`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| initialRate | Decimal |  |
+| steps | [(Decimal, Decimal)] |  |
+
+Instances:
+
+- `instance Patchable SteppedRate`
+- `instance Eq SteppedRate`
+- `instance Ord SteppedRate`
+- `instance Show SteppedRate`
+- `instance GetField initialRate SteppedRate Decimal`
+- `instance GetField steps SteppedRate [(Decimal, Decimal)]`
+- `instance GetField transferFee (TransferConfig unit) SteppedRate`
+- `instance SetField initialRate SteppedRate Decimal`
+- `instance SetField steps SteppedRate [(Decimal, Decimal)]`
+- `instance SetField transferFee (TransferConfig unit) SteppedRate`
 
 ## Functions
 
-<div id="function-splice-fees-reltimetomicros-80866">
+<span id="function-splice-fees-reltimetomicros-80866"></span>
 
-relTimeToMicros
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `relTimeToMicros`
 
-</div>
+```daml
+relTimeToMicros : RelTime -> Decimal
+```
 
-<div id="function-splice-fees-microsperday-26445">
+<span id="function-splice-fees-microsperday-26445"></span>
 
-microsPerDay
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `microsPerDay`
 
-</div>
+```daml
+microsPerDay : Decimal
+```
 
-<div id="function-splice-fees-reltimetodays-39078">
+<span id="function-splice-fees-reltimetodays-39078"></span>
 
-relTimeToDays
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `relTimeToDays`
 
-</div>
+```daml
+relTimeToDays : RelTime -> Decimal
+```
 
-<div id="function-splice-fees-daystoreltime-342">
+<span id="function-splice-fees-daystoreltime-342"></span>
 
-daysToRelTime
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+### `daysToRelTime`
 
-</div>
+```daml
+daysToRelTime : Decimal -> RelTime
+```
 
-<div id="function-splice-fees-reltimetoseconds-31347">
+<span id="function-splice-fees-reltimetoseconds-31347"></span>
 
-relTimeToSeconds
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `relTimeToSeconds`
 
-</div>
+```daml
+relTimeToSeconds : RelTime -> Decimal
+```
 
-<div id="function-splice-fees-chargerateperround-14136">
+<span id="function-splice-fees-chargerateperround-14136"></span>
 
-chargeRatePerRound
-: RatePerRound -\> RelRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `chargeRatePerRound`
 
-</div>
+```daml
+chargeRatePerRound : RatePerRound -> RelRound -> Decimal
+```
 
-<div id="function-splice-fees-scalerateperround-96257">
+<span id="function-splice-fees-scalerateperround-96257"></span>
 
-scaleRatePerRound
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> RatePerRound -\> RatePerRound
+### `scaleRatePerRound`
+
+```daml
+scaleRatePerRound : Decimal -> RatePerRound -> RatePerRound
+```
 
 Scale a round rate such that
 
-ALL s r dt. s \* chargeRatePerRound r dt = chargeRatePerRound (s `scaleRatePerRound` r) dt
+ALL s r dt. s * chargeRatePerRound r dt = chargeRatePerRound (s `scaleRatePerRound` r) dt
 
-</div>
+<span id="function-splice-fees-positiverateperround-2835"></span>
 
-<div id="function-splice-fees-positiverateperround-2835">
+### `positiveRatePerRound`
 
-positiveRatePerRound
-: RatePerRound -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+positiveRatePerRound : RatePerRound -> Bool
+```
 
-</div>
+<span id="function-splice-fees-scalefixedfee-12994"></span>
 
-<div id="function-splice-fees-scalefixedfee-12994">
+### `scaleFixedFee`
 
-scaleFixedFee
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> FixedFee -\> FixedFee
+```daml
+scaleFixedFee : Decimal -> FixedFee -> FixedFee
+```
 
-</div>
+<span id="function-splice-fees-positivefixedfee-97380"></span>
 
-<div id="function-splice-fees-positivefixedfee-97380">
+### `positiveFixedFee`
 
-positiveFixedFee
-: FixedFee -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+positiveFixedFee : FixedFee -> Bool
+```
 
-</div>
+<span id="function-splice-fees-validsteppedrate-82534"></span>
 
-<div id="function-splice-fees-validsteppedrate-82534">
+### `validSteppedRate`
 
-validSteppedRate
-: SteppedRate -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+validSteppedRate : SteppedRate -> Bool
+```
 
-</div>
+<span id="function-splice-fees-chargesteppedrate-67705"></span>
 
-<div id="function-splice-fees-chargesteppedrate-67705">
+### `chargeSteppedRate`
 
-chargeSteppedRate
-: SteppedRate -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+```daml
+chargeSteppedRate : SteppedRate -> Decimal -> Decimal
+```
 
-</div>
+<span id="function-splice-fees-gochargesteppedrate-62505"></span>
 
-<div id="function-splice-fees-gochargesteppedrate-62505">
+### `goChargeSteppedRate`
 
-goChargeSteppedRate
-: ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)) -\> \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\] -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+```daml
+goChargeSteppedRate : (Decimal, Decimal, Decimal) -> [(Decimal, Decimal)] -> Decimal
+```
 
-</div>
+<span id="function-splice-fees-scalesteppedrate-86486"></span>
 
-<div id="function-splice-fees-scalesteppedrate-86486">
+### `scaleSteppedRate`
 
-scaleSteppedRate
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> SteppedRate -\> SteppedRate
+```daml
+scaleSteppedRate : Decimal -> SteppedRate -> SteppedRate
+```
 
 Scale a fixed-plus-variable rate such that
 
-ALL s r q. s \* chargeSteppedRate r (q/s) = chargeSteppedRate (s `scaleSteppedRate` r) q
+ALL s r q. s * chargeSteppedRate r (q/s) = chargeSteppedRate (s `scaleSteppedRate` r) q
 
-</div>
+<span id="function-splice-fees-validexpiringamount-89306"></span>
 
-<div id="function-splice-fees-validexpiringamount-89306">
+### `validExpiringAmount`
 
-validExpiringAmount
-: ExpiringAmount -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+validExpiringAmount : ExpiringAmount -> Bool
+```
 
-</div>
+<span id="function-splice-fees-expiringamount-85661"></span>
 
-<div id="function-splice-fees-expiringamount-85661">
+### `expiringAmount`
 
-expiringAmount
-: RatePerRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Round -\> ExpiringAmount
+```daml
+expiringAmount : RatePerRound -> Decimal -> Round -> ExpiringAmount
+```
 
 Smart constructor for an expiring amount.
 
-</div>
+<span id="function-splice-fees-getvalueasofround0-94025"></span>
 
-<div id="function-splice-fees-getvalueasofround0-94025">
+### `getValueAsOfRound0`
 
-getValueAsOfRound0
-: ExpiringAmount -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+```daml
+getValueAsOfRound0 : ExpiringAmount -> Decimal
+```
 
-</div>
+<span id="function-splice-fees-chargerateperday-61208"></span>
 
-<div id="function-splice-fees-chargerateperday-61208">
+### `chargeRatePerDay`
 
-chargeRatePerDay
-: RatePerDay -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+```daml
+chargeRatePerDay : RatePerDay -> RelTime -> Decimal
+```
 
-</div>
+<span id="function-splice-fees-rateperroundtorateperday-46486"></span>
 
-<div id="function-splice-fees-rateperroundtorateperday-46486">
+### `ratePerRoundToRatePerDay`
 
-ratePerRoundToRatePerDay
-: RatePerRound -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> RatePerDay
-
-</div>
-
-{/* COPIED_END */}
+```daml
+ratePerRoundToRatePerDay : RatePerRound -> RelTime -> RatePerDay
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance.mdx
@@ -1,288 +1,252 @@
 ---
 title: "Splice.Issuance"
-description: "Documentation for Splice.Issuance"
+description: "Reference documentation for Daml module Splice.Issuance."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Issuance.rst" tag="0.6.4" hash="7bb0bfbc" */}
+<span id="module-splice-issuance-46787"></span>
+
+# Splice.Issuance
 
 Amulet rewards issuance configuration and computation.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
-<div id="type-splice-issuance-issuanceconfig-93012">
+<span id="type-splice-issuance-issuanceconfig-93012"></span>
 
-**data** IssuanceConfig
+### `data IssuanceConfig`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-issuance-issuanceconfig-42917">
->
-> IssuanceConfig
->
-> </div>
->
-> > | Field                        | Type                                                                                                                                                                                                                                              | Description                                                                                                                                                                |
-> > |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | amuletToIssuePerYear         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
-> > | validatorRewardPercentage    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
-> > | appRewardPercentage          | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
-> > | validatorRewardCap           | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
-> > | featuredAppRewardCap         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
-> > | unfeaturedAppRewardCap       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
-> > | optValidatorFaucetCap        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Maximal amount in \$ for the per-validator issuance of validator faucet coupons; Introduced as part of CIP-0003. Will default to 0.00 USD once CIP-0096 becomes effective. |
-> > | optDevelopmentFundPercentage | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Percentage of each mint emission allocated to the Development Fund under CIP-0082.                                                                                         |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) IssuanceConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) IssuanceConfig
->
-> **instance** GetField "amuletToIssuePerYear" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "appRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "featuredAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "issuanceConfig" OpenMiningRound IssuanceConfig
->
-> **instance** GetField "issuanceConfig" SummarizingMiningRound IssuanceConfig
->
-> **instance** GetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
->
-> **instance** GetField "optDevelopmentFundPercentage" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "optValidatorFaucetCap" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "unfeaturedAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "validatorRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "validatorRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amuletToIssuePerYear" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "appRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "featuredAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuanceConfig" OpenMiningRound IssuanceConfig
->
-> **instance** SetField "issuanceConfig" SummarizingMiningRound IssuanceConfig
->
-> **instance** SetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
->
-> **instance** SetField "optDevelopmentFundPercentage" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "optValidatorFaucetCap" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "unfeaturedAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "validatorRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "validatorRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** Patchable IssuanceConfig
+<span id="constr-splice-issuance-issuanceconfig-42917"></span>
 
-<div id="type-splice-issuance-issuancetranche-71318">
+- `IssuanceConfig`
 
-**data** IssuanceTranche
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletToIssuePerYear | Decimal |  |
+| validatorRewardPercentage | Decimal |  |
+| appRewardPercentage | Decimal |  |
+| validatorRewardCap | Decimal |  |
+| featuredAppRewardCap | Decimal |  |
+| unfeaturedAppRewardCap | Decimal |  |
+| optValidatorFaucetCap | Optional Decimal | Maximal amount in $ for the per-validator issuance of validator faucet coupons;<br/><br/>Introduced as part of CIP-0003. Will default to 0.00 USD once CIP-0096 becomes effective. |
+| optDevelopmentFundPercentage | Optional Decimal | Percentage of each mint emission allocated to the Development Fund under CIP-0082. |
 
-</div>
+Instances:
 
-> <div id="constr-splice-issuance-issuancetranche-27573">
->
-> IssuanceTranche
->
-> </div>
->
-> > | Field             | Type                                                                                                               | Description                                            |
-> > |-------------------|--------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-> > | rewardsToIssue    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Total amulets to issue as rewards in this tranche      |
-> > | issuancePerCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Issuence per reward coupon for this tranche            |
-> > | unclaimedRewards  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Amulets to issue in this tranche that were not claimed |
->
-> **instance** GetField "issuancePerCoupon" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "rewardsToIssue" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "unclaimedRewards" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuancePerCoupon" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "rewardsToIssue" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "unclaimedRewards" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+- `instance Patchable IssuanceConfig`
+- `instance Eq IssuanceConfig`
+- `instance Show IssuanceConfig`
+- `instance GetField amuletToIssuePerYear IssuanceConfig Decimal`
+- `instance GetField appRewardPercentage IssuanceConfig Decimal`
+- `instance GetField featuredAppRewardCap IssuanceConfig Decimal`
+- `instance GetField issuanceConfig OpenMiningRound IssuanceConfig`
+- `instance GetField issuanceConfig SummarizingMiningRound IssuanceConfig`
+- `instance GetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance GetField optDevelopmentFundPercentage IssuanceConfig (Optional Decimal)`
+- `instance GetField optValidatorFaucetCap IssuanceConfig (Optional Decimal)`
+- `instance GetField unfeaturedAppRewardCap IssuanceConfig Decimal`
+- `instance GetField validatorRewardCap IssuanceConfig Decimal`
+- `instance GetField validatorRewardPercentage IssuanceConfig Decimal`
+- `instance SetField amuletToIssuePerYear IssuanceConfig Decimal`
+- `instance SetField appRewardPercentage IssuanceConfig Decimal`
+- `instance SetField featuredAppRewardCap IssuanceConfig Decimal`
+- `instance SetField issuanceConfig OpenMiningRound IssuanceConfig`
+- `instance SetField issuanceConfig SummarizingMiningRound IssuanceConfig`
+- `instance SetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance SetField optDevelopmentFundPercentage IssuanceConfig (Optional Decimal)`
+- `instance SetField optValidatorFaucetCap IssuanceConfig (Optional Decimal)`
+- `instance SetField unfeaturedAppRewardCap IssuanceConfig Decimal`
+- `instance SetField validatorRewardCap IssuanceConfig Decimal`
+- `instance SetField validatorRewardPercentage IssuanceConfig Decimal`
 
-<div id="type-splice-issuance-issuingroundparameters-47575">
+<span id="type-splice-issuance-issuancetranche-71318"></span>
 
-**data** IssuingRoundParameters
+### `data IssuanceTranche`
 
-</div>
+Constructors:
 
-> Parameters to use in a round that issues amulet as rewards for collected coupons.
->
-> <div id="constr-splice-issuance-issuingroundparameters-60486">
->
-> IssuingRoundParameters
->
-> </div>
->
-> > | Field                                | Type                                                                                                                                                                                                                                              | Description                                                                                                                                             |
-> > |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | issuancePerValidatorRewardCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | issuancePerFeaturedAppRewardCoupon   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | issuancePerUnfeaturedAppRewardCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | issuancePerSvRewardCoupon            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | unclaimedAppRewards                  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | unclaimedValidatorRewards            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | unclaimedSvRewards                   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Can be non-zero due to rounding, or no SV having had the chance to claim their coupons.                                                                 |
-> > | issuancePerValidatorFaucetCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
-> > | optAmuletsToIssueToDevelopmentFund   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Note: Made optional as the addition of this field is checked by the upgrade checker on package upload because `IssuingRoundParameters` is serializable. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) IssuingRoundParameters
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) IssuingRoundParameters
->
-> **instance** GetField "issuancePerFeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "issuancePerSvRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "issuancePerUnfeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "issuancePerValidatorFaucetCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "issuancePerValidatorRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "optAmuletsToIssueToDevelopmentFund" IssuingRoundParameters ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** GetField "unclaimedAppRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "unclaimedSvRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "unclaimedValidatorRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuancePerFeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuancePerSvRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuancePerUnfeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuancePerValidatorFaucetCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "issuancePerValidatorRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "optAmuletsToIssueToDevelopmentFund" IssuingRoundParameters ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
->
-> **instance** SetField "unclaimedAppRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "unclaimedSvRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "unclaimedValidatorRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+<span id="constr-splice-issuance-issuancetranche-27573"></span>
 
-<div id="type-splice-issuance-openminingroundsummary-90943">
+- `IssuanceTranche`
 
-**data** OpenMiningRoundSummary
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rewardsToIssue | Decimal | Total amulets to issue as rewards in this tranche |
+| issuancePerCoupon | Decimal | Issuence per reward coupon for this tranche |
+| unclaimedRewards | Decimal | Amulets to issue in this tranche that were not claimed |
 
-</div>
+Instances:
 
-> A summary of total reward coupons issued against a specific open mining round.
->
-> <div id="constr-splice-issuance-openminingroundsummary-16618">
->
-> OpenMiningRoundSummary
->
-> </div>
->
-> > | Field                           | Type                                                                                                                                                                                                                                      | Description                  |
-> > |---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
-> > | totalValidatorRewardCoupons     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                              |
-> > | totalFeaturedAppRewardCoupons   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                              |
-> > | totalUnfeaturedAppRewardCoupons | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                              |
-> > | totalSvRewardWeight             | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                |                              |
-> > | optTotalValidatorFaucetCoupons  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Introduced as part of CIP-3. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) OpenMiningRoundSummary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) OpenMiningRoundSummary
->
-> **instance** GetField "optTotalValidatorFaucetCoupons" OpenMiningRoundSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
->
-> **instance** GetField "summary" AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary
->
-> **instance** GetField "totalFeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalSvRewardWeight" OpenMiningRoundSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "totalUnfeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "totalValidatorRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "optTotalValidatorFaucetCoupons" OpenMiningRoundSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
->
-> **instance** SetField "summary" AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary
->
-> **instance** SetField "totalFeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalSvRewardWeight" OpenMiningRoundSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "totalUnfeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "totalValidatorRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+- `instance GetField issuancePerCoupon IssuanceTranche Decimal`
+- `instance GetField rewardsToIssue IssuanceTranche Decimal`
+- `instance GetField unclaimedRewards IssuanceTranche Decimal`
+- `instance SetField issuancePerCoupon IssuanceTranche Decimal`
+- `instance SetField rewardsToIssue IssuanceTranche Decimal`
+- `instance SetField unclaimedRewards IssuanceTranche Decimal`
+
+<span id="type-splice-issuance-issuingroundparameters-47575"></span>
+
+### `data IssuingRoundParameters`
+
+Parameters to use in a round that issues amulet as rewards for collected coupons.
+
+Constructors:
+
+<span id="constr-splice-issuance-issuingroundparameters-60486"></span>
+
+- `IssuingRoundParameters`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issuancePerValidatorRewardCoupon | Decimal |  |
+| issuancePerFeaturedAppRewardCoupon | Decimal |  |
+| issuancePerUnfeaturedAppRewardCoupon | Decimal |  |
+| issuancePerSvRewardCoupon | Decimal |  |
+| unclaimedAppRewards | Decimal |  |
+| unclaimedValidatorRewards | Decimal |  |
+| unclaimedSvRewards | Decimal | Can be non-zero due to rounding, or no SV having had the chance to claim their coupons. |
+| issuancePerValidatorFaucetCoupon | Decimal |  |
+| optAmuletsToIssueToDevelopmentFund | Optional Decimal | Note: Made optional as the addition of this field is checked by the upgrade checker<br/><br/>on package upload because `IssuingRoundParameters` is serializable. |
+
+Instances:
+
+- `instance Eq IssuingRoundParameters`
+- `instance Show IssuingRoundParameters`
+- `instance GetField issuancePerFeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerSvRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerUnfeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerValidatorFaucetCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerValidatorRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField optAmuletsToIssueToDevelopmentFund IssuingRoundParameters (Optional Decimal)`
+- `instance GetField unclaimedAppRewards IssuingRoundParameters Decimal`
+- `instance GetField unclaimedSvRewards IssuingRoundParameters Decimal`
+- `instance GetField unclaimedValidatorRewards IssuingRoundParameters Decimal`
+- `instance SetField issuancePerFeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerSvRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerUnfeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerValidatorFaucetCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerValidatorRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField optAmuletsToIssueToDevelopmentFund IssuingRoundParameters (Optional Decimal)`
+- `instance SetField unclaimedAppRewards IssuingRoundParameters Decimal`
+- `instance SetField unclaimedSvRewards IssuingRoundParameters Decimal`
+- `instance SetField unclaimedValidatorRewards IssuingRoundParameters Decimal`
+
+<span id="type-splice-issuance-openminingroundsummary-90943"></span>
+
+### `data OpenMiningRoundSummary`
+
+A summary of total reward coupons issued against a specific open mining round.
+
+Constructors:
+
+<span id="constr-splice-issuance-openminingroundsummary-16618"></span>
+
+- `OpenMiningRoundSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| totalValidatorRewardCoupons | Decimal |  |
+| totalFeaturedAppRewardCoupons | Decimal |  |
+| totalUnfeaturedAppRewardCoupons | Decimal |  |
+| totalSvRewardWeight | Int |  |
+| optTotalValidatorFaucetCoupons | Optional Int | Introduced as part of CIP-3. |
+
+Instances:
+
+- `instance Eq OpenMiningRoundSummary`
+- `instance Show OpenMiningRoundSummary`
+- `instance GetField optTotalValidatorFaucetCoupons OpenMiningRoundSummary (Optional Int)`
+- `instance GetField summary AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary`
+- `instance GetField totalFeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance GetField totalSvRewardWeight OpenMiningRoundSummary Int`
+- `instance GetField totalUnfeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance GetField totalValidatorRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance SetField optTotalValidatorFaucetCoupons OpenMiningRoundSummary (Optional Int)`
+- `instance SetField summary AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary`
+- `instance SetField totalFeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance SetField totalSvRewardWeight OpenMiningRoundSummary Int`
+- `instance SetField totalUnfeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance SetField totalValidatorRewardCoupons OpenMiningRoundSummary Decimal`
 
 ## Functions
 
-<div id="function-splice-issuance-getvalidatorfaucetcap-50474">
+<span id="function-splice-issuance-getvalidatorfaucetcap-50474"></span>
 
-getValidatorFaucetCap
-: IssuanceConfig -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `getValidatorFaucetCap`
 
-Getter with the right default value for the validator faucet cap. Use this consistently instead of accessing the field directly.
+```daml
+getValidatorFaucetCap : IssuanceConfig -> Decimal
+```
 
-</div>
+Getter with the right default value for the validator faucet cap.
+Use this consistently instead of accessing the field directly.
 
-<div id="function-splice-issuance-validissuancecurve-81463">
+<span id="function-splice-issuance-validissuancecurve-81463"></span>
 
-validIssuanceCurve
-: Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validIssuanceCurve`
 
-</div>
+```daml
+validIssuanceCurve : Schedule RelTime IssuanceConfig -> Bool
+```
 
-<div id="function-splice-issuance-validissuanceconfig-25363">
+<span id="function-splice-issuance-validissuanceconfig-25363"></span>
 
-validIssuanceConfig
-: IssuanceConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validIssuanceConfig`
 
-</div>
+```daml
+validIssuanceConfig : IssuanceConfig -> Bool
+```
 
-<div id="function-splice-issuance-gettotalvalidatorfaucetcoupons-98130">
+<span id="function-splice-issuance-gettotalvalidatorfaucetcoupons-98130"></span>
 
-getTotalValidatorFaucetCoupons
-: OpenMiningRoundSummary -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+### `getTotalValidatorFaucetCoupons`
 
-</div>
+```daml
+getTotalValidatorFaucetCoupons : OpenMiningRoundSummary -> Int
+```
 
-<div id="function-splice-issuance-validateopenminingroundsummary-65797">
+<span id="function-splice-issuance-validateopenminingroundsummary-65797"></span>
 
-validateOpenMiningRoundSummary
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> OpenMiningRoundSummary -\> m ()
+### `validateOpenMiningRoundSummary`
 
-</div>
+```daml
+validateOpenMiningRoundSummary : CanAssert m => OpenMiningRoundSummary -> m ()
+```
 
-<div id="function-splice-issuance-computeissuingroundparameters-5863">
+<span id="function-splice-issuance-computeissuingroundparameters-5863"></span>
 
-computeIssuingRoundParameters
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> IssuanceConfig -\> OpenMiningRoundSummary -\> IssuingRoundParameters
+### `computeIssuingRoundParameters`
 
-</div>
+```daml
+computeIssuingRoundParameters : RelTime -> Decimal -> IssuanceConfig -> OpenMiningRoundSummary -> IssuingRoundParameters
+```
 
-<div id="function-splice-issuance-computeissuancetranche-10230">
+<span id="function-splice-issuance-computeissuancetranche-10230"></span>
 
-computeIssuanceTranche
-: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> IssuanceTranche
+### `computeIssuanceTranche`
+
+```daml
+computeIssuanceTranche : Decimal -> Decimal -> Decimal -> IssuanceTranche
+```
 
 `computeIssuanceTranche rewardsToIssue capPerCoupon totalCoupons`
 
-computes parameters that issue as many rewards per coupon as possible up to a maximum of `capPerCoupon` amulets.
-
-</div>
-
-{/* COPIED_END */}
+computes parameters that issue as many rewards per coupon as possible up to
+a maximum of `capPerCoupon` amulets.

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround.mdx
@@ -1,54 +1,69 @@
 ---
 title: "Splice.RelRound"
-description: "Documentation for Splice.RelRound"
+description: "Reference documentation for Daml module Splice.RelRound."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-RelRound.rst" tag="0.6.4" hash="e41bbbfd" */}
+<span id="module-splice-relround-92157"></span>
+
+# Splice.RelRound
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-relround-relround-10584">
+<span id="type-splice-relround-relround-10584"></span>
 
-**data** RelRound
+### `data RelRound`
 
-</div>
+The equivalent of RelTime for rounds, i.e., a delta between
+two rounds
 
-> The equivalent of RelTime for rounds, i.e., a delta between two rounds
->
-> <div id="constr-splice-relround-relround-94237">
->
-> RelRound
->
-> </div>
->
-> > | Field | Type                                                                                                       | Description |
-> > |-------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | diff  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RelRound
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) RelRound
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RelRound
->
-> **instance** GetField "diff" RelRound [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "diff" RelRound [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+Constructors:
+
+<span id="constr-splice-relround-relround-94237"></span>
+
+- `RelRound`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| diff | Int |  |
+
+Instances:
+
+- `instance Eq RelRound`
+- `instance Ord RelRound`
+- `instance Show RelRound`
+- `instance GetField diff RelRound Int`
+- `instance SetField diff RelRound Int`
 
 ## Functions
 
-<div id="function-splice-relround-addrelround-11446">
+<span id="function-splice-relround-addrelround-11446"></span>
 
-addRelRound
-: Round -\> RelRound -\> Round
+### `addRelRound`
 
-</div>
+```daml
+addRelRound : Round -> RelRound -> Round
+```
 
-<div id="function-splice-relround-subround-39329">
+<span id="function-splice-relround-subround-39329"></span>
 
-subRound
-: Round -\> Round -\> RelRound
+### `subRound`
 
-</div>
-
-{/* COPIED_END */}
+```daml
+subRound : Round -> Round -> RelRound
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round.mdx
@@ -1,158 +1,181 @@
 ---
 title: "Splice.Round"
-description: "Documentation for Splice.Round"
+description: "Reference documentation for Daml module Splice.Round."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Round.rst" tag="0.6.4" hash="a941ba90" */}
+<span id="module-splice-round-72925"></span>
 
-## Templates
+# Splice.Round
 
-<div id="type-splice-round-closedmininground-12506">
+## Module Snapshot
 
-**template** ClosedMiningRound
-
-</div>
-
-> A record that a specific mining round has been closed, which can be used to archive expired rewards.
->
-> Signatory: dso
->
-> | Field                                | Type                                                                                                                                                                                                                                              | Description         |
-> |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
-> | dso                                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                     |
-> | round                                | Round                                                                                                                                                                                                                                             |                     |
-> | issuancePerValidatorRewardCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
-> | issuancePerFeaturedAppRewardCoupon   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
-> | issuancePerUnfeaturedAppRewardCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
-> | issuancePerSvRewardCoupon            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
-> | optIssuancePerValidatorFaucetCoupon  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Introduced in CIP-3 |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-round-issuingmininground-98097">
-
-**template** IssuingMiningRound
-
-</div>
-
-> A mining round for whose rewards amulets are being issued.
->
-> Signatory: dso
->
-> | Field                                | Type                                                                                                                                                                                                                                              | Description                                                                                                       |
-> |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-> | dso                                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                                                                                                                   |
-> | round                                | Round                                                                                                                                                                                                                                             |                                                                                                                   |
-> | issuancePerValidatorRewardCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
-> | issuancePerFeaturedAppRewardCoupon   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
-> | issuancePerUnfeaturedAppRewardCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
-> | issuancePerSvRewardCoupon            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
-> | opensAt                              | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                 | Time after which rewards from this mining round can be collected                                                  |
-> | targetClosesAt                       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                 | Time when this round is expected to close during standard DSO. The round SHOULD NOT be archived before this time. |
-> | optIssuancePerValidatorFaucetCoupon  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Introduced in CIP-3                                                                                               |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-round-openmininground-90060">
-
-**template** OpenMiningRound
-
-</div>
-
-> A mining round for which new rewards can be registered. Note that multiple mining rounds can be open at the same time to give some time for propagating a new open round, while still registering rewards against the previous open round.
->
-> Signatory: dso
->
-> | Field             | Type                                                                                                                   | Description                                                                                                               |
-> |-------------------|------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-> | dso               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)    |                                                                                                                           |
-> | round             | Round                                                                                                                  |                                                                                                                           |
-> | amuletPrice       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     |                                                                                                                           |
-> | opensAt           | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      | Time after which transfers can use this mining round                                                                      |
-> | targetClosesAt    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      | Time when this round is expected to be closed as part of standard DSO. The round SHOULD NOT be archived before this time. |
-> | issuingFor        | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Timepoint on the issuance curve that was used to determing the issuance configuration for this round.                     |
-> | transferConfigUsd | TransferConfig USD                                                                                                     | Configuration determining the fees and limits in USD for Amulet transfers                                                 |
-> | issuanceConfig    | IssuanceConfig                                                                                                         | Configuration for issuance of this round.                                                                                 |
-> | tickDuration      | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Duration of a tick, which is the duration of half a round.                                                                |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-round-openminingroundfetch-48019">
->
->   **Choice** OpenMiningRound_Fetch
->
->   </div>
->
->   Controller: p
->
->   Returns: OpenMiningRound
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-
-<div id="type-splice-round-summarizingmininground-36579">
-
-**template** SummarizingMiningRound
-
-</div>
-
-> A mining round for which the total sum of registered rewards is being computed. Rewards can no longer be registered aginst such a round.
->
-> Signatory: dso
->
-> | Field          | Type                                                                                                                   | Description |
-> |----------------|------------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)    |             |
-> | round          | Round                                                                                                                  |             |
-> | amuletPrice    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     |             |
-> | issuanceConfig | IssuanceConfig                                                                                                         |             |
-> | tickDuration   | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Functions
 
-<div id="function-splice-round-getissuingminingroundissuancepervalidatorfaucetcoupon-99508">
+<span id="function-splice-round-getissuingminingroundissuancepervalidatorfaucetcoupon-99508"></span>
 
-getIssuingMiningRoundIssuancePerValidatorFaucetCoupon
-: IssuingMiningRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `getIssuingMiningRoundIssuancePerValidatorFaucetCoupon`
 
-Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
-
-</div>
-
-<div id="function-splice-round-getclosedminingroundissuancepervalidatorfaucetcoupon-25673">
-
-getClosedMiningRoundIssuancePerValidatorFaucetCoupon
-: ClosedMiningRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+```daml
+getIssuingMiningRoundIssuancePerValidatorFaucetCoupon : IssuingMiningRound -> Decimal
+```
 
 Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
 
-</div>
+<span id="function-splice-round-getclosedminingroundissuancepervalidatorfaucetcoupon-25673"></span>
 
-{/* COPIED_END */}
+### `getClosedMiningRoundIssuancePerValidatorFaucetCoupon`
+
+```daml
+getClosedMiningRoundIssuancePerValidatorFaucetCoupon : ClosedMiningRound -> Decimal
+```
+
+Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
+
+## Templates
+
+<span id="type-splice-round-closedmininground-12506"></span>
+
+### Template `ClosedMiningRound`
+
+A record that a specific mining round has been closed, which can
+be used to archive expired rewards.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| issuancePerValidatorRewardCoupon | Decimal |  |
+| issuancePerFeaturedAppRewardCoupon | Decimal |  |
+| issuancePerUnfeaturedAppRewardCoupon | Decimal |  |
+| issuancePerSvRewardCoupon | Decimal |  |
+| optIssuancePerValidatorFaucetCoupon | Optional Decimal | Introduced in CIP-3 |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-round-issuingmininground-98097"></span>
+
+### Template `IssuingMiningRound`
+
+A mining round for whose rewards amulets are being issued.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| issuancePerValidatorRewardCoupon | Decimal |  |
+| issuancePerFeaturedAppRewardCoupon | Decimal |  |
+| issuancePerUnfeaturedAppRewardCoupon | Decimal |  |
+| issuancePerSvRewardCoupon | Decimal |  |
+| opensAt | Time | Time after which rewards from this mining round can be collected |
+| targetClosesAt | Time | Time when this round is expected to close during standard DSO. The round SHOULD NOT be archived before this time. |
+| optIssuancePerValidatorFaucetCoupon | Optional Decimal | Introduced in CIP-3 |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-round-openmininground-90060"></span>
+
+### Template `OpenMiningRound`
+
+A mining round for which new rewards can be registered.
+Note that multiple mining rounds can be open at the same time to give some
+time for propagating a new open round, while still registering rewards
+against the previous open round.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| amuletPrice | Decimal |  |
+| opensAt | Time | Time after which transfers can use this mining round |
+| targetClosesAt | Time | Time when this round is expected to be closed as part of standard DSO. The round SHOULD NOT be archived before this time. |
+| issuingFor | RelTime | Timepoint on the issuance curve that was used to determing the issuance configuration for this round. |
+| transferConfigUsd | TransferConfig USD | Configuration determining the fees and limits in USD for Amulet transfers |
+| issuanceConfig | IssuanceConfig | Configuration for issuance of this round. |
+| tickDuration | RelTime | Duration of a tick, which is the duration of half a round. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-round-openminingroundfetch-48019"></span>
+
+#### Choice `OpenMiningRound_Fetch`
+
+Controllers: `p`
+
+Returns: `OpenMiningRound`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<span id="type-splice-round-summarizingmininground-36579"></span>
+
+### Template `SummarizingMiningRound`
+
+A mining round for which the total sum of registered rewards
+is being computed. Rewards can no longer be registered aginst such a round.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| amuletPrice | Decimal |  |
+| issuanceConfig | IssuanceConfig |  |
+| tickDuration | RelTime |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule.mdx
@@ -1,131 +1,146 @@
 ---
 title: "Splice.Schedule"
-description: "Documentation for Splice.Schedule"
+description: "Reference documentation for Daml module Splice.Schedule."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Schedule.rst" tag="0.6.4" hash="208c08b7" */}
+<span id="module-splice-schedule-45837"></span>
+
+# Splice.Schedule
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-schedule-schedule-35504">
+<span id="type-splice-schedule-schedule-35504"></span>
 
-**data** Schedule t a
+### `data Schedule t a`
 
-</div>
+A schedule of values that change over time.
 
-> A schedule of values that change over time.
->
-> <div id="constr-splice-schedule-schedule-12101">
->
-> Schedule
->
-> </div>
->
-> > | Field        | Type       | Description                                                    |
-> > |--------------|------------|----------------------------------------------------------------|
-> > | initialValue | a          | Initial value to use until the future values come into effect. |
-> > | futureValues | \[(t, a)\] | sorted in ascending order                                      |
->
-> **instance** [Functor](/appdev/reference/daml-standard-library/prelude#class-ghc-base-functor-31205) (Schedule t)
->
-> **instance** ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) t) =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (Schedule t a)
->
-> **instance** ([Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) t) =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (Schedule t a)
->
-> **instance** GetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
->
-> **instance** GetField "futureValues" (Schedule t a) \[(t, a)\]
->
-> **instance** GetField "initialValue" (Schedule t a) a
->
-> **instance** GetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
->
-> **instance** SetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
->
-> **instance** SetField "futureValues" (Schedule t a) \[(t, a)\]
->
-> **instance** SetField "initialValue" (Schedule t a) a
->
-> **instance** SetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
->
-> **instance** (Patchable t, Patchable a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t, [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a) =\> Patchable (Schedule t a)
+Constructors:
+
+<span id="constr-splice-schedule-schedule-12101"></span>
+
+- `Schedule`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| initialValue | a | Initial value to use until the future values come into effect. |
+| futureValues | [(t, a)] | sorted in ascending order |
+
+Instances:
+
+- `instance (Patchable t, Patchable a, Ord t, Eq a) => Patchable (Schedule t a)`
+- `instance Functor (Schedule t)`
+- `instance (Eq a, Eq t) => Eq (Schedule t a)`
+- `instance (Show a, Show t) => Show (Schedule t a)`
+- `instance GetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance GetField futureValues (Schedule t a) [(t, a)]`
+- `instance GetField initialValue (Schedule t a) a`
+- `instance GetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance SetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance SetField futureValues (Schedule t a) [(t, a)]`
+- `instance SetField initialValue (Schedule t a) a`
+- `instance SetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
 
 ## Functions
 
-<div id="function-splice-schedule-getvalueasof-1611">
+<span id="function-splice-schedule-getvalueasof-1611"></span>
 
-getValueAsOf
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> a
+### `getValueAsOf`
+
+```daml
+getValueAsOf : Ord t => t -> Schedule t a -> a
+```
 
 Get the value as of a specific time
 
-</div>
+<span id="function-splice-schedule-getvalueasofledgertime-35649"></span>
 
-<div id="function-splice-schedule-getvalueasofledgertime-35649">
+### `getValueAsOfLedgerTime`
 
-getValueAsOfLedgerTime
-: Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) a -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) a
+```daml
+getValueAsOfLedgerTime : Schedule Time a -> Update a
+```
 
 Variant of `getValueAsOf` that communicates workflow-level bounds.
 
-</div>
+<span id="function-splice-schedule-validschedule-3679"></span>
 
-<div id="function-splice-schedule-validschedule-3679">
+### `validSchedule`
 
-validSchedule
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> Schedule t a -\> (a -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+validSchedule : Ord t => Schedule t a -> (a -> Bool) -> Bool
+```
 
 Check the validity of a schedule given a function to check the validity of its values
 
-</div>
+<span id="function-splice-schedule-allvalues-28049"></span>
 
-<div id="function-splice-schedule-allvalues-28049">
+### `allValues`
 
-allValues
-: Schedule t a -\> \[a\]
+```daml
+allValues : Schedule t a -> [a]
+```
 
-</div>
+<span id="function-splice-schedule-nextchangescheduledat-43849"></span>
 
-<div id="function-splice-schedule-nextchangescheduledat-43849">
+### `nextChangeScheduledAt`
 
-nextChangeScheduledAt
-: Schedule t a -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) t
+```daml
+nextChangeScheduledAt : Schedule t a -> Optional t
+```
 
-</div>
+<span id="function-splice-schedule-prune-18462"></span>
 
-<div id="function-splice-schedule-prune-18462">
+### `prune`
 
-prune
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> Schedule t a
+```daml
+prune : Ord t => t -> Schedule t a -> Schedule t a
+```
 
-</div>
+<span id="function-splice-schedule-splitattime-35540"></span>
 
-<div id="function-splice-schedule-splitattime-35540">
+### `splitAtTime`
 
-splitAtTime
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> \[(t, a)\] -\> t -\> (\[(t, a)\], [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) (t, a), \[(t, a)\])
+```daml
+splitAtTime : Ord t => [(t, a)] -> t -> ([(t, a)], Optional (t, a), [(t, a)])
+```
 
-</div>
+<span id="function-splice-schedule-insert-53714"></span>
 
-<div id="function-splice-schedule-insert-53714">
+### `insert`
 
-insert
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> (t, a) -\> Schedule t a -\> Schedule t a
+```daml
+insert : Ord t => (t, a) -> Schedule t a -> Schedule t a
+```
 
-</div>
+<span id="function-splice-schedule-remove-70441"></span>
 
-<div id="function-splice-schedule-remove-70441">
+### `remove`
 
-remove
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> Schedule t a
+```daml
+remove : Ord t => t -> Schedule t a -> Schedule t a
+```
 
-</div>
+<span id="function-splice-schedule-update-39134"></span>
 
-<div id="function-splice-schedule-update-39134">
+### `update`
 
-update
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> (t, a) -\> Schedule t a -\> Schedule t a
-
-</div>
-
-{/* COPIED_END */}
+```daml
+update : Ord t => (t, a) -> Schedule t a -> Schedule t a
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types.mdx
@@ -1,299 +1,220 @@
 ---
 title: "Splice.Types"
-description: "Documentation for Splice.Types"
+description: "Reference documentation for Daml module Splice.Types."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Types.rst" tag="0.6.4" hash="710711fb" */}
+<span id="module-splice-types-4572"></span>
+
+# Splice.Types
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-types-fordso-8725">
+<span id="type-splice-types-fordso-8725"></span>
 
-**data** ForDso
+### `data ForDso`
 
-</div>
+The group of contracts managed by the DSO party.
 
-> The group of contracts managed by the DSO party.
->
-> Used for checked fetches.
->
-> <div id="constr-splice-types-fordso-8586">
->
-> ForDso
->
-> </div>
->
-> > | Field | Type                                                                                                                | Description |
-> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForDso
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForDso
->
-> **instance** GetField "dso" ForDso [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "dso" ForDso [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** HasCheckedFetch DevelopmentFundCoupon ForDso
->
-> **instance** HasCheckedFetch FeaturedAppActivityMarker ForDso
->
-> **instance** HasCheckedFetch UnclaimedDevelopmentFundCoupon ForDso
->
-> **instance** HasCheckedFetch UnclaimedReward ForDso
->
-> **instance** HasCheckedFetch ValidatorRewardCoupon ForDso
->
-> **instance** HasCheckedFetch AmuletAllocation ForDso
->
-> **instance** HasCheckedFetch AmuletRules ForDso
->
-> **instance** HasCheckedFetch MemberTraffic ForDso
->
-> **instance** HasCheckedFetch TransferCommand ForDso
->
-> **instance** HasCheckedFetch ExternalPartyConfigState ForDso
->
-> **instance** HasCheckedFetch ClosedMiningRound ForDso
->
-> **instance** HasCheckedFetch IssuingMiningRound ForDso
->
-> **instance** HasCheckedFetch OpenMiningRound ForDso
->
-> **instance** HasCheckedFetch SummarizingMiningRound ForDso
->
-> **instance** HasCheckedFetch ValidatorLicense ForDso
->
-> **instance** HasCheckedFetch AllocationView ForDso
->
-> **instance** HasCheckedFetch TransferInstructionView ForDso
+Used for checked fetches.
 
-<div id="type-splice-types-forowner-62144">
+Constructors:
 
-**data** ForOwner
+<span id="constr-splice-types-fordso-8586"></span>
 
-</div>
+- `ForDso`
 
-> The group of contracts managed by the DSO party and owned by a specific party.
->
-> Used for checked fetches.
->
-> <div id="constr-splice-types-forowner-89915">
->
-> ForOwner
->
-> </div>
->
-> > | Field | Type                                                                                                                | Description |
-> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | owner | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForOwner
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForOwner
->
-> **instance** GetField "dso" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "owner" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "dso" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "owner" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** HasCheckedFetch Amulet ForOwner
->
-> **instance** HasCheckedFetch AppRewardCoupon ForOwner
->
-> **instance** HasCheckedFetch DevelopmentFundCoupon ForOwner
->
-> **instance** HasCheckedFetch FeaturedAppActivityMarker ForOwner
->
-> **instance** HasCheckedFetch LockedAmulet ForOwner
->
-> **instance** HasCheckedFetch SvRewardCoupon ForOwner
->
-> **instance** HasCheckedFetch UnclaimedActivityRecord ForOwner
->
-> **instance** HasCheckedFetch TransferPreapproval ForOwner
->
-> **instance** HasCheckedFetch TransferCommandCounter ForOwner
->
-> **instance** HasCheckedFetch ValidatorFaucetCoupon ForOwner
->
-> **instance** HasCheckedFetch ValidatorLivenessActivityRecord ForOwner
->
-> **instance** HasCheckedFetch HoldingView ForOwner
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
 
-<div id="type-splice-types-forround-72197">
+Instances:
 
-**data** ForRound
+- `instance HasCheckedFetch DevelopmentFundCoupon ForDso`
+- `instance HasCheckedFetch FeaturedAppActivityMarker ForDso`
+- `instance HasCheckedFetch UnclaimedDevelopmentFundCoupon ForDso`
+- `instance HasCheckedFetch UnclaimedReward ForDso`
+- `instance HasCheckedFetch ValidatorRewardCoupon ForDso`
+- `instance HasCheckedFetch AmuletAllocation ForDso`
+- `instance HasCheckedFetch AmuletRules ForDso`
+- `instance HasCheckedFetch AllocationView ForDso`
+- `instance HasCheckedFetch TransferInstructionView ForDso`
+- `instance HasCheckedFetch MemberTraffic ForDso`
+- `instance HasCheckedFetch TransferCommand ForDso`
+- `instance HasCheckedFetch ExternalPartyConfigState ForDso`
+- `instance HasCheckedFetch ClosedMiningRound ForDso`
+- `instance HasCheckedFetch IssuingMiningRound ForDso`
+- `instance HasCheckedFetch OpenMiningRound ForDso`
+- `instance HasCheckedFetch SummarizingMiningRound ForDso`
+- `instance HasCheckedFetch ValidatorLicense ForDso`
+- `instance Eq ForDso`
+- `instance Show ForDso`
+- `instance GetField dso ForDso Party`
+- `instance SetField dso ForDso Party`
 
-</div>
+<span id="type-splice-types-forowner-62144"></span>
 
-> The group of contracts managed by the DSO party for a specific mining round.
->
-> Used for checked fetches.
->
-> <div id="constr-splice-types-forround-96474">
->
-> ForRound
->
-> </div>
->
-> > | Field | Type                                                                                                                | Description |
-> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | round | Round                                                                                                               |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForRound
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForRound
->
-> **instance** GetField "dso" ForRound [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "round" ForRound Round
->
-> **instance** SetField "dso" ForRound [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "round" ForRound Round
->
-> **instance** HasCheckedFetch ClosedMiningRound ForRound
->
-> **instance** HasCheckedFetch IssuingMiningRound ForRound
->
-> **instance** HasCheckedFetch OpenMiningRound ForRound
->
-> **instance** HasCheckedFetch SummarizingMiningRound ForRound
+### `data ForOwner`
 
-<div id="type-splice-types-round-16181">
+The group of contracts managed by the DSO party and owned by a specific party.
 
-**data** Round
+Used for checked fetches.
 
-</div>
+Constructors:
 
-> <div id="constr-splice-types-round-29804">
->
-> Round
->
-> </div>
->
-> > | Field  | Type                                                                                                       | Description |
-> > |--------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | number | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Round
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) Round
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Round
->
-> **instance** GetField "createdAt" ExpiringAmount Round
->
-> **instance** GetField "firstReceivedFor" FaucetState Round
->
-> **instance** GetField "holdingFeesOpenRoundNumber" ExternalPartyConfigState Round
->
-> **instance** GetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
->
-> **instance** GetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
->
-> **instance** GetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** GetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** GetField "lastReceivedFor" FaucetState Round
->
-> **instance** GetField "number" Round [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "openRoundNumber" TransferContextSummaryV2 Round
->
-> **instance** GetField "round" (AmuletCreateSummary amuletContractId) Round
->
-> **instance** GetField "round" AmuletExpireSummary Round
->
-> **instance** GetField "round" AppRewardCoupon Round
->
-> **instance** GetField "round" SvRewardCoupon Round
->
-> **instance** GetField "round" ValidatorRewardCoupon Round
->
-> **instance** GetField "round" AmuletRules_BuyMemberTrafficResult Round
->
-> **instance** GetField "round" TransferResult Round
->
-> **instance** GetField "round" ClosedMiningRound Round
->
-> **instance** GetField "round" IssuingMiningRound Round
->
-> **instance** GetField "round" OpenMiningRound Round
->
-> **instance** GetField "round" SummarizingMiningRound Round
->
-> **instance** GetField "round" ForRound Round
->
-> **instance** GetField "round" ValidatorFaucetCoupon Round
->
-> **instance** GetField "round" ValidatorLivenessActivityRecord Round
->
-> **instance** SetField "createdAt" ExpiringAmount Round
->
-> **instance** SetField "firstReceivedFor" FaucetState Round
->
-> **instance** SetField "holdingFeesOpenRoundNumber" ExternalPartyConfigState Round
->
-> **instance** SetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
->
-> **instance** SetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
->
-> **instance** SetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** SetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
->
-> **instance** SetField "lastReceivedFor" FaucetState Round
->
-> **instance** SetField "number" Round [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "openRoundNumber" TransferContextSummaryV2 Round
->
-> **instance** SetField "round" (AmuletCreateSummary amuletContractId) Round
->
-> **instance** SetField "round" AmuletExpireSummary Round
->
-> **instance** SetField "round" AppRewardCoupon Round
->
-> **instance** SetField "round" SvRewardCoupon Round
->
-> **instance** SetField "round" ValidatorRewardCoupon Round
->
-> **instance** SetField "round" AmuletRules_BuyMemberTrafficResult Round
->
-> **instance** SetField "round" TransferResult Round
->
-> **instance** SetField "round" ClosedMiningRound Round
->
-> **instance** SetField "round" IssuingMiningRound Round
->
-> **instance** SetField "round" OpenMiningRound Round
->
-> **instance** SetField "round" SummarizingMiningRound Round
->
-> **instance** SetField "round" ForRound Round
->
-> **instance** SetField "round" ValidatorFaucetCoupon Round
->
-> **instance** SetField "round" ValidatorLivenessActivityRecord Round
+<span id="constr-splice-types-forowner-89915"></span>
+
+- `ForOwner`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| owner | Party |  |
+
+Instances:
+
+- `instance HasCheckedFetch Amulet ForOwner`
+- `instance HasCheckedFetch AppRewardCoupon ForOwner`
+- `instance HasCheckedFetch DevelopmentFundCoupon ForOwner`
+- `instance HasCheckedFetch FeaturedAppActivityMarker ForOwner`
+- `instance HasCheckedFetch LockedAmulet ForOwner`
+- `instance HasCheckedFetch SvRewardCoupon ForOwner`
+- `instance HasCheckedFetch UnclaimedActivityRecord ForOwner`
+- `instance HasCheckedFetch TransferPreapproval ForOwner`
+- `instance HasCheckedFetch HoldingView ForOwner`
+- `instance HasCheckedFetch TransferCommandCounter ForOwner`
+- `instance HasCheckedFetch ValidatorFaucetCoupon ForOwner`
+- `instance HasCheckedFetch ValidatorLivenessActivityRecord ForOwner`
+- `instance Eq ForOwner`
+- `instance Show ForOwner`
+- `instance GetField dso ForOwner Party`
+- `instance GetField owner ForOwner Party`
+- `instance SetField dso ForOwner Party`
+- `instance SetField owner ForOwner Party`
+
+<span id="type-splice-types-forround-72197"></span>
+
+### `data ForRound`
+
+The group of contracts managed by the DSO party for a specific mining round.
+
+Used for checked fetches.
+
+Constructors:
+
+<span id="constr-splice-types-forround-96474"></span>
+
+- `ForRound`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+
+Instances:
+
+- `instance HasCheckedFetch ClosedMiningRound ForRound`
+- `instance HasCheckedFetch IssuingMiningRound ForRound`
+- `instance HasCheckedFetch OpenMiningRound ForRound`
+- `instance HasCheckedFetch SummarizingMiningRound ForRound`
+- `instance Eq ForRound`
+- `instance Show ForRound`
+- `instance GetField dso ForRound Party`
+- `instance GetField round ForRound Round`
+- `instance SetField dso ForRound Party`
+- `instance SetField round ForRound Round`
+
+<span id="type-splice-types-round-16181"></span>
+
+### `data Round`
+
+Constructors:
+
+<span id="constr-splice-types-round-29804"></span>
+
+- `Round`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| number | Int |  |
+
+Instances:
+
+- `instance Eq Round`
+- `instance Ord Round`
+- `instance Show Round`
+- `instance GetField createdAt ExpiringAmount Round`
+- `instance GetField firstReceivedFor FaucetState Round`
+- `instance GetField holdingFeesOpenRoundNumber ExternalPartyConfigState Round`
+- `instance GetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance GetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance GetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance GetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance GetField lastReceivedFor FaucetState Round`
+- `instance GetField number Round Int`
+- `instance GetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance GetField round (AmuletCreateSummary amuletContractId) Round`
+- `instance GetField round AmuletExpireSummary Round`
+- `instance GetField round AppRewardCoupon Round`
+- `instance GetField round SvRewardCoupon Round`
+- `instance GetField round ValidatorRewardCoupon Round`
+- `instance GetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance GetField round TransferResult Round`
+- `instance GetField round ClosedMiningRound Round`
+- `instance GetField round IssuingMiningRound Round`
+- `instance GetField round OpenMiningRound Round`
+- `instance GetField round SummarizingMiningRound Round`
+- `instance GetField round ForRound Round`
+- `instance GetField round ValidatorFaucetCoupon Round`
+- `instance GetField round ValidatorLivenessActivityRecord Round`
+- `instance SetField createdAt ExpiringAmount Round`
+- `instance SetField firstReceivedFor FaucetState Round`
+- `instance SetField holdingFeesOpenRoundNumber ExternalPartyConfigState Round`
+- `instance SetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance SetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance SetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance SetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance SetField lastReceivedFor FaucetState Round`
+- `instance SetField number Round Int`
+- `instance SetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance SetField round (AmuletCreateSummary amuletContractId) Round`
+- `instance SetField round AmuletExpireSummary Round`
+- `instance SetField round AppRewardCoupon Round`
+- `instance SetField round SvRewardCoupon Round`
+- `instance SetField round ValidatorRewardCoupon Round`
+- `instance SetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance SetField round TransferResult Round`
+- `instance SetField round ClosedMiningRound Round`
+- `instance SetField round IssuingMiningRound Round`
+- `instance SetField round OpenMiningRound Round`
+- `instance SetField round SummarizingMiningRound Round`
+- `instance SetField round ForRound Round`
+- `instance SetField round ValidatorFaucetCoupon Round`
+- `instance SetField round ValidatorLivenessActivityRecord Round`
 
 ## Functions
 
-<div id="function-splice-types-isdefinedround-76197">
+<span id="function-splice-types-isdefinedround-76197"></span>
 
-isDefinedRound
-: Round -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `isDefinedRound`
+
+```daml
+isDefinedRound : Round -> Bool
+```
 
 Check if a round has a positive round number
-
-</div>
-
-{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense.mdx
@@ -1,513 +1,489 @@
 ---
 title: "Splice.ValidatorLicense"
-description: "Documentation for Splice.ValidatorLicense"
+description: "Reference documentation for Daml module Splice.ValidatorLicense."
 ---
 
-{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-ValidatorLicense.rst" tag="0.6.4" hash="7cb05ace" */}
+<span id="module-splice-validatorlicense-59297"></span>
 
-## Templates
+# Splice.ValidatorLicense
 
-<div id="type-splice-validatorlicense-validatorfaucetcoupon-19254">
+## Module Snapshot
 
-**template** ValidatorFaucetCoupon
-
-</div>
-
-> **Deprecated**: use `ValidatorLicense_RecordValidatorLivenessActivity` instead, as that one can be expired without requiring a confirmation from the validator node.
->
-> Signatory: dso, validator
->
-> | Field     | Type                                                                                                                | Description |
-> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | round     | Round                                                                                                               |             |
->
-> - **Choice** Archive
->
->   Controller: dso, validator
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-validatorlicense-validatorfaucetcoupondsoexpire-65722">
->
->   **Choice** ValidatorFaucetCoupon_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: ValidatorFaucetCoupon_DsoExpireResult
->
->   | Field          | Type                                                                                                                                            | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
-
-<div id="type-splice-validatorlicense-validatorlicense-33456">
-
-**template** ValidatorLicense
-
-</div>
-
-> The existence of a validator license is what makes a validator an (onboarded) validator.
->
-> Signatory: dso
->
-> | Field        | Type                                                                                                                                                                                                                                             | Description                                                                                                       |
-> |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-> | validator    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The validator (party) that this license is about.                                                                 |
-> | sponsor      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The SV node that sponsored the onboarding.                                                                        |
-> | dso          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The party representing the operations of the decentralized synchronizer.                                          |
-> | faucetState  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FaucetState                                                                                                       |                                                                                                                   |
-> | metadata     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ValidatorLicenseMetadata                                                                                          |                                                                                                                   |
-> | lastActiveAt | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Last time this validator was active. Tracked to get a view on the set of validator nodes that are up and running. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-validatorlicense-validatorlicensecancel-74620">
->
->   **Choice** ValidatorLicense_Cancel
->
->   </div>
->
->   Controller: validator
->
->   Returns: ValidatorLicense_CancelResult
->
->   | Field  | Type                                                                                                         | Description |
->   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - <div id="type-splice-validatorlicense-validatorlicensereceivefaucetcoupon-91156">
->
->   **Choice** ValidatorLicense_ReceiveFaucetCoupon
->
->   </div>
->
->   Controller: validator
->
->   Returns: ValidatorLicense_ReceiveFaucetCouponResult
->
->   | Field        | Type                                                                                                                                          | Description |
->   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivity-79262">
->
->   **Choice** ValidatorLicense_RecordValidatorLivenessActivity
->
->   </div>
->
->   Controller: validator
->
->   Returns: ValidatorLicense_RecordValidatorLivenessActivityResult
->
->   | Field        | Type                                                                                                                                          | Description |
->   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
->
-> - <div id="type-splice-validatorlicense-validatorlicensereportactive-46832">
->
->   **Choice** ValidatorLicense_ReportActive
->
->   </div>
->
->   Choice for validators with disabled wallets to report themselves as active. Validators that receive amulets will report through ReceiveFaucetCoupon.
->
->   Controller: validator
->
->   Returns: ValidatorLicense_ReportActiveResult
->
->   (no fields)
->
-> - <div id="type-splice-validatorlicense-validatorlicenseupdatemetadata-65458">
->
->   **Choice** ValidatorLicense_UpdateMetadata
->
->   </div>
->
->   Controller: validator
->
->   Returns: ValidatorLicense_UpdateMetadataResult
->
->   | Field        | Type                                                                                                         | Description |
->   |--------------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | version      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->   | contactPoint | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - <div id="type-splice-validatorlicense-validatorlicensewithdraw-63410">
->
->   **Choice** ValidatorLicense_Withdraw
->
->   </div>
->
->   Controller: dso
->
->   Returns: ValidatorLicense_WithdrawResult
->
->   | Field  | Type                                                                                                         | Description |
->   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
->   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-
-<div id="type-splice-validatorlicense-validatorlivenessactivityrecord-17293">
-
-**template** ValidatorLivenessActivityRecord
-
-</div>
-
-> A copy of the ValidatorFaucetCoupon template with the only difference being that the validator is an observer instead of signatory. This is to allow to expire the coupon without the validator's involvement.
->
-> Signatory: dso
->
-> | Field     | Type                                                                                                                | Description |
-> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | round     | Round                                                                                                               |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpire-78737">
->
->   **Choice** ValidatorLivenessActivityRecord_DsoExpire
->
->   </div>
->
->   Controller: dso
->
->   Returns: ValidatorLivenessActivityRecord_DsoExpireResult
->
->   | Field          | Type                                                                                                                                            | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-validatorlicense-faucetstate-67607">
+<span id="type-splice-validatorlicense-faucetstate-67607"></span>
 
-**data** FaucetState
+### `data FaucetState`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-validatorlicense-faucetstate-48340">
->
-> FaucetState
->
-> </div>
->
-> > | Field            | Type                                                                                                       | Description                                            |
-> > |------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-> > | firstReceivedFor | Round                                                                                                      | The first round for which a coupon was received.       |
-> > | lastReceivedFor  | Round                                                                                                      | The last round for which a coupon was received.        |
-> > | numCouponsMissed | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | The number of rounds for which no coupon was received. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) FaucetState
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) FaucetState
->
-> **instance** GetField "faucetState" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FaucetState)
->
-> **instance** GetField "firstReceivedFor" FaucetState Round
->
-> **instance** GetField "lastReceivedFor" FaucetState Round
->
-> **instance** GetField "numCouponsMissed" FaucetState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "faucetState" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FaucetState)
->
-> **instance** SetField "firstReceivedFor" FaucetState Round
->
-> **instance** SetField "lastReceivedFor" FaucetState Round
->
-> **instance** SetField "numCouponsMissed" FaucetState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+<span id="constr-splice-validatorlicense-faucetstate-48340"></span>
 
-<div id="type-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-29807">
+- `FaucetState`
 
-**data** ValidatorFaucetCoupon_DsoExpireResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| firstReceivedFor | Round | The first round for which a coupon was received. |
+| lastReceivedFor | Round | The last round for which a coupon was received. |
+| numCouponsMissed | Int | The number of rounds for which no coupon was received. |
 
-</div>
+Instances:
 
-> <div id="constr-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-83728">
->
-> ValidatorFaucetCoupon_DsoExpireResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult
+- `instance Eq FaucetState`
+- `instance Show FaucetState`
+- `instance GetField faucetState ValidatorLicense (Optional FaucetState)`
+- `instance GetField firstReceivedFor FaucetState Round`
+- `instance GetField lastReceivedFor FaucetState Round`
+- `instance GetField numCouponsMissed FaucetState Int`
+- `instance SetField faucetState ValidatorLicense (Optional FaucetState)`
+- `instance SetField firstReceivedFor FaucetState Round`
+- `instance SetField lastReceivedFor FaucetState Round`
+- `instance SetField numCouponsMissed FaucetState Int`
 
-<div id="type-splice-validatorlicense-validatorlicensemetadata-6055">
+<span id="type-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-29807"></span>
 
-**data** ValidatorLicenseMetadata
+### `data ValidatorFaucetCoupon_DsoExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-validatorlicense-validatorlicensemetadata-35622">
->
-> ValidatorLicenseMetadata
->
-> </div>
->
-> > | Field         | Type                                                                                                              | Description                                                                                                                                                             |
-> > |---------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | lastUpdatedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The last time the validator metadata was updated                                                                                                                        |
-> > | version       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      | The version the validator is currently on                                                                                                                               |
-> > | contactPoint  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      | A contact point that can be used to reach the operator of the validator in case there are issues with the validator. This can be an email address or a slack user name. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ValidatorLicenseMetadata
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ValidatorLicenseMetadata
->
-> **instance** GetField "contactPoint" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "lastUpdatedAt" ValidatorLicenseMetadata [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "metadata" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ValidatorLicenseMetadata)
->
-> **instance** GetField "version" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "contactPoint" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "lastUpdatedAt" ValidatorLicenseMetadata [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "metadata" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ValidatorLicenseMetadata)
->
-> **instance** SetField "version" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+<span id="constr-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-83728"></span>
 
-<div id="type-splice-validatorlicense-validatorlicensecancelresult-12117">
+- `ValidatorFaucetCoupon_DsoExpireResult`
 
-**data** ValidatorLicense_CancelResult
+Instances:
 
-</div>
+- `instance HasExercise ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult`
+- `instance HasToAnyChoice ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult`
 
-> <div id="constr-splice-validatorlicense-validatorlicensecancelresult-95954">
->
-> ValidatorLicense_CancelResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult
+<span id="type-splice-validatorlicense-validatorlicensemetadata-6055"></span>
 
-<div id="type-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-11121">
+### `data ValidatorLicenseMetadata`
 
-**data** ValidatorLicense_ReceiveFaucetCouponResult
+Constructors:
 
-</div>
+<span id="constr-splice-validatorlicense-validatorlicensemetadata-35622"></span>
 
-> <div id="constr-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-52224">
->
-> ValidatorLicense_ReceiveFaucetCouponResult
->
-> </div>
->
-> > | Field      | Type                                                                                                                                                | Description |
-> > |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense      |             |
-> > | couponCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon |             |
->
-> **instance** GetField "couponCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon)
->
-> **instance** GetField "licenseCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** SetField "couponCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon)
->
-> **instance** SetField "licenseCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult
+- `ValidatorLicenseMetadata`
 
-<div id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-68079">
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| lastUpdatedAt | Time | The last time the validator metadata was updated |
+| version | Text | The version the validator is currently on |
+| contactPoint | Text | A contact point that can be used to reach the operator of the validator in case there are issues with the validator.<br/><br/>This can be an email address or a slack user name. |
 
-**data** ValidatorLicense_RecordValidatorLivenessActivityResult
+Instances:
 
-</div>
+- `instance Eq ValidatorLicenseMetadata`
+- `instance Show ValidatorLicenseMetadata`
+- `instance GetField contactPoint ValidatorLicenseMetadata Text`
+- `instance GetField lastUpdatedAt ValidatorLicenseMetadata Time`
+- `instance GetField metadata ValidatorLicense (Optional ValidatorLicenseMetadata)`
+- `instance GetField version ValidatorLicenseMetadata Text`
+- `instance SetField contactPoint ValidatorLicenseMetadata Text`
+- `instance SetField lastUpdatedAt ValidatorLicenseMetadata Time`
+- `instance SetField metadata ValidatorLicense (Optional ValidatorLicenseMetadata)`
+- `instance SetField version ValidatorLicenseMetadata Text`
 
-> <div id="constr-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-77154">
->
-> ValidatorLicense_RecordValidatorLivenessActivityResult
->
-> </div>
->
-> > | Field      | Type                                                                                                                                                          | Description |
-> > |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense                |             |
-> > | couponCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord |             |
->
-> **instance** GetField "couponCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord)
->
-> **instance** GetField "licenseCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** SetField "couponCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord)
->
-> **instance** SetField "licenseCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult
+<span id="type-splice-validatorlicense-validatorlicensecancelresult-12117"></span>
 
-<div id="type-splice-validatorlicense-validatorlicensereportactiveresult-44973">
+### `data ValidatorLicense_CancelResult`
 
-**data** ValidatorLicense_ReportActiveResult
+Constructors:
 
-</div>
+<span id="constr-splice-validatorlicense-validatorlicensecancelresult-95954"></span>
 
-> <div id="constr-splice-validatorlicense-validatorlicensereportactiveresult-39594">
->
-> ValidatorLicense_ReportActiveResult
->
-> </div>
->
-> > | Field      | Type                                                                                                                                           | Description |
-> > |------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
->
-> **instance** GetField "licenseCid" ValidatorLicense_ReportActiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** SetField "licenseCid" ValidatorLicense_ReportActiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult
+- `ValidatorLicense_CancelResult`
 
-<div id="type-splice-validatorlicense-validatorlicenseupdatemetadataresult-84967">
+Instances:
 
-**data** ValidatorLicense_UpdateMetadataResult
+- `instance HasExercise ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult`
 
-</div>
+<span id="type-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-11121"></span>
 
-> <div id="constr-splice-validatorlicense-validatorlicenseupdatemetadataresult-7568">
->
-> ValidatorLicense_UpdateMetadataResult
->
-> </div>
->
-> > | Field      | Type                                                                                                                                           | Description |
-> > |------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
->
-> **instance** GetField "licenseCid" ValidatorLicense_UpdateMetadataResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** SetField "licenseCid" ValidatorLicense_UpdateMetadataResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult
+### `data ValidatorLicense_ReceiveFaucetCouponResult`
 
-<div id="type-splice-validatorlicense-validatorlicensewithdrawresult-32027">
+Constructors:
 
-**data** ValidatorLicense_WithdrawResult
+<span id="constr-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-52224"></span>
 
-</div>
+- `ValidatorLicense_ReceiveFaucetCouponResult`
 
-> <div id="constr-splice-validatorlicense-validatorlicensewithdrawresult-54540">
->
-> ValidatorLicense_WithdrawResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+| couponCid | ContractId ValidatorFaucetCoupon |  |
 
-<div id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-68284">
+Instances:
 
-**data** ValidatorLivenessActivityRecord_DsoExpireResult
+- `instance GetField couponCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorFaucetCoupon)`
+- `instance GetField licenseCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorLicense)`
+- `instance SetField couponCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorFaucetCoupon)`
+- `instance SetField licenseCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult`
 
-</div>
+<span id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-68079"></span>
 
-> <div id="constr-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-79751">
->
-> ValidatorLivenessActivityRecord_DsoExpireResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult
+### `data ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+Constructors:
+
+<span id="constr-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-77154"></span>
+
+- `ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+| couponCid | ContractId ValidatorLivenessActivityRecord |  |
+
+Instances:
+
+- `instance GetField couponCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLivenessActivityRecord)`
+- `instance GetField licenseCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLicense)`
+- `instance SetField couponCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLivenessActivityRecord)`
+- `instance SetField licenseCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+<span id="type-splice-validatorlicense-validatorlicensereportactiveresult-44973"></span>
+
+### `data ValidatorLicense_ReportActiveResult`
+
+Constructors:
+
+<span id="constr-splice-validatorlicense-validatorlicensereportactiveresult-39594"></span>
+
+- `ValidatorLicense_ReportActiveResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField licenseCid ValidatorLicense_ReportActiveResult (ContractId ValidatorLicense)`
+- `instance SetField licenseCid ValidatorLicense_ReportActiveResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult`
+
+<span id="type-splice-validatorlicense-validatorlicenseupdatemetadataresult-84967"></span>
+
+### `data ValidatorLicense_UpdateMetadataResult`
+
+Constructors:
+
+<span id="constr-splice-validatorlicense-validatorlicenseupdatemetadataresult-7568"></span>
+
+- `ValidatorLicense_UpdateMetadataResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField licenseCid ValidatorLicense_UpdateMetadataResult (ContractId ValidatorLicense)`
+- `instance SetField licenseCid ValidatorLicense_UpdateMetadataResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult`
+
+<span id="type-splice-validatorlicense-validatorlicensewithdrawresult-32027"></span>
+
+### `data ValidatorLicense_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-validatorlicense-validatorlicensewithdrawresult-54540"></span>
+
+- `ValidatorLicense_WithdrawResult`
+
+Instances:
+
+- `instance HasExercise ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult`
+
+<span id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-68284"></span>
+
+### `data ValidatorLivenessActivityRecord_DsoExpireResult`
+
+Constructors:
+
+<span id="constr-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-79751"></span>
+
+- `ValidatorLivenessActivityRecord_DsoExpireResult`
+
+Instances:
+
+- `instance HasExercise ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult`
+- `instance HasFromAnyChoice ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult`
+- `instance HasToAnyChoice ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult`
 
 ## Functions
 
-<div id="function-splice-validatorlicense-metadataupdatemininterval-59469">
+<span id="function-splice-validatorlicense-metadataupdatemininterval-59469"></span>
 
-metadataUpdateMinInterval
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+### `metadataUpdateMinInterval`
 
-</div>
+```daml
+metadataUpdateMinInterval : RelTime
+```
 
-<div id="function-splice-validatorlicense-activityreportmininterval-78854">
+<span id="function-splice-validatorlicense-activityreportmininterval-78854"></span>
 
-activityReportMinInterval
-: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+### `activityReportMinInterval`
 
-</div>
+```daml
+activityReportMinInterval : RelTime
+```
 
-<div id="function-splice-validatorlicense-metadataupdateallowed-42050">
+<span id="function-splice-validatorlicense-metadataupdateallowed-42050"></span>
 
-metadataUpdateAllowed
-: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `metadataUpdateAllowed`
 
-</div>
+```daml
+metadataUpdateAllowed : Time -> Time -> Bool
+```
 
-<div id="function-splice-validatorlicense-activityreportallowed-34361">
+<span id="function-splice-validatorlicense-activityreportallowed-34361"></span>
 
-activityReportAllowed
-: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `activityReportAllowed`
 
-</div>
+```daml
+activityReportAllowed : Time -> Time -> Bool
+```
 
-<div id="function-splice-validatorlicense-validvalidatorlicense-11839">
+<span id="function-splice-validatorlicense-validvalidatorlicense-11839"></span>
 
-validValidatorLicense
-: ValidatorLicense -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validValidatorLicense`
 
-</div>
+```daml
+validValidatorLicense : ValidatorLicense -> Bool
+```
 
-<div id="function-splice-validatorlicense-maxidentifierlength-1659">
+<span id="function-splice-validatorlicense-maxidentifierlength-1659"></span>
 
-maxIdentifierLength
-: [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+### `maxIdentifierLength`
 
-</div>
+```daml
+maxIdentifierLength : Int
+```
 
-<div id="function-splice-validatorlicense-validvalidatorlicensemetadata-75992">
+<span id="function-splice-validatorlicense-validvalidatorlicensemetadata-75992"></span>
 
-validValidatorLicenseMetadata
-: ValidatorLicenseMetadata -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validValidatorLicenseMetadata`
 
-</div>
+```daml
+validValidatorLicenseMetadata : ValidatorLicenseMetadata -> Bool
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-validatorlicense-validatorfaucetcoupon-19254"></span>
+
+### Template `ValidatorFaucetCoupon`
+
+__Deprecated__: use `ValidatorLicense_RecordValidatorLivenessActivity` instead, as that one
+can be expired without requiring a confirmation from the validator node.
+
+Signatories: `dso`, `validator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| validator | Party |  |
+| round | Round |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`, `validator`
+
+Returns: `()`
+
+<span id="type-splice-validatorlicense-validatorfaucetcoupondsoexpire-65722"></span>
+
+#### Choice `ValidatorFaucetCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `ValidatorFaucetCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<span id="type-splice-validatorlicense-validatorlicense-33456"></span>
+
+### Template `ValidatorLicense`
+
+The existence of a validator license is what makes a validator an (onboarded) validator.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validator | Party | The validator (party) that this license is about. |
+| sponsor | Party | The SV node that sponsored the onboarding. |
+| dso | Party | The party representing the operations of the decentralized synchronizer. |
+| faucetState | Optional FaucetState |  |
+| metadata | Optional ValidatorLicenseMetadata |  |
+| lastActiveAt | Optional Time | Last time this validator was active. Tracked to get a view on the set of validator nodes that are up and running. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-validatorlicense-validatorlicensecancel-74620"></span>
+
+#### Choice `ValidatorLicense_Cancel`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<span id="type-splice-validatorlicense-validatorlicensereceivefaucetcoupon-91156"></span>
+
+#### Choice `ValidatorLicense_ReceiveFaucetCoupon`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_ReceiveFaucetCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivity-79262"></span>
+
+#### Choice `ValidatorLicense_RecordValidatorLivenessActivity`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<span id="type-splice-validatorlicense-validatorlicensereportactive-46832"></span>
+
+#### Choice `ValidatorLicense_ReportActive`
+
+Choice for validators with disabled wallets to report themselves as active.
+Validators that receive amulets will report through ReceiveFaucetCoupon.
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_ReportActiveResult`
+
+<span id="type-splice-validatorlicense-validatorlicenseupdatemetadata-65458"></span>
+
+#### Choice `ValidatorLicense_UpdateMetadata`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_UpdateMetadataResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| version | Text |  |
+| contactPoint | Text |  |
+
+<span id="type-splice-validatorlicense-validatorlicensewithdraw-63410"></span>
+
+#### Choice `ValidatorLicense_Withdraw`
+
+Controllers: `dso`
+
+Returns: `ValidatorLicense_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<span id="type-splice-validatorlicense-validatorlivenessactivityrecord-17293"></span>
+
+### Template `ValidatorLivenessActivityRecord`
+
+A copy of the ValidatorFaucetCoupon template with the only difference being that the validator is an observer instead of signatory.
+This is to allow to expire the coupon without the validator's involvement.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| validator | Party |  |
+| round | Round |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpire-78737"></span>
+
+#### Choice `ValidatorLivenessActivityRecord_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `ValidatorLivenessActivityRecord_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-featured-app-v1 docs"
-description: "Documentation for splice-api-featured-app-v1 docs"
+title: "splice-api-featured-app-v1"
+description: "Reference documentation for splice-api-featured-app-v1 modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-api-featured-app-v1/docs/index.rst" hash="b48c7d92" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-featured-app-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-featured-app-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.FeaturedAppRightV1](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.FeaturedAppRightV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The API for featured apps to record their activity.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
@@ -1,222 +1,209 @@
 ---
 title: "Splice.Api.FeaturedAppRightV1"
-description: "Documentation for Splice.Api.FeaturedAppRightV1"
+description: "Reference documentation for Daml module Splice.Api.FeaturedAppRightV1."
 ---
 
-{/* COPIED_START source="splice:daml/splice-api-featured-app-v1/docs/Splice-Api-FeaturedAppRightV1.rst" hash="b6a67316" */}
+<span id="module-splice-api-featuredapprightv1-64680"></span>
+
+# Splice.Api.FeaturedAppRightV1
 
 The API for featured apps to record their activity.
 
-## Interfaces
+## Module Snapshot
 
-<div id="type-splice-api-featuredapprightv1-featuredappactivitymarker-46407">
-
-**interface** FeaturedAppActivityMarker
-
-</div>
-
-> A marker created by a featured application for activity generated from that app. This is used to record activity other than amulet transfers, which have built-in support for recording featured app activity.
->
-> **viewtype** FeaturedAppActivityMarkerView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-api-featuredapprightv1-featuredappright-34177">
-
-**interface** FeaturedAppRight
-
-</div>
-
-> An interface for contracts allowing application providers to record their featured activity. Note that most instances of amulet will likely define some fair usage constraints.
->
-> **viewtype** FeaturedAppRightView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarker-36646">
->
->   **Choice** FeaturedAppRight_CreateActivityMarker
->
->   </div>
->
->   Record activity due to a featured app.
->
->   Controller: (DA.Internal.Record.getField @"provider" (view this))
->
->   Returns: FeaturedAppRight_CreateActivityMarkerResult
->
->   | Field         | Type                     | Description                                                                                                                                                                                                                                                                        |
->   |---------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | beneficiaries | \[AppRewardBeneficiary\] | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries. |
->
-> - **Method featuredAppRight_CreateActivityMarkerImpl :** ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-featuredapprightv1-apprewardbeneficiary-32645">
+<span id="type-splice-api-featuredapprightv1-apprewardbeneficiary-32645"></span>
 
-**data** AppRewardBeneficiary
+### `data AppRewardBeneficiary`
 
-</div>
+Specification of a beneficiary of featured app rewards.
 
-> Specification of a beneficiary of featured app rewards.
->
-> <div id="constr-splice-api-featuredapprightv1-apprewardbeneficiary-16584">
->
-> AppRewardBeneficiary
->
-> </div>
->
-> > | Field       | Type                                                                                    | Description                                                                                  |
-> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
->
-> **instance** Eq AppRewardBeneficiary
->
-> **instance** Ord AppRewardBeneficiary
->
-> **instance** Show AppRewardBeneficiary
->
-> **instance** GetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
->
-> **instance** GetField "beneficiary" AppRewardBeneficiary Party
->
-> **instance** GetField "weight" AppRewardBeneficiary Decimal
->
-> **instance** SetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
->
-> **instance** SetField "beneficiary" AppRewardBeneficiary Party
->
-> **instance** SetField "weight" AppRewardBeneficiary Decimal
+Constructors:
 
-<div id="type-splice-api-featuredapprightv1-featuredappactivitymarkerview-84352">
+<span id="constr-splice-api-featuredapprightv1-apprewardbeneficiary-16584"></span>
 
-**data** FeaturedAppActivityMarkerView
+- `AppRewardBeneficiary`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
 
-> <div id="constr-splice-api-featuredapprightv1-featuredappactivitymarkerview-55819">
->
-> FeaturedAppActivityMarkerView
->
-> </div>
->
-> > | Field       | Type                                                                                    | Description                                                                                  |
-> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso         | Party | The DSO party.                                                                               |
-> > | provider    | Party | The featured app provider.                                                                   |
-> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
->
-> **instance** Eq FeaturedAppActivityMarkerView
->
-> **instance** Show FeaturedAppActivityMarkerView
->
-> **instance** HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
->
-> **instance** HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
->
-> **instance** GetField "beneficiary" FeaturedAppActivityMarkerView Party
->
-> **instance** GetField "dso" FeaturedAppActivityMarkerView Party
->
-> **instance** GetField "provider" FeaturedAppActivityMarkerView Party
->
-> **instance** GetField "weight" FeaturedAppActivityMarkerView Decimal
->
-> **instance** SetField "beneficiary" FeaturedAppActivityMarkerView Party
->
-> **instance** SetField "dso" FeaturedAppActivityMarkerView Party
->
-> **instance** SetField "provider" FeaturedAppActivityMarkerView Party
->
-> **instance** SetField "weight" FeaturedAppActivityMarkerView Decimal
+Instances:
 
-<div id="type-splice-api-featuredapprightv1-featuredapprightview-50078">
+- `instance Eq AppRewardBeneficiary`
+- `instance Ord AppRewardBeneficiary`
+- `instance Show AppRewardBeneficiary`
+- `instance GetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance GetField beneficiary AppRewardBeneficiary Party`
+- `instance GetField weight AppRewardBeneficiary Decimal`
+- `instance SetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance SetField beneficiary AppRewardBeneficiary Party`
+- `instance SetField weight AppRewardBeneficiary Decimal`
 
-**data** FeaturedAppRightView
+<span id="type-splice-api-featuredapprightv1-featuredappactivitymarkerview-84352"></span>
 
-</div>
+### `data FeaturedAppActivityMarkerView`
 
-> <div id="constr-splice-api-featuredapprightv1-featuredapprightview-35459">
->
-> FeaturedAppRightView
->
-> </div>
->
-> > | Field    | Type                                                                                    | Description                |
-> > |----------|-----------------------------------------------------------------------------------------|----------------------------|
-> > | dso      | Party | The DSO party.             |
-> > | provider | Party | The featured app provider. |
->
-> **instance** Eq FeaturedAppRightView
->
-> **instance** Show FeaturedAppRightView
->
-> **instance** HasFromAnyView FeaturedAppRight FeaturedAppRightView
->
-> **instance** HasInterfaceView FeaturedAppRight FeaturedAppRightView
->
-> **instance** GetField "dso" FeaturedAppRightView Party
->
-> **instance** GetField "provider" FeaturedAppRightView Party
->
-> **instance** SetField "dso" FeaturedAppRightView Party
->
-> **instance** SetField "provider" FeaturedAppRightView Party
+Constructors:
 
-<div id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-54383">
+<span id="constr-splice-api-featuredapprightv1-featuredappactivitymarkerview-55819"></span>
 
-**data** FeaturedAppRight_CreateActivityMarkerResult
+- `FeaturedAppActivityMarkerView`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
 
-> Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
->
-> <div id="constr-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-43104">
->
-> FeaturedAppRight_CreateActivityMarkerResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                            | Description                                        |
-> > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> > | activityMarkerCids | \[ContractId FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
->
-> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" (ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult)
->
-> **instance** GetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
->
-> **instance** SetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
->
-> **instance** HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+Instances:
+
+- `instance Eq FeaturedAppActivityMarkerView`
+- `instance Show FeaturedAppActivityMarkerView`
+- `instance HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance GetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance GetField dso FeaturedAppActivityMarkerView Party`
+- `instance GetField provider FeaturedAppActivityMarkerView Party`
+- `instance GetField weight FeaturedAppActivityMarkerView Decimal`
+- `instance SetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance SetField dso FeaturedAppActivityMarkerView Party`
+- `instance SetField provider FeaturedAppActivityMarkerView Party`
+- `instance SetField weight FeaturedAppActivityMarkerView Decimal`
+
+<span id="type-splice-api-featuredapprightv1-featuredapprightview-50078"></span>
+
+### `data FeaturedAppRightView`
+
+Constructors:
+
+<span id="constr-splice-api-featuredapprightv1-featuredapprightview-35459"></span>
+
+- `FeaturedAppRightView`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+
+Instances:
+
+- `instance Eq FeaturedAppRightView`
+- `instance Show FeaturedAppRightView`
+- `instance HasFromAnyView FeaturedAppRight FeaturedAppRightView`
+- `instance HasInterfaceView FeaturedAppRight FeaturedAppRightView`
+- `instance GetField dso FeaturedAppRightView Party`
+- `instance GetField provider FeaturedAppRightView Party`
+- `instance SetField dso FeaturedAppRightView Party`
+- `instance SetField provider FeaturedAppRightView Party`
+
+<span id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-54383"></span>
+
+### `data FeaturedAppRight_CreateActivityMarkerResult`
+
+Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
+
+Constructors:
+
+<span id="constr-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-43104"></span>
+
+- `FeaturedAppRight_CreateActivityMarkerResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| activityMarkerCids | [ContractId FeaturedAppActivityMarker] | The set of activity markers created by the choice. |
+
+Instances:
+
+- `instance HasMethod FeaturedAppRight featuredAppRight_CreateActivityMarkerImpl (ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult)`
+- `instance GetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance SetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
 
 ## Functions
 
-<div id="function-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerimpl-71588">
+<span id="function-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerimpl-71588"></span>
 
-featuredAppRight_CreateActivityMarkerImpl
-: FeaturedAppRight -\> ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
+### `featuredAppRight_CreateActivityMarkerImpl`
 
-</div>
+```daml
+featuredAppRight_CreateActivityMarkerImpl : FeaturedAppRight -> ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-featuredapprightv1-featuredappactivitymarker-46407"></span>
+
+### Interface `FeaturedAppActivityMarker`
+
+A marker created by a featured application for activity generated from that app. This is used
+to record activity other than amulet transfers, which have built-in support for recording featured app activity.
+
+View Type: `FeaturedAppActivityMarkerView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-featuredapprightv1-featuredappright-34177"></span>
+
+### Interface `FeaturedAppRight`
+
+An interface for contracts allowing application providers to record their featured activity.
+Note that most instances of amulet will likely define some fair usage constraints.
+
+View Type: `FeaturedAppRightView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarker-36646"></span>
+
+#### Choice `FeaturedAppRight_CreateActivityMarker`
+
+Record activity due to a featured app.
+
+Controllers: `(DA.Internal.Record.getField @"provider" (view this))`
+
+Returns: `FeaturedAppRight_CreateActivityMarkerResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] | The set of beneficiaries and weights that define how the rewards should be split up<br/><br/>between the beneficiary parties.<br/><br/>Implementations SHOULD check that the weights are positive and add up to 1.0.<br/><br/>Implementations MAY also impose a limit on the maximum number of beneficiaries. |
+
+Methods:
+
+#### Method `featuredAppRight_CreateActivityMarkerImpl`
+
+Type: `ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-featured-app-v2 docs"
-description: "Documentation for splice-api-featured-app-v2 docs"
+title: "splice-api-featured-app-v2"
+description: "Reference documentation for splice-api-featured-app-v2 modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-api-featured-app-v2/docs/index.rst" hash="582548f8" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-featured-app-v2</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-featured-app-v2, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.FeaturedAppRightV2](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.FeaturedAppRightV2</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The API for featured apps to record their activity.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
@@ -1,223 +1,214 @@
 ---
 title: "Splice.Api.FeaturedAppRightV2"
-description: "Documentation for Splice.Api.FeaturedAppRightV2"
+description: "Reference documentation for Daml module Splice.Api.FeaturedAppRightV2."
 ---
 
-{/* COPIED_START source="splice:daml/splice-api-featured-app-v2/docs/Splice-Api-FeaturedAppRightV2.rst" hash="005aaec6" */}
+<span id="module-splice-api-featuredapprightv2-80033"></span>
 
-The API for featured apps to record their activity. This package extends FeaturedAppRightV1 with support for specifying a weight when creating a marker to improve efficiency.
+# Splice.Api.FeaturedAppRightV2
 
-## Interfaces
+The API for featured apps to record their activity.
 
-<div id="type-splice-api-featuredapprightv2-featuredappactivitymarker-59464">
+This package extends FeaturedAppRightV1 with support for specifying
 
-**interface** FeaturedAppActivityMarker
+a weight when creating a marker to improve efficiency.
 
-</div>
+## Module Snapshot
 
-> A marker created by a featured application for activity generated from that app. This is used to record activity other than amulet transfers, which have built-in support for recording featured app activity.
->
-> **viewtype** FeaturedAppActivityMarkerView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-api-featuredapprightv2-featuredappright-28172">
-
-**interface** FeaturedAppRight
-
-</div>
-
-> An interface for contracts allowing application providers to record their featured activity. Note that most instances of amulet will likely define some fair usage constraints.
->
-> **viewtype** FeaturedAppRightView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarker-77229">
->
->   **Choice** FeaturedAppRight_CreateActivityMarker
->
->   </div>
->
->   Record activity due to a featured app.
->
->   Controller: (DA.Internal.Record.getField @"provider" (view this))
->
->   Returns: FeaturedAppRight_CreateActivityMarkerResult
->
->   | Field         | Type                                                                                                                                                                                      | Description                                                                                                                                                                                                                                                                                       |
->   |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | beneficiaries | \[AppRewardBeneficiary\]                                                                                                                                                                  | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries.                |
->   | weight        | Optional Decimal | A weight for the resulting markers. None defaults to a weight of 1.0. Specifying a weight of 5 for example makes the resulting markers equivalent to 5 markers of weight 1 in terms of rewards they generate. The weight must be \>= 1.0 Implementations MAY impose an upper limit on the weight. |
->
-> - **Method featuredAppRight_CreateActivityMarkerImpl :** ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-featuredapprightv2-apprewardbeneficiary-35536">
+<span id="type-splice-api-featuredapprightv2-apprewardbeneficiary-35536"></span>
 
-**data** AppRewardBeneficiary
+### `data AppRewardBeneficiary`
 
-</div>
+Specification of a beneficiary of featured app rewards.
 
-> Specification of a beneficiary of featured app rewards.
->
-> <div id="constr-splice-api-featuredapprightv2-apprewardbeneficiary-41661">
->
-> AppRewardBeneficiary
->
-> </div>
->
-> > | Field       | Type                                                                                    | Description                                                                                  |
-> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
->
-> **instance** Eq AppRewardBeneficiary
->
-> **instance** Ord AppRewardBeneficiary
->
-> **instance** Show AppRewardBeneficiary
->
-> **instance** GetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
->
-> **instance** GetField "beneficiary" AppRewardBeneficiary Party
->
-> **instance** GetField "weight" AppRewardBeneficiary Decimal
->
-> **instance** SetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
->
-> **instance** SetField "beneficiary" AppRewardBeneficiary Party
->
-> **instance** SetField "weight" AppRewardBeneficiary Decimal
+Constructors:
 
-<div id="type-splice-api-featuredapprightv2-featuredappactivitymarkerview-70739">
+<span id="constr-splice-api-featuredapprightv2-apprewardbeneficiary-41661"></span>
 
-**data** FeaturedAppActivityMarkerView
+- `AppRewardBeneficiary`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
 
-> <div id="constr-splice-api-featuredapprightv2-featuredappactivitymarkerview-19000">
->
-> FeaturedAppActivityMarkerView
->
-> </div>
->
-> > | Field       | Type                                                                                    | Description                                                                                  |
-> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso         | Party | The DSO party.                                                                               |
-> > | provider    | Party | The featured app provider.                                                                   |
-> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
->
-> **instance** Eq FeaturedAppActivityMarkerView
->
-> **instance** Show FeaturedAppActivityMarkerView
->
-> **instance** HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
->
-> **instance** HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
->
-> **instance** GetField "beneficiary" FeaturedAppActivityMarkerView Party
->
-> **instance** GetField "dso" FeaturedAppActivityMarkerView Party
->
-> **instance** GetField "provider" FeaturedAppActivityMarkerView Party
->
-> **instance** GetField "weight" FeaturedAppActivityMarkerView Decimal
->
-> **instance** SetField "beneficiary" FeaturedAppActivityMarkerView Party
->
-> **instance** SetField "dso" FeaturedAppActivityMarkerView Party
->
-> **instance** SetField "provider" FeaturedAppActivityMarkerView Party
->
-> **instance** SetField "weight" FeaturedAppActivityMarkerView Decimal
+Instances:
 
-<div id="type-splice-api-featuredapprightv2-featuredapprightview-58075">
+- `instance Eq AppRewardBeneficiary`
+- `instance Ord AppRewardBeneficiary`
+- `instance Show AppRewardBeneficiary`
+- `instance GetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance GetField beneficiary AppRewardBeneficiary Party`
+- `instance GetField weight AppRewardBeneficiary Decimal`
+- `instance SetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance SetField beneficiary AppRewardBeneficiary Party`
+- `instance SetField weight AppRewardBeneficiary Decimal`
 
-**data** FeaturedAppRightView
+<span id="type-splice-api-featuredapprightv2-featuredappactivitymarkerview-70739"></span>
 
-</div>
+### `data FeaturedAppActivityMarkerView`
 
-> <div id="constr-splice-api-featuredapprightv2-featuredapprightview-48166">
->
-> FeaturedAppRightView
->
-> </div>
->
-> > | Field    | Type                                                                                    | Description                |
-> > |----------|-----------------------------------------------------------------------------------------|----------------------------|
-> > | dso      | Party | The DSO party.             |
-> > | provider | Party | The featured app provider. |
->
-> **instance** Eq FeaturedAppRightView
->
-> **instance** Show FeaturedAppRightView
->
-> **instance** HasFromAnyView FeaturedAppRight FeaturedAppRightView
->
-> **instance** HasInterfaceView FeaturedAppRight FeaturedAppRightView
->
-> **instance** GetField "dso" FeaturedAppRightView Party
->
-> **instance** GetField "provider" FeaturedAppRightView Party
->
-> **instance** SetField "dso" FeaturedAppRightView Party
->
-> **instance** SetField "provider" FeaturedAppRightView Party
+Constructors:
 
-<div id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-27928">
+<span id="constr-splice-api-featuredapprightv2-featuredappactivitymarkerview-19000"></span>
 
-**data** FeaturedAppRight_CreateActivityMarkerResult
+- `FeaturedAppActivityMarkerView`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
 
-> Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
->
-> <div id="constr-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-95607">
->
-> FeaturedAppRight_CreateActivityMarkerResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                            | Description                                        |
-> > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> > | activityMarkerCids | \[ContractId FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
->
-> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" (ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult)
->
-> **instance** GetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
->
-> **instance** SetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
->
-> **instance** HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+Instances:
+
+- `instance Eq FeaturedAppActivityMarkerView`
+- `instance Show FeaturedAppActivityMarkerView`
+- `instance HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance GetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance GetField dso FeaturedAppActivityMarkerView Party`
+- `instance GetField provider FeaturedAppActivityMarkerView Party`
+- `instance GetField weight FeaturedAppActivityMarkerView Decimal`
+- `instance SetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance SetField dso FeaturedAppActivityMarkerView Party`
+- `instance SetField provider FeaturedAppActivityMarkerView Party`
+- `instance SetField weight FeaturedAppActivityMarkerView Decimal`
+
+<span id="type-splice-api-featuredapprightv2-featuredapprightview-58075"></span>
+
+### `data FeaturedAppRightView`
+
+Constructors:
+
+<span id="constr-splice-api-featuredapprightv2-featuredapprightview-48166"></span>
+
+- `FeaturedAppRightView`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+
+Instances:
+
+- `instance Eq FeaturedAppRightView`
+- `instance Show FeaturedAppRightView`
+- `instance HasFromAnyView FeaturedAppRight FeaturedAppRightView`
+- `instance HasInterfaceView FeaturedAppRight FeaturedAppRightView`
+- `instance GetField dso FeaturedAppRightView Party`
+- `instance GetField provider FeaturedAppRightView Party`
+- `instance SetField dso FeaturedAppRightView Party`
+- `instance SetField provider FeaturedAppRightView Party`
+
+<span id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-27928"></span>
+
+### `data FeaturedAppRight_CreateActivityMarkerResult`
+
+Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
+
+Constructors:
+
+<span id="constr-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-95607"></span>
+
+- `FeaturedAppRight_CreateActivityMarkerResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| activityMarkerCids | [ContractId FeaturedAppActivityMarker] | The set of activity markers created by the choice. |
+
+Instances:
+
+- `instance HasMethod FeaturedAppRight featuredAppRight_CreateActivityMarkerImpl (ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult)`
+- `instance GetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance SetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
 
 ## Functions
 
-<div id="function-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerimpl-7767">
+<span id="function-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerimpl-7767"></span>
 
-featuredAppRight_CreateActivityMarkerImpl
-: FeaturedAppRight -\> ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
+### `featuredAppRight_CreateActivityMarkerImpl`
 
-</div>
+```daml
+featuredAppRight_CreateActivityMarkerImpl : FeaturedAppRight -> ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-featuredapprightv2-featuredappactivitymarker-59464"></span>
+
+### Interface `FeaturedAppActivityMarker`
+
+A marker created by a featured application for activity generated from that app. This is used
+to record activity other than amulet transfers, which have built-in support for recording featured app activity.
+
+View Type: `FeaturedAppActivityMarkerView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-featuredapprightv2-featuredappright-28172"></span>
+
+### Interface `FeaturedAppRight`
+
+An interface for contracts allowing application providers to record their featured activity.
+Note that most instances of amulet will likely define some fair usage constraints.
+
+View Type: `FeaturedAppRightView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarker-77229"></span>
+
+#### Choice `FeaturedAppRight_CreateActivityMarker`
+
+Record activity due to a featured app.
+
+Controllers: `(DA.Internal.Record.getField @"provider" (view this))`
+
+Returns: `FeaturedAppRight_CreateActivityMarkerResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] | The set of beneficiaries and weights that define how the rewards should be split up<br/><br/>between the beneficiary parties.<br/><br/>Implementations SHOULD check that the weights are positive and add up to 1.0.<br/><br/>Implementations MAY also impose a limit on the maximum number of beneficiaries. |
+| weight | Optional Decimal | A weight for the resulting markers. None defaults to a weight of 1.0.<br/><br/>Specifying a weight of 5 for example makes the resulting markers equivalent<br/><br/>to 5 markers of weight 1 in terms of rewards they generate.<br/><br/>The weight must be >= 1.0<br/><br/>Implementations MAY impose an upper limit on the weight. |
+
+Methods:
+
+#### Method `featuredAppRight_CreateActivityMarkerImpl`
+
+Type: `ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-allocation-instruction-v1 docs"
-description: "Documentation for splice-api-token-allocation-instruction-v1 docs"
+title: "splice-api-token-allocation-instruction-v1"
+description: "Reference documentation for splice-api-token-allocation-instruction-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-instruction-v1/docs/index.rst" hash="d053d143" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-allocation-instruction-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-allocation-instruction-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.AllocationInstructionV1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.AllocationInstructionV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Interfaces to enable wallets to instruct the registry to create allocations.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
@@ -1,380 +1,359 @@
 ---
 title: "Splice.Api.Token.AllocationInstructionV1"
-description: "Documentation for Splice.Api.Token.AllocationInstructionV1"
+description: "Reference documentation for Daml module Splice.Api.Token.AllocationInstructionV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-instruction-v1/docs/Splice-Api-Token-AllocationInstructionV1.rst" hash="dee8a9d7" */}
+<span id="module-splice-api-token-allocationinstructionv1-81747"></span>
+
+# Splice.Api.Token.AllocationInstructionV1
 
 Interfaces to enable wallets to instruct the registry to create allocations.
 
-## Interfaces
+## Module Snapshot
 
-<div id="type-splice-api-token-allocationinstructionv1-allocationfactory-42588">
-
-**interface** AllocationFactory
-
-</div>
-
-> Contracts implementing `AllocationFactory` are retrieved from the registry app and are used by the wallet to create allocation instructions (or allocations directly).
->
-> **viewtype** AllocationFactoryView
->
-> - <div id="type-splice-api-token-allocationinstructionv1-allocationfactoryallocate-8885">
->
->   **Choice** AllocationFactory_Allocate
->
->   </div>
->
->   Generic choice for the sender's wallet to request the allocation of assets to a specific leg of a settlement. It depends on the registry whether this results in the allocation being created directly or in an allocation instruction being created instead.
->
->   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))
->
->   Returns: AllocationInstructionResult
->
->   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
->   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin    | Party                       | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party.                                       |
->   | allocation       | AllocationSpecification                                                                                       | The allocation which should be created.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
->   | requestedAt      | Time                         | The time at which the allocation was requested.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
->   | inputHoldingCids | \[ContractId Holding\] | The holdings that SHOULD be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger; or for registries that support automatic selection of holdings for allocations. If specified, then the successful allocation MUST archive all of these holdings, so that the execution of the allocation conflicts with any other allocations using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate allocations. |
->   | extraArgs        | ExtraArgs                                                                                                     | Additional choice arguments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
->
-> - <div id="type-splice-api-token-allocationinstructionv1-allocationfactorypublicfetch-20324">
->
->   **Choice** AllocationFactory_PublicFetch
->
->   </div>
->
->   Controller: actor
->
->   Returns: AllocationFactoryView
->
->   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
->   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | Party |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - **Method allocationFactory_allocateImpl :** ContractId AllocationFactory -\> AllocationFactory_Allocate -\> Update AllocationInstructionResult
->
-> - **Method allocationFactory_publicFetchImpl :** ContractId AllocationFactory -\> AllocationFactory_PublicFetch -\> Update AllocationFactoryView
-
-<div id="type-splice-api-token-allocationinstructionv1-allocationinstruction-29622">
-
-**interface** AllocationInstruction
-
-</div>
-
-> An interface for tracking the status of an allocation instruction, i.e., a request to a registry app to create an allocation.
->
-> Registries MAY evolve the allocation instruction in multiple steps. They SHOULD do so using only the choices on this interface, so that wallets can reliably parse the transaction history and determine whether the creation of the allocation ultimately succeeded or failed.
->
-> **viewtype** AllocationInstructionView
->
-> - <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionupdate-50223">
->
->   **Choice** AllocationInstruction_Update
->
->   </div>
->
->   Update the state of the allocation instruction. Used by the registry to execute registry internal workflow steps that advance the state of the allocation instruction. A reason may be communicated via the metadata.
->
->   Controller: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))), extraActors
->
->   Returns: AllocationInstructionResult
->
->   | Field       | Type                                                                                        | Description                                                                                                                           |
->   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
->   | extraActors | \[Party\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
->   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
->
-> - <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionwithdraw-35988">
->
->   **Choice** AllocationInstruction_Withdraw
->
->   </div>
->
->   Withdraw the allocation instruction as the sender.
->
->   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))
->
->   Returns: AllocationInstructionResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - **Method allocationInstruction_updateImpl :** ContractId AllocationInstruction -\> AllocationInstruction_Update -\> Update AllocationInstructionResult
->
-> - **Method allocationInstruction_withdrawImpl :** ContractId AllocationInstruction -\> AllocationInstruction_Withdraw -\> Update AllocationInstructionResult
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-allocationinstructionv1-allocationfactoryview-21751">
+<span id="type-splice-api-token-allocationinstructionv1-allocationfactoryview-21751"></span>
 
-**data** AllocationFactoryView
+### `data AllocationFactoryView`
 
-</div>
+View for `AllocationFactory`.
 
-> View for `AllocationFactory`.
->
-> <div id="constr-splice-api-token-allocationinstructionv1-allocationfactoryview-66354">
->
-> AllocationFactoryView
->
-> </div>
->
-> > | Field | Type                                                                                    | Description                                                                                                             |
-> > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-> > | admin | Party | The party representing the registry app that administers the instruments for which this allocation factory can be used. |
-> > | meta  | Metadata                                                                                | Additional metadata specific to the allocation factory, used for extensibility.                                         |
->
-> **instance** Eq AllocationFactoryView
->
-> **instance** Show AllocationFactoryView
->
-> **instance** HasMethod AllocationFactory "allocationFactory_publicFetchImpl" (ContractId AllocationFactory -\> AllocationFactory_PublicFetch -\> Update AllocationFactoryView)
->
-> **instance** HasFromAnyView AllocationFactory AllocationFactoryView
->
-> **instance** HasInterfaceView AllocationFactory AllocationFactoryView
->
-> **instance** GetField "admin" AllocationFactoryView Party
->
-> **instance** GetField "meta" AllocationFactoryView Metadata
->
-> **instance** SetField "admin" AllocationFactoryView Party
->
-> **instance** SetField "meta" AllocationFactoryView Metadata
->
-> **instance** HasExercise AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
->
-> **instance** HasExerciseGuarded AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
->
-> **instance** HasFromAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
->
-> **instance** HasToAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+Constructors:
 
-<div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresult-30943">
+<span id="constr-splice-api-token-allocationinstructionv1-allocationfactoryview-66354"></span>
 
-**data** AllocationInstructionResult
+- `AllocationFactoryView`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instruments<br/><br/>for which this allocation factory can be used. |
+| meta | Metadata | Additional metadata specific to the allocation factory, used for extensibility. |
 
-> The result of instructing an allocation or advancing the state of an allocation instruction.
->
-> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresult-54130">
->
-> AllocationInstructionResult
->
-> </div>
->
-> > | Field            | Type                                                                                                          | Description                                                                                                                                                                      |
-> > |------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | output           | AllocationInstructionResult_Output                                                                            | The output of the step.                                                                                                                                                          |
-> > | senderChangeCids | \[ContractId Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple allocation instructions in a single Daml transaction. |
-> > | meta             | Metadata                                                                                                      | Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged.                                                                          |
->
-> **instance** Eq AllocationInstructionResult
->
-> **instance** Show AllocationInstructionResult
->
-> **instance** HasMethod AllocationFactory "allocationFactory_allocateImpl" (ContractId AllocationFactory -\> AllocationFactory_Allocate -\> Update AllocationInstructionResult)
->
-> **instance** HasMethod AllocationInstruction "allocationInstruction_updateImpl" (ContractId AllocationInstruction -\> AllocationInstruction_Update -\> Update AllocationInstructionResult)
->
-> **instance** HasMethod AllocationInstruction "allocationInstruction_withdrawImpl" (ContractId AllocationInstruction -\> AllocationInstruction_Withdraw -\> Update AllocationInstructionResult)
->
-> **instance** GetField "meta" AllocationInstructionResult Metadata
->
-> **instance** GetField "output" AllocationInstructionResult AllocationInstructionResult_Output
->
-> **instance** GetField "senderChangeCids" AllocationInstructionResult \[ContractId Holding\]
->
-> **instance** SetField "meta" AllocationInstructionResult Metadata
->
-> **instance** SetField "output" AllocationInstructionResult AllocationInstructionResult_Output
->
-> **instance** SetField "senderChangeCids" AllocationInstructionResult \[ContractId Holding\]
->
-> **instance** HasExercise AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
->
-> **instance** HasExercise AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
->
-> **instance** HasExercise AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
->
-> **instance** HasExerciseGuarded AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
->
-> **instance** HasExerciseGuarded AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
->
-> **instance** HasExerciseGuarded AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
->
-> **instance** HasFromAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
->
-> **instance** HasFromAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
->
-> **instance** HasFromAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
->
-> **instance** HasToAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
->
-> **instance** HasToAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
->
-> **instance** HasToAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+Instances:
 
-<div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresultoutput-46212">
+- `instance Eq AllocationFactoryView`
+- `instance Show AllocationFactoryView`
+- `instance HasMethod AllocationFactory allocationFactory_publicFetchImpl (ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView)`
+- `instance HasFromAnyView AllocationFactory AllocationFactoryView`
+- `instance HasInterfaceView AllocationFactory AllocationFactoryView`
+- `instance GetField admin AllocationFactoryView Party`
+- `instance GetField meta AllocationFactoryView Metadata`
+- `instance SetField admin AllocationFactoryView Party`
+- `instance SetField meta AllocationFactoryView Metadata`
+- `instance HasExercise AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+- `instance HasExerciseGuarded AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+- `instance HasFromAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+- `instance HasToAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
 
-**data** AllocationInstructionResult_Output
+<span id="type-splice-api-token-allocationinstructionv1-allocationinstructionresult-30943"></span>
 
-</div>
+### `data AllocationInstructionResult`
 
-> The output of instructing an allocation or advancing the state of an allocation instruction.
->
-> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultpending-58494">
->
-> AllocationInstructionResult_Pending
->
-> </div>
->
-> > Use this result to communicate that the creation of the allocation is pending further steps.
-> >
-> > | Field                    | Type                                                                                                                    | Description                                                               |
-> > |--------------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-> > | allocationInstructionCid | ContractId AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
->
-> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultcompleted-89210">
->
-> AllocationInstructionResult_Completed
->
-> </div>
->
-> > Use this result to communicate that the allocation was created.
-> >
-> > | Field         | Type                                                                                                         | Description                   |
-> > |---------------|--------------------------------------------------------------------------------------------------------------|-------------------------------|
-> > | allocationCid | ContractId Allocation | The newly created allocation. |
->
-> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultfailed-56799">
->
-> AllocationInstructionResult_Failed
->
-> </div>
->
-> > Use this result to communicate that the creation of the allocation did not succeed and all holdings reserved for funding the allocation have been released.
->
-> **instance** Eq AllocationInstructionResult_Output
->
-> **instance** Show AllocationInstructionResult_Output
->
-> **instance** GetField "allocationCid" AllocationInstructionResult_Output (ContractId Allocation)
->
-> **instance** GetField "allocationInstructionCid" AllocationInstructionResult_Output (ContractId AllocationInstruction)
->
-> **instance** GetField "output" AllocationInstructionResult AllocationInstructionResult_Output
->
-> **instance** SetField "allocationCid" AllocationInstructionResult_Output (ContractId Allocation)
->
-> **instance** SetField "allocationInstructionCid" AllocationInstructionResult_Output (ContractId AllocationInstruction)
->
-> **instance** SetField "output" AllocationInstructionResult AllocationInstructionResult_Output
+The result of instructing an allocation or advancing the state of an allocation instruction.
 
-<div id="type-splice-api-token-allocationinstructionv1-allocationinstructionview-72001">
+Constructors:
 
-**data** AllocationInstructionView
+<span id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresult-54130"></span>
 
-</div>
+- `AllocationInstructionResult`
 
-> View for `AllocationInstruction`.
->
-> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionview-32140">
->
-> AllocationInstructionView
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                                                                                                                |
-> > |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | originalInstructionCid | Optional (ContractId AllocationInstruction)                                 | The contract id of the original allocation instruction contract. Used by the wallet to track the lineage of allocation instructions through multiple steps. Only set if the registry evolves the allocation instruction in multiple steps. |
-> > | allocation             | AllocationSpecification                                                                                                                                                                                                                                      | The allocation that this instruction should create.                                                                                                                                                                                        |
-> > | pendingActions         | Map Party Text | The pending actions to be taken by different actors to create the allocation. ^ This field can by used to report on the progress of registry specific workflows that are required to prepare the allocation.                               |
-> > | requestedAt            | Time                                                                                                                                                                        | The time at which the allocation was requested.                                                                                                                                                                                            |
-> > | inputHoldingCids       | \[ContractId Holding\]                                                                                                                                                | The holdings to be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger.                                                                                                                |
-> > | meta                   | Metadata                                                                                                                                                                                                                                                     | Additional metadata specific to the allocation instruction, used for extensibility; e.g., more detailed status information.                                                                                                                |
->
-> **instance** Eq AllocationInstructionView
->
-> **instance** Show AllocationInstructionView
->
-> **instance** HasFromAnyView AllocationInstruction AllocationInstructionView
->
-> **instance** HasInterfaceView AllocationInstruction AllocationInstructionView
->
-> **instance** GetField "allocation" AllocationInstructionView AllocationSpecification
->
-> **instance** GetField "inputHoldingCids" AllocationInstructionView \[ContractId Holding\]
->
-> **instance** GetField "meta" AllocationInstructionView Metadata
->
-> **instance** GetField "originalInstructionCid" AllocationInstructionView (Optional (ContractId AllocationInstruction))
->
-> **instance** GetField "pendingActions" AllocationInstructionView (Map Party Text)
->
-> **instance** GetField "requestedAt" AllocationInstructionView Time
->
-> **instance** SetField "allocation" AllocationInstructionView AllocationSpecification
->
-> **instance** SetField "inputHoldingCids" AllocationInstructionView \[ContractId Holding\]
->
-> **instance** SetField "meta" AllocationInstructionView Metadata
->
-> **instance** SetField "originalInstructionCid" AllocationInstructionView (Optional (ContractId AllocationInstruction))
->
-> **instance** SetField "pendingActions" AllocationInstructionView (Map Party Text)
->
-> **instance** SetField "requestedAt" AllocationInstructionView Time
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| output | AllocationInstructionResult_Output | The output of the step. |
+| senderChangeCids | [ContractId Holding] | New holdings owned by the sender created to return "change". Can be used<br/><br/>by callers to batch creating or updating multiple allocation instructions<br/><br/>in a single Daml transaction. |
+| meta | Metadata | Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged. |
+
+Instances:
+
+- `instance Eq AllocationInstructionResult`
+- `instance Show AllocationInstructionResult`
+- `instance HasMethod AllocationFactory allocationFactory_allocateImpl (ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult)`
+- `instance HasMethod AllocationInstruction allocationInstruction_updateImpl (ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult)`
+- `instance HasMethod AllocationInstruction allocationInstruction_withdrawImpl (ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult)`
+- `instance GetField meta AllocationInstructionResult Metadata`
+- `instance GetField output AllocationInstructionResult AllocationInstructionResult_Output`
+- `instance GetField senderChangeCids AllocationInstructionResult [ContractId Holding]`
+- `instance SetField meta AllocationInstructionResult Metadata`
+- `instance SetField output AllocationInstructionResult AllocationInstructionResult_Output`
+- `instance SetField senderChangeCids AllocationInstructionResult [ContractId Holding]`
+- `instance HasExercise AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasExercise AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasExercise AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+- `instance HasExerciseGuarded AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasExerciseGuarded AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasExerciseGuarded AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+- `instance HasFromAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasFromAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasFromAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+- `instance HasToAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasToAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasToAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationinstructionresultoutput-46212"></span>
+
+### `data AllocationInstructionResult_Output`
+
+The output of instructing an allocation or advancing the state of an allocation instruction.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultpending-58494"></span>
+
+- `AllocationInstructionResult_Pending`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationInstructionCid | ContractId AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
+
+Use this result to communicate that the creation of the allocation is pending further steps.
+
+<span id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultcompleted-89210"></span>
+
+- `AllocationInstructionResult_Completed`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationCid | ContractId Allocation | The newly created allocation. |
+
+Use this result to communicate that the allocation was created.
+
+<span id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultfailed-56799"></span>
+
+- `AllocationInstructionResult_Failed`
+
+Use this result to communicate that the creation of the allocation did not succeed and
+all holdings reserved for funding the allocation have been released.
+
+Instances:
+
+- `instance Eq AllocationInstructionResult_Output`
+- `instance Show AllocationInstructionResult_Output`
+- `instance GetField allocationCid AllocationInstructionResult_Output (ContractId Allocation)`
+- `instance GetField allocationInstructionCid AllocationInstructionResult_Output (ContractId AllocationInstruction)`
+- `instance GetField output AllocationInstructionResult AllocationInstructionResult_Output`
+- `instance SetField allocationCid AllocationInstructionResult_Output (ContractId Allocation)`
+- `instance SetField allocationInstructionCid AllocationInstructionResult_Output (ContractId AllocationInstruction)`
+- `instance SetField output AllocationInstructionResult AllocationInstructionResult_Output`
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationinstructionview-72001"></span>
+
+### `data AllocationInstructionView`
+
+View for `AllocationInstruction`.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationinstructionv1-allocationinstructionview-32140"></span>
+
+- `AllocationInstructionView`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| originalInstructionCid | Optional (ContractId AllocationInstruction) | The contract id of the original allocation instruction contract.<br/><br/>Used by the wallet to track the lineage of allocation instructions through multiple steps.<br/><br/>Only set if the registry evolves the allocation instruction in multiple steps. |
+| allocation | AllocationSpecification | The allocation that this instruction should create. |
+| pendingActions | Map Party Text | The pending actions to be taken by different actors to create the allocation.<br/><br/>^ This field can by used to report on the progress of registry specific<br/><br/>workflows that are required to prepare the allocation. |
+| requestedAt | Time | The time at which the allocation was requested. |
+| inputHoldingCids | [ContractId Holding] | The holdings to be used to fund the allocation.<br/><br/>MAY be empty for registries that do not represent their holdings on-ledger. |
+| meta | Metadata | Additional metadata specific to the allocation instruction, used for<br/><br/>extensibility; e.g., more detailed status information. |
+
+Instances:
+
+- `instance Eq AllocationInstructionView`
+- `instance Show AllocationInstructionView`
+- `instance HasFromAnyView AllocationInstruction AllocationInstructionView`
+- `instance HasInterfaceView AllocationInstruction AllocationInstructionView`
+- `instance GetField allocation AllocationInstructionView AllocationSpecification`
+- `instance GetField inputHoldingCids AllocationInstructionView [ContractId Holding]`
+- `instance GetField meta AllocationInstructionView Metadata`
+- `instance GetField originalInstructionCid AllocationInstructionView (Optional (ContractId AllocationInstruction))`
+- `instance GetField pendingActions AllocationInstructionView (Map Party Text)`
+- `instance GetField requestedAt AllocationInstructionView Time`
+- `instance SetField allocation AllocationInstructionView AllocationSpecification`
+- `instance SetField inputHoldingCids AllocationInstructionView [ContractId Holding]`
+- `instance SetField meta AllocationInstructionView Metadata`
+- `instance SetField originalInstructionCid AllocationInstructionView (Optional (ContractId AllocationInstruction))`
+- `instance SetField pendingActions AllocationInstructionView (Map Party Text)`
+- `instance SetField requestedAt AllocationInstructionView Time`
 
 ## Functions
 
-<div id="function-splice-api-token-allocationinstructionv1-allocationinstructionwithdrawimpl-26170">
+<span id="function-splice-api-token-allocationinstructionv1-allocationinstructionwithdrawimpl-26170"></span>
 
-allocationInstruction_withdrawImpl
-: AllocationInstruction -\> ContractId AllocationInstruction -\> AllocationInstruction_Withdraw -\> Update AllocationInstructionResult
+### `allocationInstruction_withdrawImpl`
 
-</div>
+```daml
+allocationInstruction_withdrawImpl : AllocationInstruction -> ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult
+```
 
-<div id="function-splice-api-token-allocationinstructionv1-allocationinstructionupdateimpl-49061">
+<span id="function-splice-api-token-allocationinstructionv1-allocationinstructionupdateimpl-49061"></span>
 
-allocationInstruction_updateImpl
-: AllocationInstruction -\> ContractId AllocationInstruction -\> AllocationInstruction_Update -\> Update AllocationInstructionResult
+### `allocationInstruction_updateImpl`
 
-</div>
+```daml
+allocationInstruction_updateImpl : AllocationInstruction -> ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult
+```
 
-<div id="function-splice-api-token-allocationinstructionv1-allocationfactoryallocateimpl-1231">
+<span id="function-splice-api-token-allocationinstructionv1-allocationfactoryallocateimpl-1231"></span>
 
-allocationFactory_allocateImpl
-: AllocationFactory -\> ContractId AllocationFactory -\> AllocationFactory_Allocate -\> Update AllocationInstructionResult
+### `allocationFactory_allocateImpl`
 
-</div>
+```daml
+allocationFactory_allocateImpl : AllocationFactory -> ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult
+```
 
-<div id="function-splice-api-token-allocationinstructionv1-allocationfactorypublicfetchimpl-77778">
+<span id="function-splice-api-token-allocationinstructionv1-allocationfactorypublicfetchimpl-77778"></span>
 
-allocationFactory_publicFetchImpl
-: AllocationFactory -\> ContractId AllocationFactory -\> AllocationFactory_PublicFetch -\> Update AllocationFactoryView
+### `allocationFactory_publicFetchImpl`
 
-</div>
+```daml
+allocationFactory_publicFetchImpl : AllocationFactory -> ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationfactory-42588"></span>
+
+### Interface `AllocationFactory`
+
+Contracts implementing `AllocationFactory` are retrieved from the registry app and are
+used by the wallet to create allocation instructions (or allocations directly).
+
+View Type: `AllocationFactoryView`
+
+Choices:
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationfactoryallocate-8885"></span>
+
+#### Choice `AllocationFactory_Allocate`
+
+Generic choice for the sender's wallet to request the allocation of
+assets to a specific leg of a settlement. It depends on the registry
+whether this results in the allocation being created directly
+or in an allocation instruction being created instead.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| allocation | AllocationSpecification | The allocation which should be created. |
+| requestedAt | Time | The time at which the allocation was requested. |
+| inputHoldingCids | [ContractId Holding] | The holdings that SHOULD be used to fund the allocation.<br/><br/>MAY be empty for registries that do not represent their holdings on-ledger; or<br/><br/>for registries that support automatic selection of holdings for allocations.<br/><br/>If specified, then the successful allocation MUST archive all of these holdings, so<br/><br/>that the execution of the allocation conflicts with any other allocations<br/><br/>using these holdings. Thereby allowing that the sender can use<br/><br/>deliberate contention on holdings to prevent duplicate allocations. |
+| extraArgs | ExtraArgs | Additional choice arguments. |
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationfactorypublicfetch-20324"></span>
+
+#### Choice `AllocationFactory_PublicFetch`
+
+Controllers: `actor`
+
+Returns: `AllocationFactoryView`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| actor | Party |  |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocationFactory_allocateImpl`
+
+Type: `ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult`
+
+#### Method `allocationFactory_publicFetchImpl`
+
+Type: `ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView`
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationinstruction-29622"></span>
+
+### Interface `AllocationInstruction`
+
+An interface for tracking the status of an allocation instruction,
+i.e., a request to a registry app to create an allocation.
+
+Registries MAY evolve the allocation instruction in multiple steps. They SHOULD
+do so using only the choices on this interface, so that wallets can reliably
+parse the transaction history and determine whether the creation of the allocation ultimately
+succeeded or failed.
+
+View Type: `AllocationInstructionView`
+
+Choices:
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationinstructionupdate-50223"></span>
+
+#### Choice `AllocationInstruction_Update`
+
+Update the state of the allocation instruction. Used by the registry to
+execute registry internal workflow steps that advance the state of the
+allocation instruction. A reason may be communicated via the metadata.
+
+Controllers: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this)))))`, `extraActors`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraActors | [Party] | Extra actors authorizing the update. Implementations MUST check that<br/><br/>this field contains the expected actors for the specific update. |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-allocationinstructionv1-allocationinstructionwithdraw-35988"></span>
+
+#### Choice `AllocationInstruction_Withdraw`
+
+Withdraw the allocation instruction as the sender.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocationInstruction_updateImpl`
+
+Type: `ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult`
+
+#### Method `allocationInstruction_withdrawImpl`
+
+Type: `ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-allocation-request-v1 docs"
-description: "Documentation for splice-api-token-allocation-request-v1 docs"
+title: "splice-api-token-allocation-request-v1"
+description: "Reference documentation for splice-api-token-allocation-request-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-request-v1/docs/index.rst" hash="07b3a773" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-allocation-request-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-allocation-request-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.AllocationRequestV1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.AllocationRequestV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module defines the interface for an AllocationRequest, which is an interface that can</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
@@ -1,133 +1,154 @@
 ---
 title: "Splice.Api.Token.AllocationRequestV1"
-description: "Documentation for Splice.Api.Token.AllocationRequestV1"
+description: "Reference documentation for Daml module Splice.Api.Token.AllocationRequestV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-request-v1/docs/Splice-Api-Token-AllocationRequestV1.rst" hash="b1b99c84" */}
+<span id="module-splice-api-token-allocationrequestv1-2106"></span>
 
-This module defines the interface for an `AllocationRequest`, which is an interface that can be implemented by an app to request specific allocations from their users for the purpose of settling a DvP or a payment as part of an app's workflow.
+# Splice.Api.Token.AllocationRequestV1
 
-## Interfaces
+This module defines the interface for an `AllocationRequest`, which is an interface that can
 
-<div id="type-splice-api-token-allocationrequestv1-allocationrequest-90278">
+be implemented by an app to request specific allocations from their users
 
-**interface** AllocationRequest
+for the purpose of settling a DvP or a payment as part of an app's workflow.
 
-</div>
+## Module Snapshot
 
-> A request by an app for allocations to be created to enable the execution of a settlement.
->
-> Apps are free to use a single request spanning all senders or one request per sender.
->
-> **viewtype** AllocationRequestView
->
-> - <div id="type-splice-api-token-allocationrequestv1-allocationrequestreject-89381">
->
->   **Choice** AllocationRequest_Reject
->
->   </div>
->
->   Reject an allocation request.
->
->   Implementations SHOULD allow any sender of a transfer leg to reject the allocation request, and thereby signal that they are definitely not going to create a matching allocation for the settlement.
->
->   Controller: actor
->
->   Returns: ChoiceExecutionMetadata
->
->   | Field     | Type                                                                                    | Description                                                  |
->   |-----------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------|
->   | actor     | Party | The party rejecting the allocation request.                  |
->   | extraArgs | ExtraArgs                                                                               | Additional context required in order to exercise the choice. |
->
-> - <div id="type-splice-api-token-allocationrequestv1-allocationrequestwithdraw-15628">
->
->   **Choice** AllocationRequest_Withdraw
->
->   </div>
->
->   Withdraw an allocation request as the executor.
->
->   Used by executors to withdraw the allocation request if they are unable to execute it; e.g., because a trade has been cancelled.
->
->   Controller: (DA.Internal.Record.getField @"executor" (DA.Internal.Record.getField @"settlement" (view this)))
->
->   Returns: ChoiceExecutionMetadata
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - **Method allocationRequest_RejectImpl :** ContractId AllocationRequest -\> AllocationRequest_Reject -\> Update ChoiceExecutionMetadata
->
-> - **Method allocationRequest_WithdrawImpl :** ContractId AllocationRequest -\> AllocationRequest_Withdraw -\> Update ChoiceExecutionMetadata
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-allocationrequestv1-allocationrequestview-51417">
+<span id="type-splice-api-token-allocationrequestv1-allocationrequestview-51417"></span>
 
-**data** AllocationRequestView
+### `data AllocationRequestView`
 
-</div>
+View of `AllocationRequest`.
 
-> View of `AllocationRequest`.
->
-> Implementations SHOULD make sure that at least all senders of the transfer legs are observers of the implementing contract, so that their wallet can show the request to them.
->
-> <div id="constr-splice-api-token-allocationrequestv1-allocationrequestview-59188">
->
-> AllocationRequestView
->
-> </div>
->
-> > | Field        | Type                                                                                                    | Description                                                                                                                                                                                                                                                        |
-> > |--------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | settlement   | SettlementInfo                                                                                          | Settlement for which the assets are requested to be allocated.                                                                                                                                                                                                     |
-> > | transferLegs | TextMap TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement keyed by their identifier. This may or may not be a complete list of transfer legs that are part of the settlement, depending on the confidentiality requirements of the app. |
-> > | meta         | Metadata                                                                                                | Additional metadata specific to the allocation request, used for extensibility.                                                                                                                                                                                    |
->
-> **instance** Eq AllocationRequestView
->
-> **instance** Show AllocationRequestView
->
-> **instance** HasFromAnyView AllocationRequest AllocationRequestView
->
-> **instance** HasInterfaceView AllocationRequest AllocationRequestView
->
-> **instance** GetField "meta" AllocationRequestView Metadata
->
-> **instance** GetField "settlement" AllocationRequestView SettlementInfo
->
-> **instance** GetField "transferLegs" AllocationRequestView (TextMap TransferLeg)
->
-> **instance** SetField "meta" AllocationRequestView Metadata
->
-> **instance** SetField "settlement" AllocationRequestView SettlementInfo
->
-> **instance** SetField "transferLegs" AllocationRequestView (TextMap TransferLeg)
+Implementations SHOULD make sure that at least all senders of the transfer legs
+are observers of the implementing contract, so that their wallet can show
+the request to them.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationrequestv1-allocationrequestview-59188"></span>
+
+- `AllocationRequestView`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| settlement | SettlementInfo | Settlement for which the assets are requested to be allocated. |
+| transferLegs | TextMap TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement<br/><br/>keyed by their identifier.<br/><br/>This may or may not be a complete list of transfer legs that are part of the settlement,<br/><br/>depending on the confidentiality requirements of the app. |
+| meta | Metadata | Additional metadata specific to the allocation request, used for extensibility. |
+
+Instances:
+
+- `instance Eq AllocationRequestView`
+- `instance Show AllocationRequestView`
+- `instance HasFromAnyView AllocationRequest AllocationRequestView`
+- `instance HasInterfaceView AllocationRequest AllocationRequestView`
+- `instance GetField meta AllocationRequestView Metadata`
+- `instance GetField settlement AllocationRequestView SettlementInfo`
+- `instance GetField transferLegs AllocationRequestView (TextMap TransferLeg)`
+- `instance SetField meta AllocationRequestView Metadata`
+- `instance SetField settlement AllocationRequestView SettlementInfo`
+- `instance SetField transferLegs AllocationRequestView (TextMap TransferLeg)`
 
 ## Functions
 
-<div id="function-splice-api-token-allocationrequestv1-allocationrequestrejectimpl-48931">
+<span id="function-splice-api-token-allocationrequestv1-allocationrequestrejectimpl-48931"></span>
 
-allocationRequest_RejectImpl
-: AllocationRequest -\> ContractId AllocationRequest -\> AllocationRequest_Reject -\> Update ChoiceExecutionMetadata
+### `allocationRequest_RejectImpl`
 
-</div>
+```daml
+allocationRequest_RejectImpl : AllocationRequest -> ContractId AllocationRequest -> AllocationRequest_Reject -> Update ChoiceExecutionMetadata
+```
 
-<div id="function-splice-api-token-allocationrequestv1-allocationrequestwithdrawimpl-31866">
+<span id="function-splice-api-token-allocationrequestv1-allocationrequestwithdrawimpl-31866"></span>
 
-allocationRequest_WithdrawImpl
-: AllocationRequest -\> ContractId AllocationRequest -\> AllocationRequest_Withdraw -\> Update ChoiceExecutionMetadata
+### `allocationRequest_WithdrawImpl`
 
-</div>
+```daml
+allocationRequest_WithdrawImpl : AllocationRequest -> ContractId AllocationRequest -> AllocationRequest_Withdraw -> Update ChoiceExecutionMetadata
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-token-allocationrequestv1-allocationrequest-90278"></span>
+
+### Interface `AllocationRequest`
+
+A request by an app for allocations to be created to enable the execution of a settlement.
+
+Apps are free to use a single request spanning all senders or one request per sender.
+
+View Type: `AllocationRequestView`
+
+Choices:
+
+<span id="type-splice-api-token-allocationrequestv1-allocationrequestreject-89381"></span>
+
+#### Choice `AllocationRequest_Reject`
+
+Reject an allocation request.
+
+Implementations SHOULD allow any sender of a transfer leg to reject the allocation request,
+and thereby signal that they are definitely not going to create a matching allocation for the settlement.
+
+Controllers: `actor`
+
+Returns: `ChoiceExecutionMetadata`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party | The party rejecting the allocation request. |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-allocationrequestv1-allocationrequestwithdraw-15628"></span>
+
+#### Choice `AllocationRequest_Withdraw`
+
+Withdraw an allocation request as the executor.
+
+Used by executors to withdraw the allocation request if they are unable to execute it;
+e.g., because a trade has been cancelled.
+
+Controllers: `(DA.Internal.Record.getField @"executor" (DA.Internal.Record.getField @"settlement" (view this)))`
+
+Returns: `ChoiceExecutionMetadata`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocationRequest_RejectImpl`
+
+Type: `ContractId AllocationRequest -> AllocationRequest_Reject -> Update ChoiceExecutionMetadata`
+
+#### Method `allocationRequest_WithdrawImpl`
+
+Type: `ContractId AllocationRequest -> AllocationRequest_Withdraw -> Update ChoiceExecutionMetadata`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-allocation-v1 docs"
-description: "Documentation for splice-api-token-allocation-v1 docs"
+title: "splice-api-token-allocation-v1"
+description: "Reference documentation for splice-api-token-allocation-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-v1/docs/index.rst" hash="eca0a9a3" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-allocation-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-allocation-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.AllocationV1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.AllocationV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module defines the Allocation interface and supporting types.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
@@ -1,474 +1,430 @@
 ---
 title: "Splice.Api.Token.AllocationV1"
-description: "Documentation for Splice.Api.Token.AllocationV1"
+description: "Reference documentation for Daml module Splice.Api.Token.AllocationV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-v1/docs/Splice-Api-Token-AllocationV1.rst" hash="d9b34e39" */}
+<span id="module-splice-api-token-allocationv1-39050"></span>
+
+# Splice.Api.Token.AllocationV1
 
 This module defines the `Allocation` interface and supporting types.
 
-Contracts implementing the `Allocation` interface represent a reservation of assets to transfer them as part of an atomic on-ledger settlement requested by an app.
+Contracts implementing the `Allocation` interface represent a reservation of
 
-## Interfaces
+assets to transfer them as part of an atomic on-ledger settlement requested
 
-<div id="type-splice-api-token-allocationv1-allocation-9928">
+by an app.
 
-**interface** Allocation
+## Module Snapshot
 
-</div>
-
-> A contract representing an allocation of some amount of aasset holdings to a specific leg of a settlement.
->
-> **viewtype** AllocationView
->
-> - <div id="type-splice-api-token-allocationv1-allocationcancel-25504">
->
->   **Choice** Allocation_Cancel
->
->   </div>
->
->   Cancel the allocation. Requires authorization from sender, receiver, and executor.
->
->   Typically this authorization is granted by sender and receiver to the executor as part of the contract coordinating the settlement, so that that the executor can release the allocated assets early in case the settlement is aborted or it has definitely failed.
->
->   Controller: allocationControllers (view this)
->
->   Returns: Allocation_CancelResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - <div id="type-splice-api-token-allocationv1-allocationexecutetransfer-74529">
->
->   **Choice** Allocation_ExecuteTransfer
->
->   </div>
->
->   Execute the transfer of the allocated assets. Intended to be used to execute the settlement. This choice SHOULD succeed provided the `settlement.settleBefore` deadline has not yet passed.
->
->   Controller: allocationControllers (view this)
->
->   Returns: Allocation_ExecuteTransferResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - <div id="type-splice-api-token-allocationv1-allocationwithdraw-60458">
->
->   **Choice** Allocation_Withdraw
->
->   </div>
->
->   Withdraw the allocated assets. Used by the sender to withdraw the assets before settlement was completed. This SHOULD not fail settlement if the sender has still time to allocate the assets again; i.e., the `settlement.allocateBefore` deadline has not yet passed.
->
->   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))
->
->   Returns: Allocation_WithdrawResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - **Method allocation_cancelImpl :** ContractId Allocation -\> Allocation_Cancel -\> Update Allocation_CancelResult
->
-> - **Method allocation_executeTransferImpl :** ContractId Allocation -\> Allocation_ExecuteTransfer -\> Update Allocation_ExecuteTransferResult
->
-> - **Method allocation_withdrawImpl :** ContractId Allocation -\> Allocation_Withdraw -\> Update Allocation_WithdrawResult
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-allocationv1-allocationspecification-94148">
+<span id="type-splice-api-token-allocationv1-allocationspecification-94148"></span>
 
-**data** AllocationSpecification
+### `data AllocationSpecification`
 
-</div>
+The specification of an allocation of assets to a specific leg of a settlement.
 
-> The specification of an allocation of assets to a specific leg of a settlement.
->
-> In contrast to an `AllocationView` this just specifies what should be allocated, but not the holdings that are backing the allocation.
->
-> <div id="constr-splice-api-token-allocationv1-allocationspecification-66543">
->
-> AllocationSpecification
->
-> </div>
->
-> > | Field         | Type                                                                             | Description                                                        |
-> > |---------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------|
-> > | settlement    | SettlementInfo                                                                   | The settlement for whose execution the assets are being allocated. |
-> > | transferLegId | Text | A unique identifer for the transfer leg within the settlement.     |
-> > | transferLeg   | TransferLeg                                                                      | The transfer for which the assets are being allocated.             |
->
-> **instance** Eq AllocationSpecification
->
-> **instance** Show AllocationSpecification
->
-> **instance** GetField "allocation" AllocationView AllocationSpecification
->
-> **instance** GetField "settlement" AllocationSpecification SettlementInfo
->
-> **instance** GetField "transferLeg" AllocationSpecification TransferLeg
->
-> **instance** GetField "transferLegId" AllocationSpecification Text
->
-> **instance** SetField "allocation" AllocationView AllocationSpecification
->
-> **instance** SetField "settlement" AllocationSpecification SettlementInfo
->
-> **instance** SetField "transferLeg" AllocationSpecification TransferLeg
->
-> **instance** SetField "transferLegId" AllocationSpecification Text
+In contrast to an `AllocationView` this just specifies what should be allocated,
+but not the holdings that are backing the allocation.
 
-<div id="type-splice-api-token-allocationv1-allocationview-9103">
+Constructors:
 
-**data** AllocationView
+<span id="constr-splice-api-token-allocationv1-allocationspecification-66543"></span>
 
-</div>
+- `AllocationSpecification`
 
-> View of a funded allocation of assets to a specific leg of a settlement.
->
-> <div id="constr-splice-api-token-allocationv1-allocationview-89090">
->
-> AllocationView
->
-> </div>
->
-> > | Field       | Type                                                                                                          | Description                                                                                                                                                                                              |
-> > |-------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | allocation  | AllocationSpecification                                                                                       | The settlement for whose execution the assets are being allocated.                                                                                                                                       |
-> > | holdingCids | \[ContractId Holding\] | The holdings that are backing this allocation. Provided so that that wallets can correlate the allocation with the holdings. MAY be empty for registries that do not represent their holdings on-ledger. |
-> > | meta        | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility.                                                                                                                                  |
->
-> **instance** Eq AllocationView
->
-> **instance** Show AllocationView
->
-> **instance** HasFromAnyView Allocation AllocationView
->
-> **instance** HasInterfaceView Allocation AllocationView
->
-> **instance** GetField "allocation" AllocationView AllocationSpecification
->
-> **instance** GetField "holdingCids" AllocationView \[ContractId Holding\]
->
-> **instance** GetField "meta" AllocationView Metadata
->
-> **instance** SetField "allocation" AllocationView AllocationSpecification
->
-> **instance** SetField "holdingCids" AllocationView \[ContractId Holding\]
->
-> **instance** SetField "meta" AllocationView Metadata
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| settlement | SettlementInfo | The settlement for whose execution the assets are being allocated. |
+| transferLegId | Text | A unique identifer for the transfer leg within the settlement. |
+| transferLeg | TransferLeg | The transfer for which the assets are being allocated. |
 
-<div id="type-splice-api-token-allocationv1-allocationcancelresult-26037">
+Instances:
 
-**data** Allocation_CancelResult
+- `instance Eq AllocationSpecification`
+- `instance Show AllocationSpecification`
+- `instance GetField allocation AllocationView AllocationSpecification`
+- `instance GetField settlement AllocationSpecification SettlementInfo`
+- `instance GetField transferLeg AllocationSpecification TransferLeg`
+- `instance GetField transferLegId AllocationSpecification Text`
+- `instance SetField allocation AllocationView AllocationSpecification`
+- `instance SetField settlement AllocationSpecification SettlementInfo`
+- `instance SetField transferLeg AllocationSpecification TransferLeg`
+- `instance SetField transferLegId AllocationSpecification Text`
 
-</div>
+<span id="type-splice-api-token-allocationv1-allocationview-9103"></span>
 
-> The result of the `Allocation_Cancel` choice.
->
-> <div id="constr-splice-api-token-allocationv1-allocationcancelresult-74846">
->
-> Allocation_CancelResult
->
-> </div>
->
-> > | Field             | Type                                                                                                          | Description                                                             |
-> > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | senderHoldingCids | \[ContractId Holding\] | The holdings that were released back to the sender.                     |
-> > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
->
-> **instance** Eq Allocation_CancelResult
->
-> **instance** Show Allocation_CancelResult
->
-> **instance** HasMethod Allocation "allocation_cancelImpl" (ContractId Allocation -\> Allocation_Cancel -\> Update Allocation_CancelResult)
->
-> **instance** GetField "meta" Allocation_CancelResult Metadata
->
-> **instance** GetField "senderHoldingCids" Allocation_CancelResult \[ContractId Holding\]
->
-> **instance** SetField "meta" Allocation_CancelResult Metadata
->
-> **instance** SetField "senderHoldingCids" Allocation_CancelResult \[ContractId Holding\]
->
-> **instance** HasExercise Allocation Allocation_Cancel Allocation_CancelResult
->
-> **instance** HasExerciseGuarded Allocation Allocation_Cancel Allocation_CancelResult
->
-> **instance** HasFromAnyChoice Allocation Allocation_Cancel Allocation_CancelResult
->
-> **instance** HasToAnyChoice Allocation Allocation_Cancel Allocation_CancelResult
+### `data AllocationView`
 
-<div id="type-splice-api-token-allocationv1-allocationexecutetransferresult-74160">
+View of a funded allocation of assets to a specific leg of a settlement.
 
-**data** Allocation_ExecuteTransferResult
+Constructors:
 
-</div>
+<span id="constr-splice-api-token-allocationv1-allocationview-89090"></span>
 
-> The result of the `Allocation_ExecuteTransfer` choice.
->
-> <div id="constr-splice-api-token-allocationv1-allocationexecutetransferresult-50341">
->
-> Allocation_ExecuteTransferResult
->
-> </div>
->
-> > | Field               | Type                                                                                                          | Description                                                                                              |
-> > |---------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-> > | senderHoldingCids   | \[ContractId Holding\] | The holdings that were created for the sender. Can be used to return "change" to the sender if required. |
-> > | receiverHoldingCids | \[ContractId Holding\] | The holdings that were created for the receiver.                                                         |
-> > | meta                | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility.                        |
->
-> **instance** Eq Allocation_ExecuteTransferResult
->
-> **instance** Show Allocation_ExecuteTransferResult
->
-> **instance** HasMethod Allocation "allocation_executeTransferImpl" (ContractId Allocation -\> Allocation_ExecuteTransfer -\> Update Allocation_ExecuteTransferResult)
->
-> **instance** GetField "meta" Allocation_ExecuteTransferResult Metadata
->
-> **instance** GetField "receiverHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
->
-> **instance** GetField "senderHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
->
-> **instance** SetField "meta" Allocation_ExecuteTransferResult Metadata
->
-> **instance** SetField "receiverHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
->
-> **instance** SetField "senderHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
->
-> **instance** HasExercise Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
->
-> **instance** HasExerciseGuarded Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
->
-> **instance** HasFromAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
->
-> **instance** HasToAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+- `AllocationView`
 
-<div id="type-splice-api-token-allocationv1-allocationwithdrawresult-40879">
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocation | AllocationSpecification | The settlement for whose execution the assets are being allocated. |
+| holdingCids | [ContractId Holding] | The holdings that are backing this allocation.<br/><br/>Provided so that that wallets can correlate the allocation with the<br/><br/>holdings.<br/><br/>MAY be empty for registries that do not represent their holdings on-ledger. |
+| meta | Metadata | Additional metadata specific to the allocation, used for extensibility. |
 
-**data** Allocation_WithdrawResult
+Instances:
 
-</div>
+- `instance Eq AllocationView`
+- `instance Show AllocationView`
+- `instance HasFromAnyView Allocation AllocationView`
+- `instance HasInterfaceView Allocation AllocationView`
+- `instance GetField allocation AllocationView AllocationSpecification`
+- `instance GetField holdingCids AllocationView [ContractId Holding]`
+- `instance GetField meta AllocationView Metadata`
+- `instance SetField allocation AllocationView AllocationSpecification`
+- `instance SetField holdingCids AllocationView [ContractId Holding]`
+- `instance SetField meta AllocationView Metadata`
 
-> The result of the `Allocation_Withdraw` choice.
->
-> <div id="constr-splice-api-token-allocationv1-allocationwithdrawresult-86620">
->
-> Allocation_WithdrawResult
->
-> </div>
->
-> > | Field             | Type                                                                                                          | Description                                                             |
-> > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | senderHoldingCids | \[ContractId Holding\] | The holdings that were released back to the sender.                     |
-> > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
->
-> **instance** Eq Allocation_WithdrawResult
->
-> **instance** Show Allocation_WithdrawResult
->
-> **instance** HasMethod Allocation "allocation_withdrawImpl" (ContractId Allocation -\> Allocation_Withdraw -\> Update Allocation_WithdrawResult)
->
-> **instance** GetField "meta" Allocation_WithdrawResult Metadata
->
-> **instance** GetField "senderHoldingCids" Allocation_WithdrawResult \[ContractId Holding\]
->
-> **instance** SetField "meta" Allocation_WithdrawResult Metadata
->
-> **instance** SetField "senderHoldingCids" Allocation_WithdrawResult \[ContractId Holding\]
->
-> **instance** HasExercise Allocation Allocation_Withdraw Allocation_WithdrawResult
->
-> **instance** HasExerciseGuarded Allocation Allocation_Withdraw Allocation_WithdrawResult
->
-> **instance** HasFromAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult
->
-> **instance** HasToAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult
+<span id="type-splice-api-token-allocationv1-allocationcancelresult-26037"></span>
 
-<div id="type-splice-api-token-allocationv1-reference-53456">
+### `data Allocation_CancelResult`
 
-**data** Reference
+The result of the `Allocation_Cancel` choice.
 
-</div>
+Constructors:
 
-> A generic type to refer to data defined within an app.
->
-> <div id="constr-splice-api-token-allocationv1-reference-11427">
->
-> Reference
->
-> </div>
->
-> > | Field | Type                                                                                                             | Description                                                                                                                                                                                                                                                                |
-> > |-------|------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | id    | Text                                 | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.                                                                                                                                                         |
-> > | cid   | Optional AnyContractId | Optional contract-id to use for referring to contracts. This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml, which is due to their full textual representation being only known after transactions have been prepared. |
->
-> **instance** Eq Reference
->
-> **instance** Show Reference
->
-> **instance** GetField "cid" Reference (Optional AnyContractId)
->
-> **instance** GetField "id" Reference Text
->
-> **instance** GetField "settlementRef" SettlementInfo Reference
->
-> **instance** SetField "cid" Reference (Optional AnyContractId)
->
-> **instance** SetField "id" Reference Text
->
-> **instance** SetField "settlementRef" SettlementInfo Reference
+<span id="constr-splice-api-token-allocationv1-allocationcancelresult-74846"></span>
 
-<div id="type-splice-api-token-allocationv1-settlementinfo-4367">
+- `Allocation_CancelResult`
 
-**data** SettlementInfo
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| senderHoldingCids | [ContractId Holding] | The holdings that were released back to the sender. |
+| meta | Metadata | Additional metadata specific to the allocation, used for extensibility. |
 
-</div>
+Instances:
 
-> The minimal set of information about a settlement that an app would like to execute.
->
-> <div id="constr-splice-api-token-allocationv1-settlementinfo-25294">
->
-> SettlementInfo
->
-> </div>
->
-> > | Field          | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                      |
-> > |----------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | executor       | Party | The party that is responsible for executing the settlement.                                                                                                                                                                                                                                                                                      |
-> > | settlementRef  | Reference                                                                               | Reference to the settlement that app would like to execute.                                                                                                                                                                                                                                                                                      |
-> > | requestedAt    | Time   | When the settlement was requested. Provided for display and debugging purposes, but SHOULD be in the past.                                                                                                                                                                                                                                       |
-> > | allocateBefore | Time   | Until when (exclusive) the senders are given time to allocate their assets. This field has a particular relevance with respect to instrument versioning / corporate actions, in that the settlement pertains to the instrument version resulting from the processing of all corporate actions falling strictly before the `allocateBefore` time. |
-> > | settleBefore   | Time   | Until when (exclusive) the executor is given time to execute the settlement. SHOULD be strictly after `allocateBefore`.                                                                                                                                                                                                                          |
-> > | meta           | Metadata                                                                                | Additional metadata about the settlement, used for extensibility.                                                                                                                                                                                                                                                                                |
->
-> **instance** Eq SettlementInfo
->
-> **instance** Show SettlementInfo
->
-> **instance** GetField "allocateBefore" SettlementInfo Time
->
-> **instance** GetField "executor" SettlementInfo Party
->
-> **instance** GetField "meta" SettlementInfo Metadata
->
-> **instance** GetField "requestedAt" SettlementInfo Time
->
-> **instance** GetField "settleBefore" SettlementInfo Time
->
-> **instance** GetField "settlement" AllocationSpecification SettlementInfo
->
-> **instance** GetField "settlementRef" SettlementInfo Reference
->
-> **instance** SetField "allocateBefore" SettlementInfo Time
->
-> **instance** SetField "executor" SettlementInfo Party
->
-> **instance** SetField "meta" SettlementInfo Metadata
->
-> **instance** SetField "requestedAt" SettlementInfo Time
->
-> **instance** SetField "settleBefore" SettlementInfo Time
->
-> **instance** SetField "settlement" AllocationSpecification SettlementInfo
->
-> **instance** SetField "settlementRef" SettlementInfo Reference
+- `instance Eq Allocation_CancelResult`
+- `instance Show Allocation_CancelResult`
+- `instance HasMethod Allocation allocation_cancelImpl (ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult)`
+- `instance GetField meta Allocation_CancelResult Metadata`
+- `instance GetField senderHoldingCids Allocation_CancelResult [ContractId Holding]`
+- `instance SetField meta Allocation_CancelResult Metadata`
+- `instance SetField senderHoldingCids Allocation_CancelResult [ContractId Holding]`
+- `instance HasExercise Allocation Allocation_Cancel Allocation_CancelResult`
+- `instance HasExerciseGuarded Allocation Allocation_Cancel Allocation_CancelResult`
+- `instance HasFromAnyChoice Allocation Allocation_Cancel Allocation_CancelResult`
+- `instance HasToAnyChoice Allocation Allocation_Cancel Allocation_CancelResult`
 
-<div id="type-splice-api-token-allocationv1-transferleg-71662">
+<span id="type-splice-api-token-allocationv1-allocationexecutetransferresult-74160"></span>
 
-**data** TransferLeg
+### `data Allocation_ExecuteTransferResult`
 
-</div>
+The result of the `Allocation_ExecuteTransfer` choice.
 
-> A specification of a transfer of holdings between two parties for the purpose of a settlement, which often requires the atomic execution of multiple legs.
->
-> <div id="constr-splice-api-token-allocationv1-transferleg-72717">
->
-> TransferLeg
->
-> </div>
->
-> > | Field        | Type                                                                                    | Description                                                         |
-> > |--------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-> > | sender       | Party | The sender of the transfer.                                         |
-> > | receiver     | Party | The receiver of the transfer.                                       |
-> > | amount       | Decimal  | The amount to transfer.                                             |
-> > | instrumentId | InstrumentId                                                                            | The instrument identifier.                                          |
-> > | meta         | Metadata                                                                                | Additional metadata about the transfer leg, used for extensibility. |
->
-> **instance** Eq TransferLeg
->
-> **instance** Ord TransferLeg
->
-> **instance** Show TransferLeg
->
-> **instance** GetField "amount" TransferLeg Decimal
->
-> **instance** GetField "instrumentId" TransferLeg InstrumentId
->
-> **instance** GetField "meta" TransferLeg Metadata
->
-> **instance** GetField "receiver" TransferLeg Party
->
-> **instance** GetField "sender" TransferLeg Party
->
-> **instance** GetField "transferLeg" AllocationSpecification TransferLeg
->
-> **instance** SetField "amount" TransferLeg Decimal
->
-> **instance** SetField "instrumentId" TransferLeg InstrumentId
->
-> **instance** SetField "meta" TransferLeg Metadata
->
-> **instance** SetField "receiver" TransferLeg Party
->
-> **instance** SetField "sender" TransferLeg Party
->
-> **instance** SetField "transferLeg" AllocationSpecification TransferLeg
+Constructors:
+
+<span id="constr-splice-api-token-allocationv1-allocationexecutetransferresult-50341"></span>
+
+- `Allocation_ExecuteTransferResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| senderHoldingCids | [ContractId Holding] | The holdings that were created for the sender. Can be used to return<br/><br/>"change" to the sender if required. |
+| receiverHoldingCids | [ContractId Holding] | The holdings that were created for the receiver. |
+| meta | Metadata | Additional metadata specific to the transfer instruction, used for extensibility. |
+
+Instances:
+
+- `instance Eq Allocation_ExecuteTransferResult`
+- `instance Show Allocation_ExecuteTransferResult`
+- `instance HasMethod Allocation allocation_executeTransferImpl (ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult)`
+- `instance GetField meta Allocation_ExecuteTransferResult Metadata`
+- `instance GetField receiverHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance GetField senderHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance SetField meta Allocation_ExecuteTransferResult Metadata`
+- `instance SetField receiverHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance SetField senderHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance HasExercise Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+- `instance HasExerciseGuarded Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+- `instance HasFromAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+- `instance HasToAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+
+<span id="type-splice-api-token-allocationv1-allocationwithdrawresult-40879"></span>
+
+### `data Allocation_WithdrawResult`
+
+The result of the `Allocation_Withdraw` choice.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationv1-allocationwithdrawresult-86620"></span>
+
+- `Allocation_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| senderHoldingCids | [ContractId Holding] | The holdings that were released back to the sender. |
+| meta | Metadata | Additional metadata specific to the allocation, used for extensibility. |
+
+Instances:
+
+- `instance Eq Allocation_WithdrawResult`
+- `instance Show Allocation_WithdrawResult`
+- `instance HasMethod Allocation allocation_withdrawImpl (ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult)`
+- `instance GetField meta Allocation_WithdrawResult Metadata`
+- `instance GetField senderHoldingCids Allocation_WithdrawResult [ContractId Holding]`
+- `instance SetField meta Allocation_WithdrawResult Metadata`
+- `instance SetField senderHoldingCids Allocation_WithdrawResult [ContractId Holding]`
+- `instance HasExercise Allocation Allocation_Withdraw Allocation_WithdrawResult`
+- `instance HasExerciseGuarded Allocation Allocation_Withdraw Allocation_WithdrawResult`
+- `instance HasFromAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult`
+- `instance HasToAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult`
+
+<span id="type-splice-api-token-allocationv1-reference-53456"></span>
+
+### `data Reference`
+
+A generic type to refer to data defined within an app.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationv1-reference-11427"></span>
+
+- `Reference`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| id | Text | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient. |
+| cid | Optional AnyContractId | Optional contract-id to use for referring to contracts.<br/><br/>This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml,<br/><br/>which is due to their full textual representation being only known after transactions have been prepared. |
+
+Instances:
+
+- `instance Eq Reference`
+- `instance Show Reference`
+- `instance GetField cid Reference (Optional AnyContractId)`
+- `instance GetField id Reference Text`
+- `instance GetField settlementRef SettlementInfo Reference`
+- `instance SetField cid Reference (Optional AnyContractId)`
+- `instance SetField id Reference Text`
+- `instance SetField settlementRef SettlementInfo Reference`
+
+<span id="type-splice-api-token-allocationv1-settlementinfo-4367"></span>
+
+### `data SettlementInfo`
+
+The minimal set of information about a settlement that an app would like to execute.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationv1-settlementinfo-25294"></span>
+
+- `SettlementInfo`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| executor | Party | The party that is responsible for executing the settlement. |
+| settlementRef | Reference | Reference to the settlement that app would like to execute. |
+| requestedAt | Time | When the settlement was requested. Provided for display and debugging purposes,<br/><br/>but SHOULD be in the past. |
+| allocateBefore | Time | Until when (exclusive) the senders are given time to allocate their assets.<br/><br/>This field has a particular relevance with respect to instrument versioning / corporate<br/><br/>actions, in that the settlement pertains to the instrument version resulting from the<br/><br/>processing of all corporate actions falling strictly before the `allocateBefore` time. |
+| settleBefore | Time | Until when (exclusive) the executor is given time to execute the settlement.<br/><br/>SHOULD be strictly after `allocateBefore`. |
+| meta | Metadata | Additional metadata about the settlement, used for extensibility. |
+
+Instances:
+
+- `instance Eq SettlementInfo`
+- `instance Show SettlementInfo`
+- `instance GetField allocateBefore SettlementInfo Time`
+- `instance GetField executor SettlementInfo Party`
+- `instance GetField meta SettlementInfo Metadata`
+- `instance GetField requestedAt SettlementInfo Time`
+- `instance GetField settleBefore SettlementInfo Time`
+- `instance GetField settlement AllocationSpecification SettlementInfo`
+- `instance GetField settlementRef SettlementInfo Reference`
+- `instance SetField allocateBefore SettlementInfo Time`
+- `instance SetField executor SettlementInfo Party`
+- `instance SetField meta SettlementInfo Metadata`
+- `instance SetField requestedAt SettlementInfo Time`
+- `instance SetField settleBefore SettlementInfo Time`
+- `instance SetField settlement AllocationSpecification SettlementInfo`
+- `instance SetField settlementRef SettlementInfo Reference`
+
+<span id="type-splice-api-token-allocationv1-transferleg-71662"></span>
+
+### `data TransferLeg`
+
+A specification of a transfer of holdings between two parties for the
+purpose of a settlement, which often requires the atomic execution of multiple legs.
+
+Constructors:
+
+<span id="constr-splice-api-token-allocationv1-transferleg-72717"></span>
+
+- `TransferLeg`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The sender of the transfer. |
+| receiver | Party | The receiver of the transfer. |
+| amount | Decimal | The amount to transfer. |
+| instrumentId | InstrumentId | The instrument identifier. |
+| meta | Metadata | Additional metadata about the transfer leg, used for extensibility. |
+
+Instances:
+
+- `instance Eq TransferLeg`
+- `instance Ord TransferLeg`
+- `instance Show TransferLeg`
+- `instance GetField amount TransferLeg Decimal`
+- `instance GetField instrumentId TransferLeg InstrumentId`
+- `instance GetField meta TransferLeg Metadata`
+- `instance GetField receiver TransferLeg Party`
+- `instance GetField sender TransferLeg Party`
+- `instance GetField transferLeg AllocationSpecification TransferLeg`
+- `instance SetField amount TransferLeg Decimal`
+- `instance SetField instrumentId TransferLeg InstrumentId`
+- `instance SetField meta TransferLeg Metadata`
+- `instance SetField receiver TransferLeg Party`
+- `instance SetField sender TransferLeg Party`
+- `instance SetField transferLeg AllocationSpecification TransferLeg`
 
 ## Functions
 
-<div id="function-splice-api-token-allocationv1-allocationcontrollers-10222">
+<span id="function-splice-api-token-allocationv1-allocationcontrollers-10222"></span>
 
-allocationControllers
-: AllocationView -\> \[Party\]
+### `allocationControllers`
 
-Convenience function to refer to the union of sender, receiver, and executor of the settlement, which jointly control the execution of the allocation.
+```daml
+allocationControllers : AllocationView -> [Party]
+```
 
-</div>
+Convenience function to refer to the union of sender, receiver, and
+executor of the settlement, which jointly control the execution of the
+allocation.
 
-<div id="function-splice-api-token-allocationv1-allocationexecutetransferimpl-90251">
+<span id="function-splice-api-token-allocationv1-allocationexecutetransferimpl-90251"></span>
 
-allocation_executeTransferImpl
-: Allocation -\> ContractId Allocation -\> Allocation_ExecuteTransfer -\> Update Allocation_ExecuteTransferResult
+### `allocation_executeTransferImpl`
 
-</div>
+```daml
+allocation_executeTransferImpl : Allocation -> ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult
+```
 
-<div id="function-splice-api-token-allocationv1-allocationcancelimpl-12334">
+<span id="function-splice-api-token-allocationv1-allocationcancelimpl-12334"></span>
 
-allocation_cancelImpl
-: Allocation -\> ContractId Allocation -\> Allocation_Cancel -\> Update Allocation_CancelResult
+### `allocation_cancelImpl`
 
-</div>
+```daml
+allocation_cancelImpl : Allocation -> ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult
+```
 
-<div id="function-splice-api-token-allocationv1-allocationwithdrawimpl-40108">
+<span id="function-splice-api-token-allocationv1-allocationwithdrawimpl-40108"></span>
 
-allocation_withdrawImpl
-: Allocation -\> ContractId Allocation -\> Allocation_Withdraw -\> Update Allocation_WithdrawResult
+### `allocation_withdrawImpl`
 
-</div>
+```daml
+allocation_withdrawImpl : Allocation -> ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-token-allocationv1-allocation-9928"></span>
+
+### Interface `Allocation`
+
+A contract representing an allocation of some amount of aasset holdings to
+a specific leg of a settlement.
+
+View Type: `AllocationView`
+
+Choices:
+
+<span id="type-splice-api-token-allocationv1-allocationcancel-25504"></span>
+
+#### Choice `Allocation_Cancel`
+
+Cancel the allocation. Requires authorization from sender, receiver, and
+executor.
+
+Typically this authorization is granted by sender and receiver to the
+executor as part of the contract coordinating the settlement, so that
+that the executor can release the allocated assets early in case the
+settlement is aborted or it has definitely failed.
+
+Controllers: `allocationControllers (view this)`
+
+Returns: `Allocation_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-allocationv1-allocationexecutetransfer-74529"></span>
+
+#### Choice `Allocation_ExecuteTransfer`
+
+Execute the transfer of the allocated assets. Intended to be used to execute the settlement.
+This choice SHOULD succeed provided the `settlement.settleBefore` deadline has not yet passed.
+
+Controllers: `allocationControllers (view this)`
+
+Returns: `Allocation_ExecuteTransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-allocationv1-allocationwithdraw-60458"></span>
+
+#### Choice `Allocation_Withdraw`
+
+Withdraw the allocated assets. Used by the sender to withdraw the assets before settlement
+was completed. This SHOULD not fail settlement if the sender has still time to allocate the
+assets again; i.e., the `settlement.allocateBefore` deadline has not yet passed.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))`
+
+Returns: `Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocation_cancelImpl`
+
+Type: `ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult`
+
+#### Method `allocation_executeTransferImpl`
+
+Type: `ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult`
+
+#### Method `allocation_withdrawImpl`
+
+Type: `ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-burn-mint-v1 docs"
-description: "Documentation for splice-api-token-burn-mint-v1 docs"
+title: "splice-api-token-burn-mint-v1"
+description: "Reference documentation for splice-api-token-burn-mint-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-burn-mint-v1/docs/index.rst" hash="3c7f18eb" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-burn-mint-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-burn-mint-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.BurnMintV1](/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.BurnMintV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">An interface for registries to expose burn/mint operations in a generic way</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
@@ -1,213 +1,212 @@
 ---
 title: "Splice.Api.Token.BurnMintV1"
-description: "Documentation for Splice.Api.Token.BurnMintV1"
+description: "Reference documentation for Daml module Splice.Api.Token.BurnMintV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-burn-mint-v1/docs/Splice-Api-Token-BurnMintV1.rst" hash="7ecee559" */}
+<span id="module-splice-api-token-burnmintv1-45547"></span>
 
-An interface for registries to expose burn/mint operations in a generic way for bridges to use them, and for wallets to parse their use.
+# Splice.Api.Token.BurnMintV1
 
-## Interfaces
+An interface for registries to expose burn/mint operations in a generic way
 
-<div id="type-splice-api-token-burnmintv1-burnmintfactory-79205">
+for bridges to use them, and for wallets to parse their use.
 
-**interface** BurnMintFactory
+## Module Snapshot
 
-</div>
-
-> A factory for generic burn/mint operations.
->
-> **viewtype** BurnMintFactoryView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-api-token-burnmintv1-burnmintfactoryburnmint-20312">
->
->   **Choice** BurnMintFactory_BurnMint
->
->   </div>
->
->   Burn the holdings in `inputHoldingCids` and create holdings with the owners and amounts specified in outputs.
->
->   Note that this is jointly authorized by the admin and the `extraActors`. The `admin` thus controls all calls to this choice, and some implementations might required `extraActors` to be present, e.g., the owners of the minted and burnt holdings.
->
->   Implementations are free to restrict the implementation of this choice including failing on all inputs or not implementing this interface at all.
->
->   Controller: (DA.Internal.Record.getField @"admin" (view this)) :: extraActors
->
->   Returns: BurnMintFactory_BurnMintResult
->
->   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
->   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin    | Party                       | The expected `admin` party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | instrumentId     | InstrumentId                                                                                                  | The instrument id of the holdings. All holdings in `inputHoldingCids` as well as the resulting output holdings MUST have this instrument id.                                                                                                                                                                                                                                                                                                                                      |
->   | inputHoldingCids | \[ContractId Holding\] | The holdings that should be burnt. All holdings in `inputHoldingCids` MUST be archived by this choice. Implementations MAY enforce additional restrictions such as all `inputHoldingCids` belonging to the same owner.                                                                                                                                                                                                                                                            |
->   | outputs          | \[BurnMintOutput\]                                                                                            | The holdings that should be created. The choice MUST create new holdings with the given amounts.                                                                                                                                                                                                                                                                                                                                                                                  |
->   | extraActors      | \[Party\]                   | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs but we allow different sets of actors to support token implementations with different authorization setups.                                                                                                                                                                                                                                          |
->   | extraArgs        | ExtraArgs                                                                                                     | Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason` key in the metadata to provide a human readable description for explain why the `BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user.                                                                                                                                                                                                   |
->
-> - <div id="type-splice-api-token-burnmintv1-burnmintfactorypublicfetch-64185">
->
->   **Choice** BurnMintFactory_PublicFetch
->
->   </div>
->
->   Controller: actor
->
->   Returns: BurnMintFactoryView
->
->   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
->   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | Party | The party fetching the data.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
->
-> - **Method burnMintFactory_burnMintImpl :** ContractId BurnMintFactory -\> BurnMintFactory_BurnMint -\> Update BurnMintFactory_BurnMintResult
->
-> - **Method burnMintFactory_publicFetchImpl :** ContractId BurnMintFactory -\> BurnMintFactory_PublicFetch -\> Update BurnMintFactoryView
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-burnmintv1-burnmintfactoryview-72718">
+<span id="type-splice-api-token-burnmintv1-burnmintfactoryview-72718"></span>
 
-**data** BurnMintFactoryView
+### `data BurnMintFactoryView`
 
-</div>
+The view of a `BurnMintFactory`.
 
-> The view of a `BurnMintFactory`.
->
-> <div id="constr-splice-api-token-burnmintv1-burnmintfactoryview-23617">
->
-> BurnMintFactoryView
->
-> </div>
->
-> > | Field | Type                                                                                    | Description                                                                                                             |
-> > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-> > | admin | Party | The party representing the registry app that administers the instruments for which this burnt-mint factory can be used. |
-> > | meta  | Metadata                                                                                | Additional metadata specific to the burn-mint factory, used for extensibility.                                          |
->
-> **instance** Eq BurnMintFactoryView
->
-> **instance** Show BurnMintFactoryView
->
-> **instance** HasMethod BurnMintFactory "burnMintFactory_publicFetchImpl" (ContractId BurnMintFactory -\> BurnMintFactory_PublicFetch -\> Update BurnMintFactoryView)
->
-> **instance** HasFromAnyView BurnMintFactory BurnMintFactoryView
->
-> **instance** HasInterfaceView BurnMintFactory BurnMintFactoryView
->
-> **instance** GetField "admin" BurnMintFactoryView Party
->
-> **instance** GetField "meta" BurnMintFactoryView Metadata
->
-> **instance** SetField "admin" BurnMintFactoryView Party
->
-> **instance** SetField "meta" BurnMintFactoryView Metadata
->
-> **instance** HasExercise BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
->
-> **instance** HasExerciseGuarded BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
->
-> **instance** HasFromAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
->
-> **instance** HasToAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+Constructors:
 
-<div id="type-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-61365">
+<span id="constr-splice-api-token-burnmintv1-burnmintfactoryview-23617"></span>
 
-**data** BurnMintFactory_BurnMintResult
+- `BurnMintFactoryView`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instruments<br/><br/>for which this burnt-mint factory can be used. |
+| meta | Metadata | Additional metadata specific to the burn-mint factory, used for extensibility. |
 
-> The result of calling the `BurnMintFactory_BurnMint` choice.
->
-> <div id="constr-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-13976">
->
-> BurnMintFactory_BurnMintResult
->
-> </div>
->
-> > | Field      | Type                                                                                                          | Description                                                                                                              |
-> > |------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-> > | outputCids | \[ContractId Holding\] | The holdings created by the choice. Must contain exactly the outputs specified in the choice argument in the same order. |
->
-> **instance** Eq BurnMintFactory_BurnMintResult
->
-> **instance** Show BurnMintFactory_BurnMintResult
->
-> **instance** HasMethod BurnMintFactory "burnMintFactory_burnMintImpl" (ContractId BurnMintFactory -\> BurnMintFactory_BurnMint -\> Update BurnMintFactory_BurnMintResult)
->
-> **instance** GetField "outputCids" BurnMintFactory_BurnMintResult \[ContractId Holding\]
->
-> **instance** SetField "outputCids" BurnMintFactory_BurnMintResult \[ContractId Holding\]
->
-> **instance** HasExercise BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
->
-> **instance** HasExerciseGuarded BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
->
-> **instance** HasFromAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
->
-> **instance** HasToAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+Instances:
 
-<div id="type-splice-api-token-burnmintv1-burnmintoutput-36483">
+- `instance Eq BurnMintFactoryView`
+- `instance Show BurnMintFactoryView`
+- `instance HasMethod BurnMintFactory burnMintFactory_publicFetchImpl (ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView)`
+- `instance HasFromAnyView BurnMintFactory BurnMintFactoryView`
+- `instance HasInterfaceView BurnMintFactory BurnMintFactoryView`
+- `instance GetField admin BurnMintFactoryView Party`
+- `instance GetField meta BurnMintFactoryView Metadata`
+- `instance SetField admin BurnMintFactoryView Party`
+- `instance SetField meta BurnMintFactoryView Metadata`
+- `instance HasExercise BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+- `instance HasExerciseGuarded BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+- `instance HasFromAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+- `instance HasToAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
 
-**data** BurnMintOutput
+<span id="type-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-61365"></span>
 
-</div>
+### `data BurnMintFactory_BurnMintResult`
 
-> The specification of a holding to create as part of the burn/mint operation.
->
-> <div id="constr-splice-api-token-burnmintv1-burnmintoutput-15750">
->
-> BurnMintOutput
->
-> </div>
->
-> > | Field   | Type                                                                                    | Description                                                                                               |
-> > |---------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-> > | owner   | Party | The owner of the holding to create.                                                                       |
-> > | amount  | Decimal  | The amount of the holding to create.                                                                      |
-> > | context | ChoiceContext                                                                           | Context specific to this output which can be used to support locking or other registry-specific features. |
->
-> **instance** Eq BurnMintOutput
->
-> **instance** Show BurnMintOutput
->
-> **instance** GetField "amount" BurnMintOutput Decimal
->
-> **instance** GetField "context" BurnMintOutput ChoiceContext
->
-> **instance** GetField "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
->
-> **instance** GetField "owner" BurnMintOutput Party
->
-> **instance** SetField "amount" BurnMintOutput Decimal
->
-> **instance** SetField "context" BurnMintOutput ChoiceContext
->
-> **instance** SetField "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
->
-> **instance** SetField "owner" BurnMintOutput Party
+The result of calling the `BurnMintFactory_BurnMint` choice.
+
+Constructors:
+
+<span id="constr-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-13976"></span>
+
+- `BurnMintFactory_BurnMintResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| outputCids | [ContractId Holding] | The holdings created by the choice.<br/><br/>Must contain exactly the outputs specified in the choice argument in the same order. |
+
+Instances:
+
+- `instance Eq BurnMintFactory_BurnMintResult`
+- `instance Show BurnMintFactory_BurnMintResult`
+- `instance HasMethod BurnMintFactory burnMintFactory_burnMintImpl (ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult)`
+- `instance GetField outputCids BurnMintFactory_BurnMintResult [ContractId Holding]`
+- `instance SetField outputCids BurnMintFactory_BurnMintResult [ContractId Holding]`
+- `instance HasExercise BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+- `instance HasExerciseGuarded BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+- `instance HasFromAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+- `instance HasToAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+
+<span id="type-splice-api-token-burnmintv1-burnmintoutput-36483"></span>
+
+### `data BurnMintOutput`
+
+The specification of a holding to create as part of the burn/mint operation.
+
+Constructors:
+
+<span id="constr-splice-api-token-burnmintv1-burnmintoutput-15750"></span>
+
+- `BurnMintOutput`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party | The owner of the holding to create. |
+| amount | Decimal | The amount of the holding to create. |
+| context | ChoiceContext | Context specific to this output which can be used to support locking<br/><br/>or other registry-specific features. |
+
+Instances:
+
+- `instance Eq BurnMintOutput`
+- `instance Show BurnMintOutput`
+- `instance GetField amount BurnMintOutput Decimal`
+- `instance GetField context BurnMintOutput ChoiceContext`
+- `instance GetField outputs BurnMintFactory_BurnMint [BurnMintOutput]`
+- `instance GetField owner BurnMintOutput Party`
+- `instance SetField amount BurnMintOutput Decimal`
+- `instance SetField context BurnMintOutput ChoiceContext`
+- `instance SetField outputs BurnMintFactory_BurnMint [BurnMintOutput]`
+- `instance SetField owner BurnMintOutput Party`
 
 ## Functions
 
-<div id="function-splice-api-token-burnmintv1-burnmintfactoryburnmintimpl-9738">
+<span id="function-splice-api-token-burnmintv1-burnmintfactoryburnmintimpl-9738"></span>
 
-burnMintFactory_burnMintImpl
-: BurnMintFactory -\> ContractId BurnMintFactory -\> BurnMintFactory_BurnMint -\> Update BurnMintFactory_BurnMintResult
+### `burnMintFactory_burnMintImpl`
 
-</div>
+```daml
+burnMintFactory_burnMintImpl : BurnMintFactory -> ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult
+```
 
-<div id="function-splice-api-token-burnmintv1-burnmintfactorypublicfetchimpl-75623">
+<span id="function-splice-api-token-burnmintv1-burnmintfactorypublicfetchimpl-75623"></span>
 
-burnMintFactory_publicFetchImpl
-: BurnMintFactory -\> ContractId BurnMintFactory -\> BurnMintFactory_PublicFetch -\> Update BurnMintFactoryView
+### `burnMintFactory_publicFetchImpl`
 
-</div>
+```daml
+burnMintFactory_publicFetchImpl : BurnMintFactory -> ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-token-burnmintv1-burnmintfactory-79205"></span>
+
+### Interface `BurnMintFactory`
+
+A factory for generic burn/mint operations.
+
+View Type: `BurnMintFactoryView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-token-burnmintv1-burnmintfactoryburnmint-20312"></span>
+
+#### Choice `BurnMintFactory_BurnMint`
+
+Burn the holdings in `inputHoldingCids` and create holdings with the
+owners and amounts specified in outputs.
+
+Note that this is jointly authorized by the admin and the `extraActors`.
+The `admin` thus controls all calls to this choice, and some implementations might
+required `extraActors` to be present, e.g., the owners of the minted and burnt holdings.
+
+Implementations are free to restrict the implementation of this choice
+including failing on all inputs or not implementing this interface at all.
+
+Controllers: `(DA.Internal.Record.getField @"admin" (view this)) :: extraActors`
+
+Returns: `BurnMintFactory_BurnMintResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected `admin` party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| instrumentId | InstrumentId | The instrument id of the holdings.<br/><br/>All holdings in `inputHoldingCids` as well as the resulting output holdings MUST<br/><br/>have this instrument id. |
+| inputHoldingCids | [ContractId Holding] | The holdings that should be burnt.<br/><br/>All holdings in `inputHoldingCids` MUST be archived by this choice.<br/><br/>Implementations MAY enforce additional restrictions such as all `inputHoldingCids`<br/><br/>belonging to the same owner. |
+| outputs | [BurnMintOutput] | The holdings that should be created. The choice MUST create new holdings with the given amounts. |
+| extraActors | [Party] | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs<br/><br/>but we allow different sets of actors to support token implementations with different authorization setups. |
+| extraArgs | ExtraArgs | Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason`<br/><br/>key in the metadata to provide a human readable description for explain why the<br/><br/>`BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user. |
+
+<span id="type-splice-api-token-burnmintv1-burnmintfactorypublicfetch-64185"></span>
+
+#### Choice `BurnMintFactory_PublicFetch`
+
+Controllers: `actor`
+
+Returns: `BurnMintFactoryView`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| actor | Party | The party fetching the data. |
+
+Methods:
+
+#### Method `burnMintFactory_burnMintImpl`
+
+Type: `ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult`
+
+#### Method `burnMintFactory_publicFetchImpl`
+
+Type: `ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-holding-v1 docs"
-description: "Documentation for splice-api-token-holding-v1 docs"
+title: "splice-api-token-holding-v1"
+description: "Reference documentation for splice-api-token-holding-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-holding-v1/docs/index.rst" hash="f6c58451" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-holding-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-holding-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.HoldingV1](/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.HoldingV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Types and interfaces for retrieving an investor&#x27;s holdings.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
@@ -1,166 +1,147 @@
 ---
 title: "Splice.Api.Token.HoldingV1"
-description: "Documentation for Splice.Api.Token.HoldingV1"
+description: "Reference documentation for Daml module Splice.Api.Token.HoldingV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-holding-v1/docs/Splice-Api-Token-HoldingV1.rst" hash="af79a40b" */}
+<span id="module-splice-api-token-holdingv1-43900"></span>
+
+# Splice.Api.Token.HoldingV1
 
 Types and interfaces for retrieving an investor's holdings.
 
-## Interfaces
+## Module Snapshot
 
-<div id="type-splice-api-token-holdingv1-holding-25898">
-
-**interface** Holding
-
-</div>
-
-> Holding interface.
->
-> **viewtype** HoldingView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-holdingv1-holdingview-83501">
+<span id="type-splice-api-token-holdingv1-holdingview-83501"></span>
 
-**data** HoldingView
+### `data HoldingView`
 
-</div>
+View for `Holding`.
 
-> View for `Holding`.
->
-> <div id="constr-splice-api-token-holdingv1-holdingview-75848">
->
-> HoldingView
->
-> </div>
->
-> > | Field        | Type                                                                                                    | Description                                                                                                                                  |
-> > |--------------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-> > | owner        | Party                 | Owner of the holding.                                                                                                                        |
-> > | instrumentId | InstrumentId                                                                                            | Instrument being held.                                                                                                                       |
-> > | amount       | Decimal                  | Size of the holding.                                                                                                                         |
-> > | lock         | Optional Lock | Lock on the holding. Registries SHOULD allow holdings with expired locks as inputs to transfers to enable a combined unlocking + use choice. |
-> > | meta         | Metadata                                                                                                | Metadata.                                                                                                                                    |
->
-> **instance** Eq HoldingView
->
-> **instance** Show HoldingView
->
-> **instance** HasFromAnyView Holding HoldingView
->
-> **instance** HasInterfaceView Holding HoldingView
->
-> **instance** GetField "amount" HoldingView Decimal
->
-> **instance** GetField "instrumentId" HoldingView InstrumentId
->
-> **instance** GetField "lock" HoldingView (Optional Lock)
->
-> **instance** GetField "meta" HoldingView Metadata
->
-> **instance** GetField "owner" HoldingView Party
->
-> **instance** SetField "amount" HoldingView Decimal
->
-> **instance** SetField "instrumentId" HoldingView InstrumentId
->
-> **instance** SetField "lock" HoldingView (Optional Lock)
->
-> **instance** SetField "meta" HoldingView Metadata
->
-> **instance** SetField "owner" HoldingView Party
+Constructors:
 
-<div id="type-splice-api-token-holdingv1-instrumentid-28218">
+<span id="constr-splice-api-token-holdingv1-holdingview-75848"></span>
 
-**data** InstrumentId
+- `HoldingView`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party | Owner of the holding. |
+| instrumentId | InstrumentId | Instrument being held. |
+| amount | Decimal | Size of the holding. |
+| lock | Optional Lock | Lock on the holding.<br/><br/>Registries SHOULD allow holdings with expired locks as inputs to<br/><br/>transfers to enable a combined unlocking + use choice. |
+| meta | Metadata | Metadata. |
 
-> A globally unique identifier for instruments.
->
-> <div id="constr-splice-api-token-holdingv1-instrumentid-17961">
->
-> InstrumentId
->
-> </div>
->
-> > | Field | Type                                                                                    | Description                                                                                                                          |
-> > |-------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-> > | admin | Party | The party representing the registry app that administers the instrument.                                                             |
-> > | id    | Text        | The identifier used for the instrument by the instrument admin. This identifier MUST be unique and unambiguous per instrument admin. |
->
-> **instance** Eq InstrumentId
->
-> **instance** Ord InstrumentId
->
-> **instance** Show InstrumentId
->
-> **instance** GetField "admin" InstrumentId Party
->
-> **instance** GetField "id" InstrumentId Text
->
-> **instance** GetField "instrumentId" HoldingView InstrumentId
->
-> **instance** SetField "admin" InstrumentId Party
->
-> **instance** SetField "id" InstrumentId Text
->
-> **instance** SetField "instrumentId" HoldingView InstrumentId
+Instances:
 
-<div id="type-splice-api-token-holdingv1-lock-70295">
+- `instance Eq HoldingView`
+- `instance Show HoldingView`
+- `instance HasFromAnyView Holding HoldingView`
+- `instance HasInterfaceView Holding HoldingView`
+- `instance GetField amount HoldingView Decimal`
+- `instance GetField instrumentId HoldingView InstrumentId`
+- `instance GetField lock HoldingView (Optional Lock)`
+- `instance GetField meta HoldingView Metadata`
+- `instance GetField owner HoldingView Party`
+- `instance SetField amount HoldingView Decimal`
+- `instance SetField instrumentId HoldingView InstrumentId`
+- `instance SetField lock HoldingView (Optional Lock)`
+- `instance SetField meta HoldingView Metadata`
+- `instance SetField owner HoldingView Party`
 
-**data** Lock
+<span id="type-splice-api-token-holdingv1-instrumentid-28218"></span>
 
-</div>
+### `data InstrumentId`
 
-> Details of a lock.
->
-> <div id="constr-splice-api-token-holdingv1-lock-56452">
->
-> Lock
->
-> </div>
->
-> > | Field        | Type                                                                                                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                          |
-> > |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | holders      | \[Party\]                                                                                                   | Unique list of parties which are locking the contract. (Represented as a list, as that has the better JSON encoding.)                                                                                                                                                                                                                                |
-> > | expiresAt    | Optional Time      | Absolute, inclusive deadline as of which the lock expires.                                                                                                                                                                                                                                                                                           |
-> > | expiresAfter | Optional RelTime | Duration after which the created lock expires. Measured relative to the ledger time that the locked holding contract was created. If both `expiresAt` and `expiresAfter` are set, the lock expires at the earlier of the two times.                                                                                                                  |
-> > | context      | Optional Text           | Short, human-readable description of the context of the lock. Used by wallets to enable users to understand the reason for the lock. Note that the visibility of the content in this field might be wider than the visibility of the contracts in the context. You should thus carefully decide what information is safe to put in the lock context. |
->
-> **instance** Eq Lock
->
-> **instance** Ord Lock
->
-> **instance** Show Lock
->
-> **instance** GetField "context" Lock (Optional Text)
->
-> **instance** GetField "expiresAfter" Lock (Optional RelTime)
->
-> **instance** GetField "expiresAt" Lock (Optional Time)
->
-> **instance** GetField "holders" Lock \[Party\]
->
-> **instance** GetField "lock" HoldingView (Optional Lock)
->
-> **instance** SetField "context" Lock (Optional Text)
->
-> **instance** SetField "expiresAfter" Lock (Optional RelTime)
->
-> **instance** SetField "expiresAt" Lock (Optional Time)
->
-> **instance** SetField "holders" Lock \[Party\]
->
-> **instance** SetField "lock" HoldingView (Optional Lock)
+A globally unique identifier for instruments.
 
-{/* COPIED_END */}
+Constructors:
+
+<span id="constr-splice-api-token-holdingv1-instrumentid-17961"></span>
+
+- `InstrumentId`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instrument. |
+| id | Text | The identifier used for the instrument by the instrument admin.<br/><br/>This identifier MUST be unique and unambiguous per instrument admin. |
+
+Instances:
+
+- `instance Eq InstrumentId`
+- `instance Ord InstrumentId`
+- `instance Show InstrumentId`
+- `instance GetField admin InstrumentId Party`
+- `instance GetField id InstrumentId Text`
+- `instance GetField instrumentId HoldingView InstrumentId`
+- `instance SetField admin InstrumentId Party`
+- `instance SetField id InstrumentId Text`
+- `instance SetField instrumentId HoldingView InstrumentId`
+
+<span id="type-splice-api-token-holdingv1-lock-70295"></span>
+
+### `data Lock`
+
+Details of a lock.
+
+Constructors:
+
+<span id="constr-splice-api-token-holdingv1-lock-56452"></span>
+
+- `Lock`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| holders | [Party] | Unique list of parties which are locking the contract.<br/><br/>(Represented as a list, as that has the better JSON encoding.) |
+| expiresAt | Optional Time | Absolute, inclusive deadline as of which the lock expires. |
+| expiresAfter | Optional RelTime | Duration after which the created lock expires. Measured relative<br/><br/>to the ledger time that the locked holding contract was created.<br/><br/>If both `expiresAt` and `expiresAfter` are set, the lock expires at<br/><br/>the earlier of the two times. |
+| context | Optional Text | Short, human-readable description of the context of the lock.<br/><br/>Used by wallets to enable users to understand the reason for the lock.<br/><br/>Note that the visibility of the content in this field might be wider<br/><br/>than the visibility of the contracts in the context. You should thus<br/><br/>carefully decide what information is safe to put in the lock context. |
+
+Instances:
+
+- `instance Eq Lock`
+- `instance Ord Lock`
+- `instance Show Lock`
+- `instance GetField context Lock (Optional Text)`
+- `instance GetField expiresAfter Lock (Optional RelTime)`
+- `instance GetField expiresAt Lock (Optional Time)`
+- `instance GetField holders Lock [Party]`
+- `instance GetField lock HoldingView (Optional Lock)`
+- `instance SetField context Lock (Optional Text)`
+- `instance SetField expiresAfter Lock (Optional RelTime)`
+- `instance SetField expiresAt Lock (Optional Time)`
+- `instance SetField holders Lock [Party]`
+- `instance SetField lock HoldingView (Optional Lock)`
+
+## Interfaces
+
+<span id="type-splice-api-token-holdingv1-holding-25898"></span>
+
+### Interface `Holding`
+
+Holding interface.
+
+View Type: `HoldingView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-metadata-v1 docs"
-description: "Documentation for splice-api-token-metadata-v1 docs"
+title: "splice-api-token-metadata-v1"
+description: "Reference documentation for splice-api-token-metadata-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-metadata-v1/docs/index.rst" hash="aad1ce6e" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-metadata-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-metadata-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.MetadataV1](/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.MetadataV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Types and interfaces for retrieving metadata about tokens.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
@@ -1,294 +1,270 @@
 ---
 title: "Splice.Api.Token.MetadataV1"
-description: "Documentation for Splice.Api.Token.MetadataV1"
+description: "Reference documentation for Daml module Splice.Api.Token.MetadataV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-metadata-v1/docs/Splice-Api-Token-MetadataV1.rst" hash="621f860b" */}
+<span id="module-splice-api-token-metadatav1-34807"></span>
+
+# Splice.Api.Token.MetadataV1
 
 Types and interfaces for retrieving metadata about tokens.
 
-## Interfaces
+## Module Snapshot
 
-<div id="type-splice-api-token-metadatav1-anycontract-39598">
-
-**interface** AnyContract
-
-</div>
-
-> Interface used to represent arbitrary contracts. Note that this is not expected to be implemented by any template, so it should only be used in the form `ContractId AnyContract` and through `coerceContractId` but not through any of the interface functions like `fetchFromInterface` that check whether the template actually implements the interface.
->
-> **viewtype** AnyContractView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-metadatav1-anycontractid-4875">
+<span id="type-splice-api-token-metadatav1-anycontractid-4875"></span>
 
-**type** AnyContractId
-= ContractId AnyContract
+### `type AnyContractId = ContractId AnyContract`
 
 A reference to some contract id. Use `coerceContractId` to convert from and to this type.
 
-</div>
+<span id="type-splice-api-token-metadatav1-anycontractview-55353"></span>
 
-<div id="type-splice-api-token-metadatav1-anycontractview-55353">
+### `data AnyContractView`
 
-**data** AnyContractView
+Not used. See the `AnyContract` interface for more information.
 
-</div>
+Constructors:
 
-> Not used. See the `AnyContract` interface for more information.
->
-> <div id="constr-splice-api-token-metadatav1-anycontractview-50558">
->
-> AnyContractView
->
-> </div>
->
-> > (no fields)
->
-> **instance** HasFromAnyView AnyContract AnyContractView
->
-> **instance** HasInterfaceView AnyContract AnyContractView
+<span id="constr-splice-api-token-metadatav1-anycontractview-50558"></span>
 
-<div id="type-splice-api-token-metadatav1-anyvalue-34700">
+- `AnyContractView`
 
-**data** AnyValue
+(no fields)
 
-</div>
+Instances:
 
-> A generic representation of serializable Daml values.
->
-> Used to pass arbitrary data across interface boundaries. For example to pass data from an an app backend to an interface choice implementation.
->
-> <div id="constr-splice-api-token-metadatav1-avtext-20580">
->
-> AV_Text Text
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avint-52425">
->
-> AV_Int Int
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avdecimal-71267">
->
-> AV_Decimal Decimal
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avbool-76457">
->
-> AV_Bool Bool
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avdate-46205">
->
-> AV_Date Date
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avtime-30398">
->
-> AV_Time Time
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avreltime-31008">
->
-> AV_RelTime RelTime
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avparty-78344">
->
-> AV_Party Party
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avcontractid-3242">
->
-> AV_ContractId AnyContractId
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avlist-50505">
->
-> AV_List \[AnyValue\]
->
-> </div>
->
-> <div id="constr-splice-api-token-metadatav1-avmap-39932">
->
-> AV_Map (TextMap AnyValue)
->
-> </div>
->
-> **instance** Eq AnyValue
->
-> **instance** Show AnyValue
->
-> **instance** GetField "values" ChoiceContext (TextMap AnyValue)
->
-> **instance** SetField "values" ChoiceContext (TextMap AnyValue)
+- `instance HasFromAnyView AnyContract AnyContractView`
+- `instance HasInterfaceView AnyContract AnyContractView`
 
-<div id="type-splice-api-token-metadatav1-choicecontext-5566">
+<span id="type-splice-api-token-metadatav1-anyvalue-34700"></span>
 
-**data** ChoiceContext
+### `data AnyValue`
 
-</div>
+A generic representation of serializable Daml values.
 
-> A type for passing extra data from an app's backends to the choices of that app exercised in commands submitted by app users.
->
-> <div id="constr-splice-api-token-metadatav1-choicecontext-36049">
->
-> ChoiceContext
->
-> </div>
->
-> > | Field  | Type                                                                                                 | Description                                                                                                                                    |
-> > |--------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | values | TextMap AnyValue | The values passed in by the app backend to the choice. The keys are considered internal to the app and should not be read by third-party code. |
->
-> **instance** Eq ChoiceContext
->
-> **instance** Show ChoiceContext
->
-> **instance** GetField "context" ExtraArgs ChoiceContext
->
-> **instance** GetField "values" ChoiceContext (TextMap AnyValue)
->
-> **instance** SetField "context" ExtraArgs ChoiceContext
->
-> **instance** SetField "values" ChoiceContext (TextMap AnyValue)
+Used to pass arbitrary data across interface boundaries. For example to pass
+data from an an app backend to an interface choice implementation.
 
-<div id="type-splice-api-token-metadatav1-choiceexecutionmetadata-98464">
+Constructors:
 
-**data** ChoiceExecutionMetadata
+<span id="constr-splice-api-token-metadatav1-avtext-20580"></span>
 
-</div>
+- `AV_Text Text`
 
-> A generic result for choices that do not need to return specific data.
->
-> <div id="constr-splice-api-token-metadatav1-choiceexecutionmetadata-73543">
->
-> ChoiceExecutionMetadata
->
-> </div>
->
-> > | Field | Type     | Description                                                                                  |
-> > |-------|----------|----------------------------------------------------------------------------------------------|
-> > | meta  | Metadata | Additional metadata specific to the result of exercising the choice, used for extensibility. |
->
-> **instance** Eq ChoiceExecutionMetadata
->
-> **instance** Show ChoiceExecutionMetadata
->
-> **instance** GetField "meta" ChoiceExecutionMetadata Metadata
->
-> **instance** SetField "meta" ChoiceExecutionMetadata Metadata
+<span id="constr-splice-api-token-metadatav1-avint-52425"></span>
 
-<div id="type-splice-api-token-metadatav1-extraargs-90869">
+- `AV_Int Int`
 
-**data** ExtraArgs
+<span id="constr-splice-api-token-metadatav1-avdecimal-71267"></span>
 
-</div>
+- `AV_Decimal Decimal`
 
-> A common type for passing both the choice context and the metadata to a choice.
->
-> <div id="constr-splice-api-token-metadatav1-extraargs-16750">
->
-> ExtraArgs
->
-> </div>
->
-> > | Field   | Type          | Description                                                                                                                                                                                                                                                                                      |
-> > |---------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | context | ChoiceContext | Extra arguments to be passed to the implementation of an interface choice. These are provided via an off-ledger API by the app implementing the interface.                                                                                                                                       |
-> > | meta    | Metadata      | Additional metadata to pass in. In contrast to the `extraArgs`, these are provided by the caller of the choice. The expectation is that the meaning of metadata fields will be agreed on in later standards, or on a case-by-case basis between the caller and the implementer of the interface. |
->
-> **instance** Eq ExtraArgs
->
-> **instance** Show ExtraArgs
->
-> **instance** GetField "context" ExtraArgs ChoiceContext
->
-> **instance** GetField "meta" ExtraArgs Metadata
->
-> **instance** SetField "context" ExtraArgs ChoiceContext
->
-> **instance** SetField "meta" ExtraArgs Metadata
+<span id="constr-splice-api-token-metadatav1-avbool-76457"></span>
 
-<div id="type-splice-api-token-metadatav1-metadata-21206">
+- `AV_Bool Bool`
 
-**data** Metadata
+<span id="constr-splice-api-token-metadatav1-avdate-46205"></span>
 
-</div>
+- `AV_Date Date`
 
-> Machine-readable metadata intended for communicating additional information using well-known keys between systems. This is mainly used to allow for the post-hoc expansion of the information associated with contracts and choice arguments and results.
->
-> Modeled after by k8s support for annotations: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/([https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)\\](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)\).
->
-> Implementors SHOULD follow the same conventions for allocating keys as used by k8s; i.e., they SHOULD be prefixed using the DNS name of the app defining the key.
->
-> Implementors SHOULD keep metadata small, as on-ledger data is costly.
->
-> <div id="constr-splice-api-token-metadatav1-metadata-84299">
->
-> Metadata
->
-> </div>
->
-> > | Field  | Type                                                                                                                                                                         | Description                          |
-> > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-> > | values | TextMap Text | Key-value pairs of metadata entries. |
->
-> **instance** Eq Metadata
->
-> **instance** Ord Metadata
->
-> **instance** Show Metadata
->
-> **instance** GetField "meta" ChoiceExecutionMetadata Metadata
->
-> **instance** GetField "meta" ExtraArgs Metadata
->
-> **instance** GetField "values" Metadata (TextMap Text)
->
-> **instance** SetField "meta" ChoiceExecutionMetadata Metadata
->
-> **instance** SetField "meta" ExtraArgs Metadata
->
-> **instance** SetField "values" Metadata (TextMap Text)
+<span id="constr-splice-api-token-metadatav1-avtime-30398"></span>
+
+- `AV_Time Time`
+
+<span id="constr-splice-api-token-metadatav1-avreltime-31008"></span>
+
+- `AV_RelTime RelTime`
+
+<span id="constr-splice-api-token-metadatav1-avparty-78344"></span>
+
+- `AV_Party Party`
+
+<span id="constr-splice-api-token-metadatav1-avcontractid-3242"></span>
+
+- `AV_ContractId AnyContractId`
+
+<span id="constr-splice-api-token-metadatav1-avlist-50505"></span>
+
+- `AV_List [AnyValue]`
+
+<span id="constr-splice-api-token-metadatav1-avmap-39932"></span>
+
+- `AV_Map (TextMap AnyValue)`
+
+Instances:
+
+- `instance Eq AnyValue`
+- `instance Show AnyValue`
+- `instance GetField values ChoiceContext (TextMap AnyValue)`
+- `instance SetField values ChoiceContext (TextMap AnyValue)`
+
+<span id="type-splice-api-token-metadatav1-choicecontext-5566"></span>
+
+### `data ChoiceContext`
+
+A type for passing extra data from an app's backends to the choices of that app
+exercised in commands submitted by app users.
+
+Constructors:
+
+<span id="constr-splice-api-token-metadatav1-choicecontext-36049"></span>
+
+- `ChoiceContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| values | TextMap AnyValue | The values passed in by the app backend to the choice.<br/><br/>The keys are considered internal to the app and should not be read by<br/><br/>third-party code. |
+
+Instances:
+
+- `instance Eq ChoiceContext`
+- `instance Show ChoiceContext`
+- `instance GetField context ExtraArgs ChoiceContext`
+- `instance GetField values ChoiceContext (TextMap AnyValue)`
+- `instance SetField context ExtraArgs ChoiceContext`
+- `instance SetField values ChoiceContext (TextMap AnyValue)`
+
+<span id="type-splice-api-token-metadatav1-choiceexecutionmetadata-98464"></span>
+
+### `data ChoiceExecutionMetadata`
+
+A generic result for choices that do not need to return specific data.
+
+Constructors:
+
+<span id="constr-splice-api-token-metadatav1-choiceexecutionmetadata-73543"></span>
+
+- `ChoiceExecutionMetadata`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| meta | Metadata | Additional metadata specific to the result of exercising the choice, used for extensibility. |
+
+Instances:
+
+- `instance Eq ChoiceExecutionMetadata`
+- `instance Show ChoiceExecutionMetadata`
+- `instance GetField meta ChoiceExecutionMetadata Metadata`
+- `instance SetField meta ChoiceExecutionMetadata Metadata`
+
+<span id="type-splice-api-token-metadatav1-extraargs-90869"></span>
+
+### `data ExtraArgs`
+
+A common type for passing both the choice context and the metadata to a choice.
+
+Constructors:
+
+<span id="constr-splice-api-token-metadatav1-extraargs-16750"></span>
+
+- `ExtraArgs`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | ChoiceContext | Extra arguments to be passed to the implementation of an interface choice.<br/><br/>These are provided via an off-ledger API by the app implementing the interface. |
+| meta | Metadata | Additional metadata to pass in.<br/><br/>In contrast to the `extraArgs`, these are provided by the caller of the choice.<br/><br/>The expectation is that the meaning of metadata fields will be agreed on<br/><br/>in later standards, or on a case-by-case basis between the caller and the<br/><br/>implementer of the interface. |
+
+Instances:
+
+- `instance Eq ExtraArgs`
+- `instance Show ExtraArgs`
+- `instance GetField context ExtraArgs ChoiceContext`
+- `instance GetField meta ExtraArgs Metadata`
+- `instance SetField context ExtraArgs ChoiceContext`
+- `instance SetField meta ExtraArgs Metadata`
+
+<span id="type-splice-api-token-metadatav1-metadata-21206"></span>
+
+### `data Metadata`
+
+Machine-readable metadata intended for communicating additional information
+using well-known keys between systems. This is mainly used to allow for the post-hoc
+expansion of the information associated with contracts and choice arguments and results.
+
+Modeled after by k8s support for annotations: [https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
+
+Implementors SHOULD follow the same conventions for allocating keys as used by k8s; i.e.,
+they SHOULD be prefixed using the DNS name of the app defining the key.
+
+Implementors SHOULD keep metadata small, as on-ledger data is costly.
+
+Constructors:
+
+<span id="constr-splice-api-token-metadatav1-metadata-84299"></span>
+
+- `Metadata`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| values | TextMap Text | Key-value pairs of metadata entries. |
+
+Instances:
+
+- `instance Eq Metadata`
+- `instance Ord Metadata`
+- `instance Show Metadata`
+- `instance GetField meta ChoiceExecutionMetadata Metadata`
+- `instance GetField meta ExtraArgs Metadata`
+- `instance GetField values Metadata (TextMap Text)`
+- `instance SetField meta ChoiceExecutionMetadata Metadata`
+- `instance SetField meta ExtraArgs Metadata`
+- `instance SetField values Metadata (TextMap Text)`
 
 ## Functions
 
-<div id="function-splice-api-token-metadatav1-emptychoicecontext-1208">
+<span id="function-splice-api-token-metadatav1-emptychoicecontext-1208"></span>
 
-emptyChoiceContext
-: ChoiceContext
+### `emptyChoiceContext`
+
+```daml
+emptyChoiceContext : ChoiceContext
+```
 
 Empty choice context.
 
-</div>
+<span id="function-splice-api-token-metadatav1-emptymetadata-88176"></span>
 
-<div id="function-splice-api-token-metadatav1-emptymetadata-88176">
+### `emptyMetadata`
 
-emptyMetadata
-: Metadata
+```daml
+emptyMetadata : Metadata
+```
 
 Empty metadata.
 
-</div>
+## Interfaces
 
-{/* COPIED_END */}
+<span id="type-splice-api-token-metadatav1-anycontract-39598"></span>
+
+### Interface `AnyContract`
+
+Interface used to represent arbitrary contracts.
+Note that this is not expected to be implemented by any template,
+so it should only be used in the form `ContractId AnyContract` and through `coerceContractId`
+but not through any of the interface functions like `fetchFromInterface` that check whether the template actually implements the interface.
+
+View Type: `AnyContractView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-api-token-transfer-instruction-v1 docs"
-description: "Documentation for splice-api-token-transfer-instruction-v1 docs"
+title: "splice-api-token-transfer-instruction-v1"
+description: "Reference documentation for splice-api-token-transfer-instruction-v1 modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-transfer-instruction-v1/docs/index.rst" hash="507f148b" */}
+<div class="x2mdx-ref-hero">
+
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
+
+
+  <h1 class="x2mdx-ref-title">splice-api-token-transfer-instruction-v1</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-api-token-transfer-instruction-v1, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
 
 ## Modules
 
-- [Splice.Api.Token.TransferInstructionV1](/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1)
 
-{/* COPIED_END */}
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Api.Token.TransferInstructionV1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Instruct transfers of holdings between parties.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
@@ -1,555 +1,508 @@
 ---
 title: "Splice.Api.Token.TransferInstructionV1"
-description: "Documentation for Splice.Api.Token.TransferInstructionV1"
+description: "Reference documentation for Daml module Splice.Api.Token.TransferInstructionV1."
 ---
 
-{/* COPIED_START source="splice:token-standard/splice-api-token-transfer-instruction-v1/docs/Splice-Api-Token-TransferInstructionV1.rst" hash="7caf50a0" */}
+<span id="module-splice-api-token-transferinstructionv1-72974"></span>
+
+# Splice.Api.Token.TransferInstructionV1
 
 Instruct transfers of holdings between parties.
 
-## Interfaces
+## Module Snapshot
 
-<div id="type-splice-api-token-transferinstructionv1-transferfactory-55548">
-
-**interface** TransferFactory
-
-</div>
-
-> A factory contract to instruct transfers of holdings between parties.
->
-> **viewtype** TransferFactoryView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-api-token-transferinstructionv1-transferfactorypublicfetch-56912">
->
->   **Choice** TransferFactory_PublicFetch
->
->   </div>
->
->   Fetch the view of the factory contract.
->
->   Controller: actor
->
->   Returns: TransferFactoryView
->
->   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
->   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | Party | The party fetching the contract.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
->
-> - <div id="type-splice-api-token-transferinstructionv1-transferfactorytransfer-25365">
->
->   **Choice** TransferFactory_Transfer
->
->   </div>
->
->   Instruct the registry to execute a transfer. Implementations MUST ensure that this choice fails if `transfer.executeBefore` is in the past.
->
->   Controller: (DA.Internal.Record.getField @"sender" transfer)
->
->   Returns: TransferInstructionResult
->
->   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
->   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | transfer      | Transfer                                                                                | The transfer to execute.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
->   | extraArgs     | ExtraArgs                                                                               | The extra arguments to pass to the transfer implementation.                                                                                                                                                                                                                                                                                                                                                                                                                     |
->
-> - **Method transferFactory_publicFetchImpl :** ContractId TransferFactory -\> TransferFactory_PublicFetch -\> Update TransferFactoryView
->
-> - **Method transferFactory_transferImpl :** ContractId TransferFactory -\> TransferFactory_Transfer -\> Update TransferInstructionResult
-
-<div id="type-splice-api-token-transferinstructionv1-transferinstruction-69882">
-
-**interface** TransferInstruction
-
-</div>
-
-> An interface for tracking the status of a transfer instruction, i.e., a request to a registry app to execute a transfer.
->
-> Registries MAY evolve the transfer instruction in multiple steps. They SHOULD do so using only the choices on this interface, so that wallets can reliably parse the transaction history and determine whether the instruction ultimately succeeded or failed.
->
-> **viewtype** TransferInstructionView
->
-> - **Choice** Archive
->
->   Controller: Signatories of implementing template
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionaccept-36884">
->
->   **Choice** TransferInstruction_Accept
->
->   </div>
->
->   Accept the transfer as the receiver.
->
->   This choice is only available if the instruction is in `TransferPendingReceiverAcceptance` state.
->
->   Note that while implementations will typically return `TransferInstructionResult_Completed`, this is not guaranteed. The result of the choice is implementation-specific and MAY be any of the three possible results.
->
->   Controller: (DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))
->
->   Returns: TransferInstructionResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionreject-89645">
->
->   **Choice** TransferInstruction_Reject
->
->   </div>
->
->   Reject the transfer as the receiver.
->
->   This choice is only available if the instruction is in `TransferPendingReceiverAcceptance` state.
->
->   Controller: (DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))
->
->   Returns: TransferInstructionResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionupdate-27423">
->
->   **Choice** TransferInstruction_Update
->
->   </div>
->
->   Update the state of the transfer instruction. Used by the registry to execute registry internal workflow steps that advance the state of the transfer instruction. A reason may be communicated via the metadata.
->
->   Controller: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transfer" (view this)))), extraActors
->
->   Returns: TransferInstructionResult
->
->   | Field       | Type                                                                                        | Description                                                                                                                           |
->   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
->   | extraActors | \[Party\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
->   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
->
-> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionwithdraw-43648">
->
->   **Choice** TransferInstruction_Withdraw
->
->   </div>
->
->   Withdraw the transfer instruction as the sender.
->
->   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transfer" (view this)))
->
->   Returns: TransferInstructionResult
->
->   | Field     | Type      | Description                                                  |
->   |-----------|-----------|--------------------------------------------------------------|
->   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
->
-> - **Method transferInstruction_acceptImpl :** ContractId TransferInstruction -\> TransferInstruction_Accept -\> Update TransferInstructionResult
->
-> - **Method transferInstruction_rejectImpl :** ContractId TransferInstruction -\> TransferInstruction_Reject -\> Update TransferInstructionResult
->
-> - **Method transferInstruction_updateImpl :** ContractId TransferInstruction -\> TransferInstruction_Update -\> Update TransferInstructionResult
->
-> - **Method transferInstruction_withdrawImpl :** ContractId TransferInstruction -\> TransferInstruction_Withdraw -\> Update TransferInstructionResult
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-api-token-transferinstructionv1-transfer-51973">
+<span id="type-splice-api-token-transferinstructionv1-transfer-51973"></span>
 
-**data** Transfer
+### `data Transfer`
 
-</div>
+A specification of a transfer of holdings between two parties.
 
-> A specification of a transfer of holdings between two parties.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transfer-5022">
->
-> Transfer
->
-> </div>
->
-> > | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-> > |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | sender           | Party                       | The sender of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-> > | receiver         | Party                       | The receiver of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-> > | amount           | Decimal                        | The amount to transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-> > | instrumentId     | InstrumentId                                                                                                  | The instrument identifier.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-> > | requestedAt      | Time                         | Wallet provided timestamp when the transfer was requested. MUST be in the past when instructing the transfer.                                                                                                                                                                                                                                                                                                                                                               |
-> > | executeBefore    | Time                         | Until when (exclusive) the transfer may be executed. MUST be in the future when instructing the transfer. Registries SHOULD NOT execute the transfer instruction after this time, so that senders can retry creating a new transfer instruction after this time.                                                                                                                                                                                                            |
-> > | inputHoldingCids | \[ContractId Holding\] | The holding contracts that should be used to fund the transfer. MAY be empty if the registry supports automatic selection of holdings for transfers or does not represent holdings on-ledger. If specified, then the transfer MUST archive all of these holdings, so that the execution of the transfer conflicts with any other transfers using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate transfers. |
-> > | meta             | Metadata                                                                                                      | Metadata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
->
-> **instance** Eq Transfer
->
-> **instance** Show Transfer
->
-> **instance** GetField "amount" Transfer Decimal
->
-> **instance** GetField "executeBefore" Transfer Time
->
-> **instance** GetField "inputHoldingCids" Transfer \[ContractId Holding\]
->
-> **instance** GetField "instrumentId" Transfer InstrumentId
->
-> **instance** GetField "meta" Transfer Metadata
->
-> **instance** GetField "receiver" Transfer Party
->
-> **instance** GetField "requestedAt" Transfer Time
->
-> **instance** GetField "sender" Transfer Party
->
-> **instance** GetField "transfer" TransferFactory_Transfer Transfer
->
-> **instance** GetField "transfer" TransferInstructionView Transfer
->
-> **instance** SetField "amount" Transfer Decimal
->
-> **instance** SetField "executeBefore" Transfer Time
->
-> **instance** SetField "inputHoldingCids" Transfer \[ContractId Holding\]
->
-> **instance** SetField "instrumentId" Transfer InstrumentId
->
-> **instance** SetField "meta" Transfer Metadata
->
-> **instance** SetField "receiver" Transfer Party
->
-> **instance** SetField "requestedAt" Transfer Time
->
-> **instance** SetField "sender" Transfer Party
->
-> **instance** SetField "transfer" TransferFactory_Transfer Transfer
->
-> **instance** SetField "transfer" TransferInstructionView Transfer
+Constructors:
 
-<div id="type-splice-api-token-transferinstructionv1-transferfactoryview-36679">
+<span id="constr-splice-api-token-transferinstructionv1-transfer-5022"></span>
 
-**data** TransferFactoryView
+- `Transfer`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The sender of the transfer. |
+| receiver | Party | The receiver of the transfer. |
+| amount | Decimal | The amount to transfer. |
+| instrumentId | InstrumentId | The instrument identifier. |
+| requestedAt | Time | Wallet provided timestamp when the transfer was requested.<br/><br/>MUST be in the past when instructing the transfer. |
+| executeBefore | Time | Until when (exclusive) the transfer may be executed. MUST be in the<br/><br/>future when instructing the transfer.<br/><br/>Registries SHOULD NOT execute the transfer instruction after this time,<br/><br/>so that senders can retry creating a new transfer instruction after this time. |
+| inputHoldingCids | [ContractId Holding] | The holding contracts that should be used to fund the transfer.<br/><br/>MAY be empty if the registry supports automatic selection of holdings for transfers<br/><br/>or does not represent holdings on-ledger.<br/><br/>If specified, then the transfer MUST archive all of these holdings, so<br/><br/>that the execution of the transfer conflicts with any other transfers<br/><br/>using these holdings. Thereby allowing that the sender can use<br/><br/>deliberate contention on holdings to prevent duplicate transfers. |
+| meta | Metadata | Metadata. |
 
-> View for `TransferFactory`.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferfactoryview-43930">
->
-> TransferFactoryView
->
-> </div>
->
-> > | Field | Type                                                                                    | Description                                                                                                           |
-> > |-------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-> > | admin | Party | The party representing the registry app that administers the instruments for which this transfer factory can be used. |
-> > | meta  | Metadata                                                                                | Additional metadata specific to the transfer factory, used for extensibility.                                         |
->
-> **instance** Eq TransferFactoryView
->
-> **instance** Show TransferFactoryView
->
-> **instance** HasMethod TransferFactory "transferFactory_publicFetchImpl" (ContractId TransferFactory -\> TransferFactory_PublicFetch -\> Update TransferFactoryView)
->
-> **instance** HasFromAnyView TransferFactory TransferFactoryView
->
-> **instance** HasInterfaceView TransferFactory TransferFactoryView
->
-> **instance** GetField "admin" TransferFactoryView Party
->
-> **instance** GetField "meta" TransferFactoryView Metadata
->
-> **instance** SetField "admin" TransferFactoryView Party
->
-> **instance** SetField "meta" TransferFactoryView Metadata
->
-> **instance** HasExercise TransferFactory TransferFactory_PublicFetch TransferFactoryView
->
-> **instance** HasExerciseGuarded TransferFactory TransferFactory_PublicFetch TransferFactoryView
->
-> **instance** HasFromAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView
->
-> **instance** HasToAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView
+Instances:
 
-<div id="type-splice-api-token-transferinstructionv1-transferinstructionresult-24735">
+- `instance Eq Transfer`
+- `instance Show Transfer`
+- `instance GetField amount Transfer Decimal`
+- `instance GetField executeBefore Transfer Time`
+- `instance GetField inputHoldingCids Transfer [ContractId Holding]`
+- `instance GetField instrumentId Transfer InstrumentId`
+- `instance GetField meta Transfer Metadata`
+- `instance GetField receiver Transfer Party`
+- `instance GetField requestedAt Transfer Time`
+- `instance GetField sender Transfer Party`
+- `instance GetField transfer TransferFactory_Transfer Transfer`
+- `instance GetField transfer TransferInstructionView Transfer`
+- `instance SetField amount Transfer Decimal`
+- `instance SetField executeBefore Transfer Time`
+- `instance SetField inputHoldingCids Transfer [ContractId Holding]`
+- `instance SetField instrumentId Transfer InstrumentId`
+- `instance SetField meta Transfer Metadata`
+- `instance SetField receiver Transfer Party`
+- `instance SetField requestedAt Transfer Time`
+- `instance SetField sender Transfer Party`
+- `instance SetField transfer TransferFactory_Transfer Transfer`
+- `instance SetField transfer TransferInstructionView Transfer`
 
-**data** TransferInstructionResult
+<span id="type-splice-api-token-transferinstructionv1-transferfactoryview-36679"></span>
 
-</div>
+### `data TransferFactoryView`
 
-> The result of instructing a transfer or advancing the state of a transfer instruction.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresult-25274">
->
-> TransferInstructionResult
->
-> </div>
->
-> > | Field            | Type                                                                                                          | Description                                                                                                                                                                    |
-> > |------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | output           | TransferInstructionResult_Output                                                                              | The output of the step.                                                                                                                                                        |
-> > | senderChangeCids | \[ContractId Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple transfer instructions in a single Daml transaction. |
-> > | meta             | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged.                                                                          |
->
-> **instance** Eq TransferInstructionResult
->
-> **instance** Show TransferInstructionResult
->
-> **instance** HasMethod TransferFactory "transferFactory_transferImpl" (ContractId TransferFactory -\> TransferFactory_Transfer -\> Update TransferInstructionResult)
->
-> **instance** HasMethod TransferInstruction "transferInstruction_acceptImpl" (ContractId TransferInstruction -\> TransferInstruction_Accept -\> Update TransferInstructionResult)
->
-> **instance** HasMethod TransferInstruction "transferInstruction_rejectImpl" (ContractId TransferInstruction -\> TransferInstruction_Reject -\> Update TransferInstructionResult)
->
-> **instance** HasMethod TransferInstruction "transferInstruction_updateImpl" (ContractId TransferInstruction -\> TransferInstruction_Update -\> Update TransferInstructionResult)
->
-> **instance** HasMethod TransferInstruction "transferInstruction_withdrawImpl" (ContractId TransferInstruction -\> TransferInstruction_Withdraw -\> Update TransferInstructionResult)
->
-> **instance** GetField "meta" TransferInstructionResult Metadata
->
-> **instance** GetField "output" TransferInstructionResult TransferInstructionResult_Output
->
-> **instance** GetField "senderChangeCids" TransferInstructionResult \[ContractId Holding\]
->
-> **instance** SetField "meta" TransferInstructionResult Metadata
->
-> **instance** SetField "output" TransferInstructionResult TransferInstructionResult_Output
->
-> **instance** SetField "senderChangeCids" TransferInstructionResult \[ContractId Holding\]
->
-> **instance** HasExercise TransferFactory TransferFactory_Transfer TransferInstructionResult
->
-> **instance** HasExercise TransferInstruction TransferInstruction_Accept TransferInstructionResult
->
-> **instance** HasExercise TransferInstruction TransferInstruction_Reject TransferInstructionResult
->
-> **instance** HasExercise TransferInstruction TransferInstruction_Update TransferInstructionResult
->
-> **instance** HasExercise TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
->
-> **instance** HasExerciseGuarded TransferFactory TransferFactory_Transfer TransferInstructionResult
->
-> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Accept TransferInstructionResult
->
-> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Reject TransferInstructionResult
->
-> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Update TransferInstructionResult
->
-> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
->
-> **instance** HasFromAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult
->
-> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult
->
-> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult
->
-> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult
->
-> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
->
-> **instance** HasToAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult
->
-> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult
->
-> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult
->
-> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult
->
-> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+View for `TransferFactory`.
 
-<div id="type-splice-api-token-transferinstructionv1-transferinstructionresultoutput-59824">
+Constructors:
 
-**data** TransferInstructionResult_Output
+<span id="constr-splice-api-token-transferinstructionv1-transferfactoryview-43930"></span>
 
-</div>
+- `TransferFactoryView`
 
-> The output of instructing a transfer or advancing the state of a transfer instruction.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultpending-18902">
->
-> TransferInstructionResult_Pending
->
-> </div>
->
-> > Use this result to communicate that the transfer is pending further steps.
-> >
-> > | Field                  | Type                                                                                                                  | Description                                                             |
-> > |------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | transferInstructionCid | ContractId TransferInstruction | Contract id of the transfer instruction representing the pending state. |
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultcompleted-47798">
->
-> TransferInstructionResult_Completed
->
-> </div>
->
-> > Use this result to communicate that the transfer succeeded and the receiver has received their holdings.
-> >
-> > | Field               | Type                                                                                                          | Description                                                                                       |
-> > |---------------------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-> > | receiverHoldingCids | \[ContractId Holding\] | The newly created holdings owned by the receiver as part of successfully completing the transfer. |
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultfailed-21543">
->
-> TransferInstructionResult_Failed
->
-> </div>
->
-> > Use this result to communicate that the transfer did not succeed and all holdings (minus fees) have been returned to the sender.
->
-> **instance** Eq TransferInstructionResult_Output
->
-> **instance** Show TransferInstructionResult_Output
->
-> **instance** GetField "output" TransferInstructionResult TransferInstructionResult_Output
->
-> **instance** GetField "receiverHoldingCids" TransferInstructionResult_Output \[ContractId Holding\]
->
-> **instance** GetField "transferInstructionCid" TransferInstructionResult_Output (ContractId TransferInstruction)
->
-> **instance** SetField "output" TransferInstructionResult TransferInstructionResult_Output
->
-> **instance** SetField "receiverHoldingCids" TransferInstructionResult_Output \[ContractId Holding\]
->
-> **instance** SetField "transferInstructionCid" TransferInstructionResult_Output (ContractId TransferInstruction)
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instruments for<br/><br/>which this transfer factory can be used. |
+| meta | Metadata | Additional metadata specific to the transfer factory, used for extensibility. |
 
-<div id="type-splice-api-token-transferinstructionv1-transferinstructionstatus-36298">
+Instances:
 
-**data** TransferInstructionStatus
+- `instance Eq TransferFactoryView`
+- `instance Show TransferFactoryView`
+- `instance HasMethod TransferFactory transferFactory_publicFetchImpl (ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView)`
+- `instance HasFromAnyView TransferFactory TransferFactoryView`
+- `instance HasInterfaceView TransferFactory TransferFactoryView`
+- `instance GetField admin TransferFactoryView Party`
+- `instance GetField meta TransferFactoryView Metadata`
+- `instance SetField admin TransferFactoryView Party`
+- `instance SetField meta TransferFactoryView Metadata`
+- `instance HasExercise TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+- `instance HasExerciseGuarded TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+- `instance HasFromAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+- `instance HasToAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView`
 
-</div>
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionresult-24735"></span>
 
-> Status of a transfer instruction.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferpendingreceiveracceptance-84710">
->
-> TransferPendingReceiverAcceptance
->
-> </div>
->
-> > The transfer is pending acceptance by the receiver.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferpendinginternalworkflow-24806">
->
-> TransferPendingInternalWorkflow
->
-> </div>
->
-> > The transfer is pending actions to be taken as part of registry internal workflows.
-> >
-> > | Field          | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                            |
-> > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | pendingActions | Map Party Text | The actions that a party could take to advance the transfer. This field can by used to inform wallet users whether they need to take an action or not. |
->
-> **instance** Eq TransferInstructionStatus
->
-> **instance** Show TransferInstructionStatus
->
-> **instance** GetField "pendingActions" TransferInstructionStatus (Map Party Text)
->
-> **instance** GetField "status" TransferInstructionView TransferInstructionStatus
->
-> **instance** SetField "pendingActions" TransferInstructionStatus (Map Party Text)
->
-> **instance** SetField "status" TransferInstructionView TransferInstructionStatus
+### `data TransferInstructionResult`
 
-<div id="type-splice-api-token-transferinstructionv1-transferinstructionview-46309">
+The result of instructing a transfer or advancing the state of a transfer instruction.
 
-**data** TransferInstructionView
+Constructors:
 
-</div>
+<span id="constr-splice-api-token-transferinstructionv1-transferinstructionresult-25274"></span>
 
-> View for `TransferInstruction`.
->
-> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionview-88808">
->
-> TransferInstructionView
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                                                                                       | Description                                                                                                                                                                                                                          |
-> > |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | originalInstructionCid | Optional (ContractId TransferInstruction) | The contract id of the original transfer instruction contract. Used by the wallet to track the lineage of transfer instructions through multiple steps. Only set if the registry evolves the transfer instruction in multiple steps. |
-> > | transfer               | Transfer                                                                                                                                                                                                                   | The transfer specified by the transfer instruction.                                                                                                                                                                                  |
-> > | status                 | TransferInstructionStatus                                                                                                                                                                                                  | The status of the transfer instruction.                                                                                                                                                                                              |
-> > | meta                   | Metadata                                                                                                                                                                                                                   | Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information.                                                                                                            |
->
-> **instance** Eq TransferInstructionView
->
-> **instance** Show TransferInstructionView
->
-> **instance** HasFromAnyView TransferInstruction TransferInstructionView
->
-> **instance** HasInterfaceView TransferInstruction TransferInstructionView
->
-> **instance** GetField "meta" TransferInstructionView Metadata
->
-> **instance** GetField "originalInstructionCid" TransferInstructionView (Optional (ContractId TransferInstruction))
->
-> **instance** GetField "status" TransferInstructionView TransferInstructionStatus
->
-> **instance** GetField "transfer" TransferInstructionView Transfer
->
-> **instance** SetField "meta" TransferInstructionView Metadata
->
-> **instance** SetField "originalInstructionCid" TransferInstructionView (Optional (ContractId TransferInstruction))
->
-> **instance** SetField "status" TransferInstructionView TransferInstructionStatus
->
-> **instance** SetField "transfer" TransferInstructionView Transfer
+- `TransferInstructionResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| output | TransferInstructionResult_Output | The output of the step. |
+| senderChangeCids | [ContractId Holding] | New holdings owned by the sender created to return "change". Can be used<br/><br/>by callers to batch creating or updating multiple transfer instructions<br/><br/>in a single Daml transaction. |
+| meta | Metadata | Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged. |
+
+Instances:
+
+- `instance Eq TransferInstructionResult`
+- `instance Show TransferInstructionResult`
+- `instance HasMethod TransferFactory transferFactory_transferImpl (ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_acceptImpl (ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_rejectImpl (ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_updateImpl (ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_withdrawImpl (ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult)`
+- `instance GetField meta TransferInstructionResult Metadata`
+- `instance GetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance GetField senderChangeCids TransferInstructionResult [ContractId Holding]`
+- `instance SetField meta TransferInstructionResult Metadata`
+- `instance SetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance SetField senderChangeCids TransferInstructionResult [ContractId Holding]`
+- `instance HasExercise TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+- `instance HasExerciseGuarded TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+- `instance HasFromAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+- `instance HasToAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionresultoutput-59824"></span>
+
+### `data TransferInstructionResult_Output`
+
+The output of instructing a transfer or advancing the state of a transfer instruction.
+
+Constructors:
+
+<span id="constr-splice-api-token-transferinstructionv1-transferinstructionresultpending-18902"></span>
+
+- `TransferInstructionResult_Pending`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction | Contract id of the transfer instruction representing the pending state. |
+
+Use this result to communicate that the transfer is pending further steps.
+
+<span id="constr-splice-api-token-transferinstructionv1-transferinstructionresultcompleted-47798"></span>
+
+- `TransferInstructionResult_Completed`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiverHoldingCids | [ContractId Holding] | The newly created holdings owned by the receiver as part of successfully<br/><br/>completing the transfer. |
+
+Use this result to communicate that the transfer succeeded and the receiver
+has received their holdings.
+
+<span id="constr-splice-api-token-transferinstructionv1-transferinstructionresultfailed-21543"></span>
+
+- `TransferInstructionResult_Failed`
+
+Use this result to communicate that the transfer did not succeed and all holdings (minus fees)
+have been returned to the sender.
+
+Instances:
+
+- `instance Eq TransferInstructionResult_Output`
+- `instance Show TransferInstructionResult_Output`
+- `instance GetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance GetField receiverHoldingCids TransferInstructionResult_Output [ContractId Holding]`
+- `instance GetField transferInstructionCid TransferInstructionResult_Output (ContractId TransferInstruction)`
+- `instance SetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance SetField receiverHoldingCids TransferInstructionResult_Output [ContractId Holding]`
+- `instance SetField transferInstructionCid TransferInstructionResult_Output (ContractId TransferInstruction)`
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionstatus-36298"></span>
+
+### `data TransferInstructionStatus`
+
+Status of a transfer instruction.
+
+Constructors:
+
+<span id="constr-splice-api-token-transferinstructionv1-transferpendingreceiveracceptance-84710"></span>
+
+- `TransferPendingReceiverAcceptance`
+
+The transfer is pending acceptance by the receiver.
+
+<span id="constr-splice-api-token-transferinstructionv1-transferpendinginternalworkflow-24806"></span>
+
+- `TransferPendingInternalWorkflow`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| pendingActions | Map Party Text | The actions that a party could take to advance the transfer.<br/><br/>This field can by used to inform wallet users whether they need to take an action or not. |
+
+The transfer is pending actions to be taken as part of registry internal workflows.
+
+Instances:
+
+- `instance Eq TransferInstructionStatus`
+- `instance Show TransferInstructionStatus`
+- `instance GetField pendingActions TransferInstructionStatus (Map Party Text)`
+- `instance GetField status TransferInstructionView TransferInstructionStatus`
+- `instance SetField pendingActions TransferInstructionStatus (Map Party Text)`
+- `instance SetField status TransferInstructionView TransferInstructionStatus`
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionview-46309"></span>
+
+### `data TransferInstructionView`
+
+View for `TransferInstruction`.
+
+Constructors:
+
+<span id="constr-splice-api-token-transferinstructionv1-transferinstructionview-88808"></span>
+
+- `TransferInstructionView`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| originalInstructionCid | Optional (ContractId TransferInstruction) | The contract id of the original transfer instruction contract.<br/><br/>Used by the wallet to track the lineage of transfer instructions through multiple steps.<br/><br/>Only set if the registry evolves the transfer instruction in multiple steps. |
+| transfer | Transfer | The transfer specified by the transfer instruction. |
+| status | TransferInstructionStatus | The status of the transfer instruction. |
+| meta | Metadata | Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information. |
+
+Instances:
+
+- `instance Eq TransferInstructionView`
+- `instance Show TransferInstructionView`
+- `instance HasFromAnyView TransferInstruction TransferInstructionView`
+- `instance HasInterfaceView TransferInstruction TransferInstructionView`
+- `instance GetField meta TransferInstructionView Metadata`
+- `instance GetField originalInstructionCid TransferInstructionView (Optional (ContractId TransferInstruction))`
+- `instance GetField status TransferInstructionView TransferInstructionStatus`
+- `instance GetField transfer TransferInstructionView Transfer`
+- `instance SetField meta TransferInstructionView Metadata`
+- `instance SetField originalInstructionCid TransferInstructionView (Optional (ContractId TransferInstruction))`
+- `instance SetField status TransferInstructionView TransferInstructionStatus`
+- `instance SetField transfer TransferInstructionView Transfer`
 
 ## Functions
 
-<div id="function-splice-api-token-transferinstructionv1-transferinstructionacceptimpl-78274">
+<span id="function-splice-api-token-transferinstructionv1-transferinstructionacceptimpl-78274"></span>
 
-transferInstruction_acceptImpl
-: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Accept -\> Update TransferInstructionResult
+### `transferInstruction_acceptImpl`
 
-</div>
+```daml
+transferInstruction_acceptImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult
+```
 
-<div id="function-splice-api-token-transferinstructionv1-transferinstructionrejectimpl-50311">
+<span id="function-splice-api-token-transferinstructionv1-transferinstructionrejectimpl-50311"></span>
 
-transferInstruction_rejectImpl
-: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Reject -\> Update TransferInstructionResult
+### `transferInstruction_rejectImpl`
 
-</div>
+```daml
+transferInstruction_rejectImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult
+```
 
-<div id="function-splice-api-token-transferinstructionv1-transferinstructionwithdrawimpl-10586">
+<span id="function-splice-api-token-transferinstructionv1-transferinstructionwithdrawimpl-10586"></span>
 
-transferInstruction_withdrawImpl
-: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Withdraw -\> Update TransferInstructionResult
+### `transferInstruction_withdrawImpl`
 
-</div>
+```daml
+transferInstruction_withdrawImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult
+```
 
-<div id="function-splice-api-token-transferinstructionv1-transferinstructionupdateimpl-73329">
+<span id="function-splice-api-token-transferinstructionv1-transferinstructionupdateimpl-73329"></span>
 
-transferInstruction_updateImpl
-: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Update -\> Update TransferInstructionResult
+### `transferInstruction_updateImpl`
 
-</div>
+```daml
+transferInstruction_updateImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult
+```
 
-<div id="function-splice-api-token-transferinstructionv1-transferfactorytransferimpl-82483">
+<span id="function-splice-api-token-transferinstructionv1-transferfactorytransferimpl-82483"></span>
 
-transferFactory_transferImpl
-: TransferFactory -\> ContractId TransferFactory -\> TransferFactory_Transfer -\> Update TransferInstructionResult
+### `transferFactory_transferImpl`
 
-</div>
+```daml
+transferFactory_transferImpl : TransferFactory -> ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult
+```
 
-<div id="function-splice-api-token-transferinstructionv1-transferfactorypublicfetchimpl-930">
+<span id="function-splice-api-token-transferinstructionv1-transferfactorypublicfetchimpl-930"></span>
 
-transferFactory_publicFetchImpl
-: TransferFactory -\> ContractId TransferFactory -\> TransferFactory_PublicFetch -\> Update TransferFactoryView
+### `transferFactory_publicFetchImpl`
 
-</div>
+```daml
+transferFactory_publicFetchImpl : TransferFactory -> ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView
+```
 
-{/* COPIED_END */}
+## Interfaces
+
+<span id="type-splice-api-token-transferinstructionv1-transferfactory-55548"></span>
+
+### Interface `TransferFactory`
+
+A factory contract to instruct transfers of holdings between parties.
+
+View Type: `TransferFactoryView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-token-transferinstructionv1-transferfactorypublicfetch-56912"></span>
+
+#### Choice `TransferFactory_PublicFetch`
+
+Fetch the view of the factory contract.
+
+Controllers: `actor`
+
+Returns: `TransferFactoryView`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| actor | Party | The party fetching the contract. |
+
+<span id="type-splice-api-token-transferinstructionv1-transferfactorytransfer-25365"></span>
+
+#### Choice `TransferFactory_Transfer`
+
+Instruct the registry to execute a transfer.
+Implementations MUST ensure that this choice fails if `transfer.executeBefore` is in the past.
+
+Controllers: `(DA.Internal.Record.getField @"sender" transfer)`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| transfer | Transfer | The transfer to execute. |
+| extraArgs | ExtraArgs | The extra arguments to pass to the transfer implementation. |
+
+Methods:
+
+#### Method `transferFactory_publicFetchImpl`
+
+Type: `ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView`
+
+#### Method `transferFactory_transferImpl`
+
+Type: `ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult`
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstruction-69882"></span>
+
+### Interface `TransferInstruction`
+
+An interface for tracking the status of a transfer instruction,
+i.e., a request to a registry app to execute a transfer.
+
+Registries MAY evolve the transfer instruction in multiple steps. They SHOULD
+do so using only the choices on this interface, so that wallets can reliably
+parse the transaction history and determine whether the instruction ultimately
+succeeded or failed.
+
+View Type: `TransferInstructionView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionaccept-36884"></span>
+
+#### Choice `TransferInstruction_Accept`
+
+Accept the transfer as the receiver.
+
+This choice is only available if the instruction is in
+`TransferPendingReceiverAcceptance` state.
+
+Note that while implementations will typically return `TransferInstructionResult_Completed`,
+this is not guaranteed. The result of the choice is implementation-specific and MAY
+be any of the three possible results.
+
+Controllers: `(DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionreject-89645"></span>
+
+#### Choice `TransferInstruction_Reject`
+
+Reject the transfer as the receiver.
+
+This choice is only available if the instruction is in
+`TransferPendingReceiverAcceptance` state.
+
+Controllers: `(DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionupdate-27423"></span>
+
+#### Choice `TransferInstruction_Update`
+
+Update the state of the transfer instruction. Used by the registry to
+execute registry internal workflow steps that advance the state of the
+transfer instruction. A reason may be communicated via the metadata.
+
+Controllers: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transfer" (view this))))`, `extraActors`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraActors | [Party] | Extra actors authorizing the update. Implementations MUST check that<br/><br/>this field contains the expected actors for the specific update. |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<span id="type-splice-api-token-transferinstructionv1-transferinstructionwithdraw-43648"></span>
+
+#### Choice `TransferInstruction_Withdraw`
+
+Withdraw the transfer instruction as the sender.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transfer" (view this)))`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+Methods:
+
+#### Method `transferInstruction_acceptImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult`
+
+#### Method `transferInstruction_rejectImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult`
+
+#### Method `transferInstruction_updateImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult`
+
+#### Method `transferInstruction_withdrawImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/index.mdx
@@ -1,16 +1,495 @@
 ---
-title: "splice-dso-governance docs"
-description: "Documentation for splice-dso-governance docs"
+title: "splice-dso-governance"
+description: "Reference documentation for splice-dso-governance modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/index.rst" tag="0.6.4" hash="f237c273" */}
+<div class="x2mdx-ref-hero">
 
-- [Splice.CometBft](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft)
-- [Splice.DSO.AmuletPrice](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice)
-- [Splice.DSO.DecentralizedSynchronizer](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer)
-- [Splice.DSO.SvState](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate)
-- [Splice.DsoBootstrap](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap)
-- [Splice.DsoRules](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules)
-- [Splice.SvOnboarding](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding)
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-{/* COPIED_END */}
+
+  <h1 class="x2mdx-ref-title">splice-dso-governance</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-dso-governance, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.CometBft</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.DSO.AmuletPrice</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Templates and code for the SVs to agree on a amulet price using median-based voting.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.DSO.DecentralizedSynchronizer</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Data structures and contracts related managing the decentralized synchronizer.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.DSO.SvState</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Templates to track per-sv state.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.DsoBootstrap</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.DsoRules</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.SvOnboarding</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 7</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft.mdx
@@ -1,246 +1,221 @@
 ---
 title: "Splice.CometBft"
-description: "Documentation for Splice.CometBft"
+description: "Reference documentation for Daml module Splice.CometBft."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-CometBft.rst" tag="0.6.4" hash="5c393ed3" */}
+<span id="module-splice-cometbft-61948"></span>
+
+# Splice.CometBft
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-cometbft-cometbftconfig-79018">
+<span id="type-splice-cometbft-cometbftconfig-79018"></span>
 
-**data** CometBftConfig
+### `data CometBftConfig`
 
-</div>
+Config for all CometBFT nodes and keys under the control of a single SV node operator.
 
-> Config for all CometBFT nodes and keys under the control of a single SV node operator.
->
-> <div id="constr-splice-cometbft-cometbftconfig-91607">
->
-> CometBftConfig
->
-> </div>
->
-> > | Field          | Type                                                                                                                                                                                                                                            | Description                                          |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-> > | nodes          | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig | A map from CometBft node-ids to their configuration. |
-> > | governanceKeys | \[GovernanceKeyConfig\]                                                                                                                                                                                                                         |                                                      |
-> > | sequencingKeys | \[SequencingKeyConfig\]                                                                                                                                                                                                                         |                                                      |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CometBftConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CometBftConfig
->
-> **instance** GetField "cometBft" SynchronizerNodeConfig CometBftConfig
->
-> **instance** GetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
->
-> **instance** GetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
->
-> **instance** GetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
->
-> **instance** SetField "cometBft" SynchronizerNodeConfig CometBftConfig
->
-> **instance** SetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
->
-> **instance** SetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
->
-> **instance** SetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
->
-> **instance** Patchable CometBftConfig
+Constructors:
 
-<div id="type-splice-cometbft-cometbftconfiglimits-81004">
+<span id="constr-splice-cometbft-cometbftconfig-91607"></span>
 
-**data** CometBftConfigLimits
+- `CometBftConfig`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| nodes | Map Text CometBftNodeConfig | A map from CometBft node-ids to their configuration. |
+| governanceKeys | [GovernanceKeyConfig] |  |
+| sequencingKeys | [SequencingKeyConfig] |  |
 
-> Limits on the configurations that SV node operators can choose for their CometBFT nodes and keys.
->
-> <div id="constr-splice-cometbft-cometbftconfiglimits-44281">
->
-> CometBftConfigLimits
->
-> </div>
->
-> > | Field                | Type                                                                                                       | Description |
-> > |----------------------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | maxNumCometBftNodes  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | maxNumGovernanceKeys | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | maxNumSequencingKeys | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | maxNodeIdLength      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
-> > | maxPubKeyLength      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CometBftConfigLimits
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CometBftConfigLimits
->
-> **instance** GetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
->
-> **instance** GetField "maxNodeIdLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumCometBftNodes" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumGovernanceKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxNumSequencingKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "maxPubKeyLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
->
-> **instance** SetField "maxNodeIdLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumCometBftNodes" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumGovernanceKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxNumSequencingKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "maxPubKeyLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** Patchable CometBftConfigLimits
+Instances:
 
-<div id="type-splice-cometbft-cometbftnodeconfig-40106">
+- `instance Patchable CometBftConfig`
+- `instance Eq CometBftConfig`
+- `instance Show CometBftConfig`
+- `instance GetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance GetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance GetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance GetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
+- `instance SetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance SetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance SetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance SetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
 
-**data** CometBftNodeConfig
+<span id="type-splice-cometbft-cometbftconfiglimits-81004"></span>
 
-</div>
+### `data CometBftConfigLimits`
 
-> Config for a single CometBFT node.
->
-> <div id="constr-splice-cometbft-cometbftnodeconfig-66571">
->
-> CometBftNodeConfig
->
-> </div>
->
-> > | Field           | Type                                                                                                         | Description |
-> > |-----------------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | validatorPubKey | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
-> > | votingPower     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CometBftNodeConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CometBftNodeConfig
->
-> **instance** GetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
->
-> **instance** GetField "validatorPubKey" CometBftNodeConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "votingPower" CometBftNodeConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
->
-> **instance** SetField "validatorPubKey" CometBftNodeConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "votingPower" CometBftNodeConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** Patchable CometBftNodeConfig
+Limits on the configurations that SV node operators can choose for their CometBFT nodes and keys.
 
-<div id="type-splice-cometbft-governancekeyconfig-71820">
+Constructors:
 
-**data** GovernanceKeyConfig
+<span id="constr-splice-cometbft-cometbftconfiglimits-44281"></span>
 
-</div>
+- `CometBftConfigLimits`
 
-> Config for a key used by the SvApp to create CometBFT network governance transactions.
->
-> <div id="constr-splice-cometbft-governancekeyconfig-53123">
->
-> GovernanceKeyConfig
->
-> </div>
->
-> > | Field  | Type                                                                                                         | Description |
-> > |--------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | pubKey | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) GovernanceKeyConfig
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) GovernanceKeyConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) GovernanceKeyConfig
->
-> **instance** GetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
->
-> **instance** GetField "pubKey" GovernanceKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
->
-> **instance** SetField "pubKey" GovernanceKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** Patchable GovernanceKeyConfig
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| maxNumCometBftNodes | Int |  |
+| maxNumGovernanceKeys | Int |  |
+| maxNumSequencingKeys | Int |  |
+| maxNodeIdLength | Int |  |
+| maxPubKeyLength | Int |  |
 
-<div id="type-splice-cometbft-sequencingkeyconfig-30402">
+Instances:
 
-**data** SequencingKeyConfig
+- `instance Patchable CometBftConfigLimits`
+- `instance Eq CometBftConfigLimits`
+- `instance Show CometBftConfigLimits`
+- `instance GetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance GetField maxNodeIdLength CometBftConfigLimits Int`
+- `instance GetField maxNumCometBftNodes CometBftConfigLimits Int`
+- `instance GetField maxNumGovernanceKeys CometBftConfigLimits Int`
+- `instance GetField maxNumSequencingKeys CometBftConfigLimits Int`
+- `instance GetField maxPubKeyLength CometBftConfigLimits Int`
+- `instance SetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance SetField maxNodeIdLength CometBftConfigLimits Int`
+- `instance SetField maxNumCometBftNodes CometBftConfigLimits Int`
+- `instance SetField maxNumGovernanceKeys CometBftConfigLimits Int`
+- `instance SetField maxNumSequencingKeys CometBftConfigLimits Int`
+- `instance SetField maxPubKeyLength CometBftConfigLimits Int`
 
-</div>
+<span id="type-splice-cometbft-cometbftnodeconfig-40106"></span>
 
-> Config for a key used by the CometBFT Sequencer Driver to sequence messages via the CometBFT network.
->
-> <div id="constr-splice-cometbft-sequencingkeyconfig-16921">
->
-> SequencingKeyConfig
->
-> </div>
->
-> > | Field  | Type                                                                                                         | Description |
-> > |--------|--------------------------------------------------------------------------------------------------------------|-------------|
-> > | pubKey | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencingKeyConfig
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) SequencingKeyConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencingKeyConfig
->
-> **instance** GetField "pubKey" SequencingKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
->
-> **instance** SetField "pubKey" SequencingKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
->
-> **instance** Patchable SequencingKeyConfig
+### `data CometBftNodeConfig`
+
+Config for a single CometBFT node.
+
+Constructors:
+
+<span id="constr-splice-cometbft-cometbftnodeconfig-66571"></span>
+
+- `CometBftNodeConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorPubKey | Text |  |
+| votingPower | Int |  |
+
+Instances:
+
+- `instance Patchable CometBftNodeConfig`
+- `instance Eq CometBftNodeConfig`
+- `instance Show CometBftNodeConfig`
+- `instance GetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance GetField validatorPubKey CometBftNodeConfig Text`
+- `instance GetField votingPower CometBftNodeConfig Int`
+- `instance SetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance SetField validatorPubKey CometBftNodeConfig Text`
+- `instance SetField votingPower CometBftNodeConfig Int`
+
+<span id="type-splice-cometbft-governancekeyconfig-71820"></span>
+
+### `data GovernanceKeyConfig`
+
+Config for a key used by the SvApp to create CometBFT network governance transactions.
+
+Constructors:
+
+<span id="constr-splice-cometbft-governancekeyconfig-53123"></span>
+
+- `GovernanceKeyConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| pubKey | Text |  |
+
+Instances:
+
+- `instance Patchable GovernanceKeyConfig`
+- `instance Eq GovernanceKeyConfig`
+- `instance Ord GovernanceKeyConfig`
+- `instance Show GovernanceKeyConfig`
+- `instance GetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance GetField pubKey GovernanceKeyConfig Text`
+- `instance SetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance SetField pubKey GovernanceKeyConfig Text`
+
+<span id="type-splice-cometbft-sequencingkeyconfig-30402"></span>
+
+### `data SequencingKeyConfig`
+
+Config for a key used by the CometBFT Sequencer Driver to sequence messages via the CometBFT network.
+
+Constructors:
+
+<span id="constr-splice-cometbft-sequencingkeyconfig-16921"></span>
+
+- `SequencingKeyConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| pubKey | Text |  |
+
+Instances:
+
+- `instance Patchable SequencingKeyConfig`
+- `instance Eq SequencingKeyConfig`
+- `instance Ord SequencingKeyConfig`
+- `instance Show SequencingKeyConfig`
+- `instance GetField pubKey SequencingKeyConfig Text`
+- `instance GetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
+- `instance SetField pubKey SequencingKeyConfig Text`
+- `instance SetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
 
 ## Functions
 
-<div id="function-splice-cometbft-emptycometbftconfig-94578">
+<span id="function-splice-cometbft-emptycometbftconfig-94578"></span>
 
-emptyCometBftConfig
-: CometBftConfig
+### `emptyCometBftConfig`
 
-</div>
+```daml
+emptyCometBftConfig : CometBftConfig
+```
 
-<div id="function-splice-cometbft-defaultcometbftconfiglimits-24082">
+<span id="function-splice-cometbft-defaultcometbftconfiglimits-24082"></span>
 
-defaultCometBftConfigLimits
-: CometBftConfigLimits
+### `defaultCometBftConfigLimits`
 
-</div>
+```daml
+defaultCometBftConfigLimits : CometBftConfigLimits
+```
 
-<div id="function-splice-cometbft-validcometbftconfig-37027">
+<span id="function-splice-cometbft-validcometbftconfig-37027"></span>
 
-validCometBftConfig
-: CometBftConfigLimits -\> CometBftConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validCometBftConfig`
 
-</div>
+```daml
+validCometBftConfig : CometBftConfigLimits -> CometBftConfig -> Bool
+```
 
-<div id="function-splice-cometbft-validcometbftnodeconfig-27003">
+<span id="function-splice-cometbft-validcometbftnodeconfig-27003"></span>
 
-validCometBftNodeConfig
-: CometBftConfigLimits -\> ([Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952), CometBftNodeConfig) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validCometBftNodeConfig`
 
-</div>
+```daml
+validCometBftNodeConfig : CometBftConfigLimits -> (Text, CometBftNodeConfig) -> Bool
+```
 
-<div id="function-splice-cometbft-totalvotingpower-81580">
+<span id="function-splice-cometbft-totalvotingpower-81580"></span>
 
-totalVotingPower
-: CometBftConfig -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+### `totalVotingPower`
 
-</div>
-
-{/* COPIED_END */}
+```daml
+totalVotingPower : CometBftConfig -> Int
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice.mdx
@@ -1,59 +1,81 @@
 ---
 title: "Splice.DSO.AmuletPrice"
-description: "Documentation for Splice.DSO.AmuletPrice"
+description: "Reference documentation for Daml module Splice.DSO.AmuletPrice."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DSO-AmuletPrice.rst" tag="0.6.4" hash="1c68e822" */}
+<span id="module-splice-dso-amuletprice-58480"></span>
+
+# Splice.DSO.AmuletPrice
 
 Templates and code for the SVs to agree on a amulet price using median-based voting.
 
-Every sv can change its desired amulet price at any time they like provided they wait at least one tick duration (2.5 minutes by default) between changes.
+Every sv can change its desired amulet price at any time they like provided they
 
-New `OpenMiningRounds` are always openened with the median of the amulet prices voted for by the SVs.
+wait at least one tick duration (2.5 minutes by default) between changes.
 
-## Templates
+New `OpenMiningRounds` are always openened with the median of the amulet prices voted for
 
-<div id="type-splice-dso-amuletprice-amuletpricevote-96658">
+by the SVs.
 
-**template** AmuletPriceVote
+## Module Snapshot
 
-</div>
-
-> A vote by an SV for their desired amulet price.
->
-> Signatory: dso
->
-> | Field         | Type                                                                                                                                                                                                                                              | Description                                                                                                  |
-> |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-> | dso           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                                                                                                              |
-> | sv            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                                                                                                              |
-> | amuletPrice   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Set to None for new svs, but defined thereafter.                                                             |
-> | lastUpdatedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                 | The last time this price was updated. Tracked to limit svs from changing their vote more than once per tick. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Functions
 
-<div id="function-splice-dso-amuletprice-fetchmedianamuletprice-30507">
+<span id="function-splice-dso-amuletprice-fetchmedianamuletprice-30507"></span>
 
-fetchMedianAmuletPrice
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `fetchMedianAmuletPrice`
 
-</div>
+```daml
+fetchMedianAmuletPrice : Party -> [Party] -> [ContractId AmuletPriceVote] -> Update Decimal
+```
 
-<div id="function-splice-dso-amuletprice-median-98146">
+<span id="function-splice-dso-amuletprice-median-98146"></span>
 
-median
-: \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\] -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `median`
+
+```daml
+median : [Decimal] -> Decimal
+```
 
 See https://en.wikipedia.org/wiki/Median
 
-</div>
+## Templates
 
-{/* COPIED_END */}
+<span id="type-splice-dso-amuletprice-amuletpricevote-96658"></span>
+
+### Template `AmuletPriceVote`
+
+A vote by an SV for their desired amulet price.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party |  |
+| amuletPrice | Optional Decimal | Set to None for new svs, but defined thereafter. |
+| lastUpdatedAt | Time | The last time this price was updated. Tracked to limit svs from<br/><br/>changing their vote more than once per tick. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer.mdx
@@ -1,548 +1,468 @@
 ---
 title: "Splice.DSO.DecentralizedSynchronizer"
-description: "Documentation for Splice.DSO.DecentralizedSynchronizer"
+description: "Reference documentation for Daml module Splice.DSO.DecentralizedSynchronizer."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DSO-DecentralizedSynchronizer.rst" tag="0.6.4" hash="90fb1057" */}
+<span id="module-splice-dso-decentralizedsynchronizer-50859"></span>
+
+# Splice.DSO.DecentralizedSynchronizer
 
 Data structures and contracts related managing the decentralized synchronizer.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
-<div id="type-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-15965">
+<span id="type-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-15965"></span>
 
-**data** DsoDecentralizedSynchronizerConfig
+### `data DsoDecentralizedSynchronizerConfig`
 
-</div>
+The decentralized synchronizer consists of a series of actual synchronizers.
+New synchronizers are created by the SVs for the rare case of needing to roll-out
+a BFT protocol upgrade that cannot be rolled out in a backwards compatible fashion.
 
-> The decentralized synchronizer consists of a series of actual synchronizers. New synchronizers are created by the SVs for the rare case of needing to roll-out a BFT protocol upgrade that cannot be rolled out in a backwards compatible fashion.
->
-> Note that synchronizers themselves are formed by a cluster of nodes run by the SVs. As can be seen form `SynchronizerNodeConfig` each sv runs multiple different kinds of physical nodes.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-75458">
->
-> DsoDecentralizedSynchronizerConfig
->
-> </div>
->
-> > | Field                | Type                                                                                                                                                                                                                                            | Description                                                                 |
-> > |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-> > | synchronizers        | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig | The actual synchronizers, numbered sequentially.                            |
-> > | lastSynchronizerId   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                    | The last allocated synchronizer Id.                                         |
-> > | activeSynchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                    | The synchronizer to be used for managing standard DSO and Amulet workflows. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoDecentralizedSynchronizerConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoDecentralizedSynchronizerConfig
->
-> **instance** GetField "activeSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
->
-> **instance** GetField "lastSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
->
-> **instance** SetField "activeSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
->
-> **instance** SetField "lastSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
->
-> **instance** Patchable DsoDecentralizedSynchronizerConfig
+Note that synchronizers themselves are formed by a cluster of nodes run by the SVs.
+As can be seen form `SynchronizerNodeConfig` each sv runs multiple different kinds of
+physical nodes.
 
-<div id="type-splice-dso-decentralizedsynchronizer-legacysequencerconfig-76078">
+Constructors:
 
-**data** LegacySequencerConfig
+<span id="constr-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-75458"></span>
 
-</div>
+- `DsoDecentralizedSynchronizerConfig`
 
-> Config for a legacy sequencer, i.e., a migration id that is still up but paused. This is useful to allow validators to catch up.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-legacysequencerconfig-74515">
->
-> LegacySequencerConfig
->
-> </div>
->
-> > | Field       | Type                                                                                                         | Description                                                    |
-> > |-------------|--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-> > | migrationId | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)   | The synchronizer migration id corresponding to this sequencer. |
-> > | sequencerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The id of the sequencer.                                       |
-> > | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The public accessible url of the sequencer.                    |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) LegacySequencerConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) LegacySequencerConfig
->
-> **instance** GetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
->
-> **instance** GetField "migrationId" LegacySequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "sequencerId" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "url" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
->
-> **instance** SetField "migrationId" LegacySequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "sequencerId" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "url" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** Patchable LegacySequencerConfig
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| synchronizers | Map Text SynchronizerConfig | The actual synchronizers, numbered sequentially. |
+| lastSynchronizerId | Text | The last allocated synchronizer Id. |
+| activeSynchronizerId | Text | The synchronizer to be used for managing standard DSO and Amulet workflows. |
 
-<div id="type-splice-dso-decentralizedsynchronizer-mediatorconfig-99298">
+Instances:
 
-**data** MediatorConfig
+- `instance Patchable DsoDecentralizedSynchronizerConfig`
+- `instance Eq DsoDecentralizedSynchronizerConfig`
+- `instance Show DsoDecentralizedSynchronizerConfig`
+- `instance GetField activeSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance GetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance GetField lastSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance GetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+- `instance SetField activeSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance SetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance SetField lastSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance SetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
 
-</div>
+<span id="type-splice-dso-decentralizedsynchronizer-legacysequencerconfig-76078"></span>
 
-> Config for a mediator.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-mediatorconfig-88513">
->
-> MediatorConfig
->
-> </div>
->
-> > | Field      | Type                                                                                                         | Description             |
-> > |------------|--------------------------------------------------------------------------------------------------------------|-------------------------|
-> > | mediatorId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The id of the mediator. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MediatorConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MediatorConfig
->
-> **instance** GetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
->
-> **instance** GetField "mediatorId" MediatorConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
->
-> **instance** SetField "mediatorId" MediatorConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** Patchable MediatorConfig
+### `data LegacySequencerConfig`
 
-<div id="type-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfig-61630">
+Config for a legacy sequencer, i.e., a migration id that is still up but paused. This is useful to allow validators to catch up.
 
-**data** PhysicalSynchronizerNodeConfig
+Constructors:
 
-</div>
+<span id="constr-splice-dso-decentralizedsynchronizer-legacysequencerconfig-74515"></span>
 
-> <div id="constr-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfig-31009">
->
-> PhysicalSynchronizerNodeConfig
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                     | Description                                              |
-> > |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-> > | sequencer | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig | The configuration of this sv's optional local sequencer. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PhysicalSynchronizerNodeConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PhysicalSynchronizerNodeConfig
->
-> **instance** GetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
->
-> **instance** SetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
->
-> **instance** Patchable PhysicalSynchronizerNodeConfig
+- `LegacySequencerConfig`
 
-<div id="type-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfigmap-79969">
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| migrationId | Int | The synchronizer migration id corresponding to this sequencer. |
+| sequencerId | Text | The id of the sequencer. |
+| url | Text | The public accessible url of the sequencer. |
 
-**type** PhysicalSynchronizerNodeConfigMap
-= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) PhysicalSynchronizerNodeConfig
+Instances:
+
+- `instance Patchable LegacySequencerConfig`
+- `instance Eq LegacySequencerConfig`
+- `instance Show LegacySequencerConfig`
+- `instance GetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance GetField migrationId LegacySequencerConfig Int`
+- `instance GetField sequencerId LegacySequencerConfig Text`
+- `instance GetField url LegacySequencerConfig Text`
+- `instance SetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance SetField migrationId LegacySequencerConfig Int`
+- `instance SetField sequencerId LegacySequencerConfig Text`
+- `instance SetField url LegacySequencerConfig Text`
+
+<span id="type-splice-dso-decentralizedsynchronizer-mediatorconfig-99298"></span>
+
+### `data MediatorConfig`
+
+Config for a mediator.
+
+Constructors:
+
+<span id="constr-splice-dso-decentralizedsynchronizer-mediatorconfig-88513"></span>
+
+- `MediatorConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mediatorId | Text | The id of the mediator. |
+
+Instances:
+
+- `instance Patchable MediatorConfig`
+- `instance Eq MediatorConfig`
+- `instance Show MediatorConfig`
+- `instance GetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance GetField mediatorId MediatorConfig Text`
+- `instance SetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance SetField mediatorId MediatorConfig Text`
+
+<span id="type-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfig-61630"></span>
+
+### `data PhysicalSynchronizerNodeConfig`
+
+Constructors:
+
+<span id="constr-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfig-31009"></span>
+
+- `PhysicalSynchronizerNodeConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sequencer | Optional SequencerConnectionConfig | The configuration of this sv's optional local sequencer. |
+
+Instances:
+
+- `instance Patchable PhysicalSynchronizerNodeConfig`
+- `instance Eq PhysicalSynchronizerNodeConfig`
+- `instance Show PhysicalSynchronizerNodeConfig`
+- `instance GetField sequencer PhysicalSynchronizerNodeConfig (Optional SequencerConnectionConfig)`
+- `instance SetField sequencer PhysicalSynchronizerNodeConfig (Optional SequencerConnectionConfig)`
+
+<span id="type-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfigmap-79969"></span>
+
+### `type PhysicalSynchronizerNodeConfigMap = Map Int PhysicalSynchronizerNodeConfig`
 
 A map from physical synchronizer serial to the configuration of a sv's node for that physical synchronizer.
 
-**instance** GetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
+Instances:
 
-**instance** SetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
+- `instance GetField physicalSynchronizers SynchronizerNodeConfig (Optional PhysicalSynchronizerNodeConfigMap)`
+- `instance SetField physicalSynchronizers SynchronizerNodeConfig (Optional PhysicalSynchronizerNodeConfigMap)`
 
-</div>
+<span id="type-splice-dso-decentralizedsynchronizer-scanconfig-87910"></span>
 
-<div id="type-splice-dso-decentralizedsynchronizer-scanconfig-87910">
+### `data ScanConfig`
 
-**data** ScanConfig
+Config for a Scan instance.
 
-</div>
+Constructors:
 
-> Config for a Scan instance.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-scanconfig-27525">
->
-> ScanConfig
->
-> </div>
->
-> > | Field     | Type                                                                                                         | Description                                       |
-> > |-----------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-> > | publicUrl | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The publicly accessible URL of the Scan instance. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ScanConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ScanConfig
->
-> **instance** GetField "publicUrl" ScanConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
->
-> **instance** SetField "publicUrl" ScanConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
->
-> **instance** Patchable ScanConfig
+<span id="constr-splice-dso-decentralizedsynchronizer-scanconfig-27525"></span>
 
-<div id="type-splice-dso-decentralizedsynchronizer-sequencerconfig-38423">
+- `ScanConfig`
 
-**data** SequencerConfig
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| publicUrl | Text | The publicly accessible URL of the Scan instance. |
 
-</div>
+Instances:
 
-> Config for a sequencer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-sequencerconfig-73098">
->
-> SequencerConfig
->
-> </div>
->
-> > | Field          | Type                                                                                                                                                                                                                                             | Description                                                                                                       |
-> > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-> > | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                       | The synchronizer migration id corresponding to this sequencer.                                                    |
-> > | sequencerId    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                     | The id of the sequencer.                                                                                          |
-> > | url            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                     | The public accessible url of the sequencer.                                                                       |
-> > | availableAfter | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Any participant should subscribe this sequencer after this time. ^ If not set the sequencer is not yet accessible |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencerConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencerConfig
->
-> **instance** GetField "availableAfter" SequencerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
->
-> **instance** GetField "migrationId" SequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
->
-> **instance** GetField "sequencerId" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "url" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "availableAfter" SequencerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
->
-> **instance** SetField "migrationId" SequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
->
-> **instance** SetField "sequencerId" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "url" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** Patchable SequencerConfig
+- `instance Patchable ScanConfig`
+- `instance Eq ScanConfig`
+- `instance Show ScanConfig`
+- `instance GetField publicUrl ScanConfig Text`
+- `instance GetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+- `instance SetField publicUrl ScanConfig Text`
+- `instance SetField scan SynchronizerNodeConfig (Optional ScanConfig)`
 
-<div id="type-splice-dso-decentralizedsynchronizer-sequencerconnectionconfig-44977">
+<span id="type-splice-dso-decentralizedsynchronizer-sequencerconfig-38423"></span>
 
-**data** SequencerConnectionConfig
+### `data SequencerConfig`
 
-</div>
+Config for a sequencer.
 
-> Connection config for a sequencer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-sequencerconnectionconfig-40632">
->
-> SequencerConnectionConfig
->
-> </div>
->
-> > | Field | Type                                                                                                         | Description                                 |
-> > |-------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------|
-> > | url   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The public accessible url of the sequencer. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencerConnectionConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencerConnectionConfig
->
-> **instance** GetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
->
-> **instance** GetField "url" SequencerConnectionConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
->
-> **instance** SetField "url" SequencerConnectionConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** Patchable SequencerConnectionConfig
+Constructors:
 
-<div id="type-splice-dso-decentralizedsynchronizer-sequenceridentityconfig-4269">
+<span id="constr-splice-dso-decentralizedsynchronizer-sequencerconfig-73098"></span>
 
-**data** SequencerIdentityConfig
+- `SequencerConfig`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| migrationId | Int | The synchronizer migration id corresponding to this sequencer. |
+| sequencerId | Text | The id of the sequencer. |
+| url | Text | The public accessible url of the sequencer. |
+| availableAfter | Optional Time | Any participant should subscribe this sequencer after this time.<br/><br/>^ If not set the sequencer is not yet accessible |
 
-> Config for a sequencer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-sequenceridentityconfig-97016">
->
-> SequencerIdentityConfig
->
-> </div>
->
-> > | Field          | Type                                                                                                                                                                                                                                             | Description                                                                                                       |
-> > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-> > | sequencerId    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                     | The id of the sequencer.                                                                                          |
-> > | availableAfter | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Any participant should subscribe this sequencer after this time. ^ If not set the sequencer is not yet accessible |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencerIdentityConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencerIdentityConfig
->
-> **instance** GetField "availableAfter" SequencerIdentityConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
->
-> **instance** GetField "sequencerId" SequencerIdentityConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
->
-> **instance** SetField "availableAfter" SequencerIdentityConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
->
-> **instance** SetField "sequencerId" SequencerIdentityConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
->
-> **instance** Patchable SequencerIdentityConfig
+Instances:
 
-<div id="type-splice-dso-decentralizedsynchronizer-synchronizerconfig-49093">
+- `instance Patchable SequencerConfig`
+- `instance Eq SequencerConfig`
+- `instance Show SequencerConfig`
+- `instance GetField availableAfter SequencerConfig (Optional Time)`
+- `instance GetField migrationId SequencerConfig Int`
+- `instance GetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance GetField sequencerId SequencerConfig Text`
+- `instance GetField url SequencerConfig Text`
+- `instance SetField availableAfter SequencerConfig (Optional Time)`
+- `instance SetField migrationId SequencerConfig Int`
+- `instance SetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance SetField sequencerId SequencerConfig Text`
+- `instance SetField url SequencerConfig Text`
 
-**data** SynchronizerConfig
+<span id="type-splice-dso-decentralizedsynchronizer-sequencerconnectionconfig-44977"></span>
 
-</div>
+### `data SequencerConnectionConfig`
 
-> The DSO-level configuration of a synchronizer. This contains the shared parameters of the synchronizer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-synchronizerconfig-62326">
->
-> SynchronizerConfig
->
-> </div>
->
-> > | Field                               | Type                                                                                                                                                                                                                                      | Description                                                                                                                      |
-> > |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-> > | state                               | SynchronizerState                                                                                                                                                                                                                         | The state of this synchronizer                                                                                                   |
-> > | cometBftGenesisJson                 | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                              | The CometBftGenesis json value required for new svs to bring up their CometBft nodes for this synchronizer.                      |
-> > | acsCommitmentReconciliationInterval | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Participants connected to the decentralized synchronizer exchange ACS commitment messages every reconciliation interval seconds. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerConfig
->
-> **instance** GetField "acsCommitmentReconciliationInterval" SynchronizerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
->
-> **instance** GetField "cometBftGenesisJson" SynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "state" SynchronizerConfig SynchronizerState
->
-> **instance** GetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
->
-> **instance** SetField "acsCommitmentReconciliationInterval" SynchronizerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
->
-> **instance** SetField "cometBftGenesisJson" SynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "state" SynchronizerConfig SynchronizerState
->
-> **instance** SetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
->
-> **instance** Patchable SynchronizerConfig
+Connection config for a sequencer.
 
-<div id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-10457">
+Constructors:
 
-**data** SynchronizerNodeConfig
+<span id="constr-splice-dso-decentralizedsynchronizer-sequencerconnectionconfig-40632"></span>
 
-</div>
+- `SequencerConnectionConfig`
 
-> The configuration of a sv's node for a particular synchronizer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-64798">
->
-> SynchronizerNodeConfig
->
-> </div>
->
-> > | Field                 | Type                                                                                                                                                             | Description                                                                                                                                       |
-> > |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | cometBft              | CometBftConfig                                                                                                                                                   | The configuration of this sv's CometBFT nodes and keys.                                                                                           |
-> > | sequencer             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig                   | The configuration of this sv's optional local sequencer.                                                                                          |
-> > | mediator              | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig                    | The configuration of this sv's optional local mediator.                                                                                           |
-> > | scan                  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig                        | The configuration of this sv's optional Scan instance.                                                                                            |
-> > | legacySequencerConfig | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig             | The legacy sequencer config for the prior migration id that is still up. We store this so it can be published on scan and validators can catchup. |
-> > | sequencerIdentity     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig           | The configuration of this sv's optional local sequencer.                                                                                          |
-> > | physicalSynchronizers | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap | The synchronizer node configs for the currently running physical synchronizers.                                                                   |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerNodeConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerNodeConfig
->
-> **instance** GetField "cometBft" SynchronizerNodeConfig CometBftConfig
->
-> **instance** GetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
->
-> **instance** GetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
->
-> **instance** GetField "newNodeConfig" DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig
->
-> **instance** GetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
->
-> **instance** GetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
->
-> **instance** GetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
->
-> **instance** GetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
->
-> **instance** SetField "cometBft" SynchronizerNodeConfig CometBftConfig
->
-> **instance** SetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
->
-> **instance** SetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
->
-> **instance** SetField "newNodeConfig" DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig
->
-> **instance** SetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
->
-> **instance** SetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
->
-> **instance** SetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
->
-> **instance** SetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
->
-> **instance** Patchable SynchronizerNodeConfig
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| url | Text | The public accessible url of the sequencer. |
 
-<div id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-3659">
+Instances:
 
-**data** SynchronizerNodeConfigLimits
+- `instance Patchable SequencerConnectionConfig`
+- `instance Eq SequencerConnectionConfig`
+- `instance Show SequencerConnectionConfig`
+- `instance GetField sequencer PhysicalSynchronizerNodeConfig (Optional SequencerConnectionConfig)`
+- `instance GetField url SequencerConnectionConfig Text`
+- `instance SetField sequencer PhysicalSynchronizerNodeConfig (Optional SequencerConnectionConfig)`
+- `instance SetField url SequencerConnectionConfig Text`
 
-</div>
+<span id="type-splice-dso-decentralizedsynchronizer-sequenceridentityconfig-4269"></span>
 
-> <div id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-16072">
->
-> SynchronizerNodeConfigLimits
->
-> </div>
->
-> > | Field    | Type                 | Description |
-> > |----------|----------------------|-------------|
-> > | cometBft | CometBftConfigLimits |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerNodeConfigLimits
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerNodeConfigLimits
->
-> **instance** GetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
->
-> **instance** GetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
->
-> **instance** SetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
->
-> **instance** SetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
->
-> **instance** Patchable SynchronizerNodeConfigLimits
+### `data SequencerIdentityConfig`
 
-<div id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfigmap-59848">
+Config for a sequencer.
 
-**type** SynchronizerNodeConfigMap
-= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerNodeConfig
+Constructors:
+
+<span id="constr-splice-dso-decentralizedsynchronizer-sequenceridentityconfig-97016"></span>
+
+- `SequencerIdentityConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sequencerId | Text | The id of the sequencer. |
+| availableAfter | Optional Time | Any participant should subscribe this sequencer after this time.<br/><br/>^ If not set the sequencer is not yet accessible |
+
+Instances:
+
+- `instance Patchable SequencerIdentityConfig`
+- `instance Eq SequencerIdentityConfig`
+- `instance Show SequencerIdentityConfig`
+- `instance GetField availableAfter SequencerIdentityConfig (Optional Time)`
+- `instance GetField sequencerId SequencerIdentityConfig Text`
+- `instance GetField sequencerIdentity SynchronizerNodeConfig (Optional SequencerIdentityConfig)`
+- `instance SetField availableAfter SequencerIdentityConfig (Optional Time)`
+- `instance SetField sequencerId SequencerIdentityConfig Text`
+- `instance SetField sequencerIdentity SynchronizerNodeConfig (Optional SequencerIdentityConfig)`
+
+<span id="type-splice-dso-decentralizedsynchronizer-synchronizerconfig-49093"></span>
+
+### `data SynchronizerConfig`
+
+The DSO-level configuration of a synchronizer. This contains the shared parameters
+of the synchronizer.
+
+Constructors:
+
+<span id="constr-splice-dso-decentralizedsynchronizer-synchronizerconfig-62326"></span>
+
+- `SynchronizerConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| state | SynchronizerState | The state of this synchronizer |
+| cometBftGenesisJson | Text | The CometBftGenesis json value required for new svs to bring up<br/><br/>their CometBft nodes for this synchronizer. |
+| acsCommitmentReconciliationInterval | Optional Int | Participants connected to the decentralized synchronizer exchange ACS commitment messages<br/><br/>every reconciliation interval seconds. |
+
+Instances:
+
+- `instance Patchable SynchronizerConfig`
+- `instance Eq SynchronizerConfig`
+- `instance Show SynchronizerConfig`
+- `instance GetField acsCommitmentReconciliationInterval SynchronizerConfig (Optional Int)`
+- `instance GetField cometBftGenesisJson SynchronizerConfig Text`
+- `instance GetField state SynchronizerConfig SynchronizerState`
+- `instance GetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+- `instance SetField acsCommitmentReconciliationInterval SynchronizerConfig (Optional Int)`
+- `instance SetField cometBftGenesisJson SynchronizerConfig Text`
+- `instance SetField state SynchronizerConfig SynchronizerState`
+- `instance SetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+
+<span id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-10457"></span>
+
+### `data SynchronizerNodeConfig`
+
+The configuration of a sv's node for a particular synchronizer.
+
+Constructors:
+
+<span id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-64798"></span>
+
+- `SynchronizerNodeConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cometBft | CometBftConfig | The configuration of this sv's CometBFT nodes and keys. |
+| sequencer | Optional SequencerConfig | The configuration of this sv's optional local sequencer. |
+| mediator | Optional MediatorConfig | The configuration of this sv's optional local mediator. |
+| scan | Optional ScanConfig | The configuration of this sv's optional Scan instance. |
+| legacySequencerConfig | Optional LegacySequencerConfig | The legacy sequencer config for the prior migration id that is still up. We store this so it can be published on scan and validators can catchup. |
+| sequencerIdentity | Optional SequencerIdentityConfig | The configuration of this sv's optional local sequencer. |
+| physicalSynchronizers | Optional PhysicalSynchronizerNodeConfigMap | The synchronizer node configs for the currently running physical synchronizers. |
+
+Instances:
+
+- `instance Patchable SynchronizerNodeConfig`
+- `instance Eq SynchronizerNodeConfig`
+- `instance Show SynchronizerNodeConfig`
+- `instance GetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance GetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance GetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance GetField newNodeConfig DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig`
+- `instance GetField physicalSynchronizers SynchronizerNodeConfig (Optional PhysicalSynchronizerNodeConfigMap)`
+- `instance GetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+- `instance GetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance GetField sequencerIdentity SynchronizerNodeConfig (Optional SequencerIdentityConfig)`
+- `instance SetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance SetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance SetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance SetField newNodeConfig DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig`
+- `instance SetField physicalSynchronizers SynchronizerNodeConfig (Optional PhysicalSynchronizerNodeConfigMap)`
+- `instance SetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+- `instance SetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance SetField sequencerIdentity SynchronizerNodeConfig (Optional SequencerIdentityConfig)`
+
+<span id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-3659"></span>
+
+### `data SynchronizerNodeConfigLimits`
+
+Constructors:
+
+<span id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-16072"></span>
+
+- `SynchronizerNodeConfigLimits`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cometBft | CometBftConfigLimits |  |
+
+Instances:
+
+- `instance Patchable SynchronizerNodeConfigLimits`
+- `instance Eq SynchronizerNodeConfigLimits`
+- `instance Show SynchronizerNodeConfigLimits`
+- `instance GetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance GetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+- `instance SetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance SetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+
+<span id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfigmap-59848"></span>
+
+### `type SynchronizerNodeConfigMap = Map Text SynchronizerNodeConfig`
 
 A map from synchronizer-ids to the configuration of a sv's node for this synchronizer.
 
-**instance** GetField "sv1SynchronizerNodes" DsoBootstrap SynchronizerNodeConfigMap
+Instances:
 
-**instance** GetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+- `instance GetField sv1SynchronizerNodes DsoBootstrap SynchronizerNodeConfigMap`
+- `instance GetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+- `instance SetField sv1SynchronizerNodes DsoBootstrap SynchronizerNodeConfigMap`
+- `instance SetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
 
-**instance** SetField "sv1SynchronizerNodes" DsoBootstrap SynchronizerNodeConfigMap
+<span id="type-splice-dso-decentralizedsynchronizer-synchronizerstate-25483"></span>
 
-**instance** SetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+### `data SynchronizerState`
 
-</div>
+The state of a synchronizer.
 
-<div id="type-splice-dso-decentralizedsynchronizer-synchronizerstate-25483">
+Constructors:
 
-**data** SynchronizerState
+<span id="constr-splice-dso-decentralizedsynchronizer-dsbootstrapping-64886"></span>
 
-</div>
+- `DS_Bootstrapping`
 
-> The state of a synchronizer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-dsbootstrapping-64886">
->
-> DS_Bootstrapping
->
-> </div>
->
-> > The synchronizer is still being bootstrapped, and SVs are required to provision their nodes for it.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-dsoperational-99130">
->
-> DS_Operational
->
-> </div>
->
-> > The synchronizer is operational, and thus can be used as the active synchronizer.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-dsdecomissioned-12812">
->
-> DS_Decomissioned
->
-> </div>
->
-> > The synchronizer has been decommissioned and svs are now allowed to shutdown their nodes for that synchronizer. We track this state explicitly instead of just deleting the synchronizer config, as decomissioning likely takes a while, and we want to avoid confusion among SV operators when they see errors raised from some of their synchronizer nodes.
->
-> <div id="constr-splice-dso-decentralizedsynchronizer-extsynchronizerstate-26922">
->
-> ExtSynchronizerState
->
-> </div>
->
-> > Extension constructor to work around the current lack of upgrading for variants in Daml 3.0. Will serve as the default value in a containing record in case of an extension.
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerState
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerState
->
-> **instance** GetField "state" SynchronizerConfig SynchronizerState
->
-> **instance** SetField "state" SynchronizerConfig SynchronizerState
->
-> **instance** Patchable SynchronizerState
+The synchronizer is still being bootstrapped, and SVs are required to
+provision their nodes for it.
+
+<span id="constr-splice-dso-decentralizedsynchronizer-dsoperational-99130"></span>
+
+- `DS_Operational`
+
+The synchronizer is operational, and thus can be used as
+the active synchronizer.
+
+<span id="constr-splice-dso-decentralizedsynchronizer-dsdecomissioned-12812"></span>
+
+- `DS_Decomissioned`
+
+The synchronizer has been decommissioned and svs are now allowed to shutdown
+their nodes for that synchronizer. We track this state explicitly instead of just
+deleting the synchronizer config, as decomissioning likely takes a while, and we
+want to avoid confusion among SV operators when they see errors raised from
+some of their synchronizer nodes.
+
+<span id="constr-splice-dso-decentralizedsynchronizer-extsynchronizerstate-26922"></span>
+
+- `ExtSynchronizerState`
+
+Extension constructor to work around the current lack of upgrading for variants in Daml 3.0.
+Will serve as the default value in a containing record in case of an extension.
+
+Instances:
+
+- `instance Patchable SynchronizerState`
+- `instance Eq SynchronizerState`
+- `instance Show SynchronizerState`
+- `instance GetField state SynchronizerConfig SynchronizerState`
+- `instance SetField state SynchronizerConfig SynchronizerState`
 
 ## Functions
 
-<div id="function-splice-dso-decentralizedsynchronizer-nosynchronizernodes-89430">
+<span id="function-splice-dso-decentralizedsynchronizer-nosynchronizernodes-89430"></span>
 
-noSynchronizerNodes
-: SynchronizerNodeConfigMap
+### `noSynchronizerNodes`
 
-</div>
+```daml
+noSynchronizerNodes : SynchronizerNodeConfigMap
+```
 
-<div id="function-splice-dso-decentralizedsynchronizer-emptysynchronizernodeconfig-56591">
+<span id="function-splice-dso-decentralizedsynchronizer-emptysynchronizernodeconfig-56591"></span>
 
-emptySynchronizerNodeConfig
-: SynchronizerNodeConfig
+### `emptySynchronizerNodeConfig`
 
-</div>
+```daml
+emptySynchronizerNodeConfig : SynchronizerNodeConfig
+```
 
-<div id="function-splice-dso-decentralizedsynchronizer-validsynchronizernodeconfig-25090">
+<span id="function-splice-dso-decentralizedsynchronizer-validsynchronizernodeconfig-25090"></span>
 
-validSynchronizerNodeConfig
-: SynchronizerNodeConfigLimits -\> SynchronizerNodeConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `validSynchronizerNodeConfig`
 
-</div>
+```daml
+validSynchronizerNodeConfig : SynchronizerNodeConfigLimits -> SynchronizerNodeConfig -> Bool
+```
 
-<div id="function-splice-dso-decentralizedsynchronizer-defaultsynchronizernodeconfiglimits-67119">
+<span id="function-splice-dso-decentralizedsynchronizer-defaultsynchronizernodeconfiglimits-67119"></span>
 
-defaultSynchronizerNodeConfigLimits
-: SynchronizerNodeConfigLimits
+### `defaultSynchronizerNodeConfigLimits`
 
-</div>
-
-{/* COPIED_END */}
+```daml
+defaultSynchronizerNodeConfigLimits : SynchronizerNodeConfigLimits
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate.mdx
@@ -1,291 +1,269 @@
 ---
 title: "Splice.DSO.SvState"
-description: "Documentation for Splice.DSO.SvState"
+description: "Reference documentation for Daml module Splice.DSO.SvState."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DSO-SvState.rst" tag="0.6.4" hash="1ea16913" */}
+<span id="module-splice-dso-svstate-17621"></span>
+
+# Splice.DSO.SvState
 
 Templates to track per-sv state.
 
-## Templates
+## Module Snapshot
 
-<div id="type-splice-dso-svstate-svnodestate-44938">
-
-**template** SvNodeState
-
-</div>
-
-> State of a node managed by an SV operator party.
->
-> There is exactly one such state per SV operator party. Even though every SV can operate at most one node at any one time, there can though be multiple SV node states per SV, as the state of offboarded nodes is kept around for debugging purposes.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                | Description                                     |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                 |
-> | sv     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The SV operator party identifying the node.     |
-> | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The SV name in whose name the node is operated. |
-> | state  | NodeState                                                                                                           |                                                 |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-dso-svstate-svrewardstate-90395">
-
-**template** SvRewardState
-
-</div>
-
-> State of reward collection for a sv identified by their sv name.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                | Description |
-> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
-> | state  | RewardState                                                                                                         |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-dso-svstate-svstatusreport-18374">
-
-**template** SvStatusReport
-
-</div>
-
-> A singleton contract per SV party that is used to regularly submit status reports.
->
-> Individual status reports serve as a heartbeat for a specific SV party and its associoated SV node ; and to distribute that SVs view on the network to all other SVs.
->
-> Signatory: dso
->
-> | Field  | Type                                                                                                                                    | Description                                                                      |
-> |--------|-----------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     |                                                                                  |
-> | sv     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     | The SV party that submitted this report.                                         |
-> | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                            | The name of the SV operator whose operator party was used to submit this report. |
-> | number | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                              | The number of this report, starting from 0.                                      |
-> | status | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SvStatus | None is used when initially creating the contract upon sv addition.              |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-dso-svstate-forsv-86032">
+<span id="type-splice-dso-svstate-forsv-86032"></span>
 
-**data** ForSv
+### `data ForSv`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-dso-svstate-forsv-25145">
->
-> ForSv
->
-> </div>
->
-> > | Field  | Type                                                                                                                | Description |
-> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForSv
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForSv
->
-> **instance** GetField "dso" ForSv [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "svName" ForSv [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dso" ForSv [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "svName" ForSv [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** HasCheckedFetch SvRewardState ForSv
+<span id="constr-splice-dso-svstate-forsv-25145"></span>
 
-<div id="type-splice-dso-svstate-forsvnode-12988">
+- `ForSv`
 
-**data** ForSvNode
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| svName | Text |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-dso-svstate-forsvnode-35713">
->
-> ForSvNode
->
-> </div>
->
-> > | Field  | Type                                                                                                                | Description |
-> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | sv     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForSvNode
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForSvNode
->
-> **instance** GetField "dso" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "sv" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "svName" ForSvNode [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dso" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "sv" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "svName" ForSvNode [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** HasCheckedFetch SvNodeState ForSvNode
->
-> **instance** HasCheckedFetch SvStatusReport ForSvNode
+- `instance HasCheckedFetch SvRewardState ForSv`
+- `instance Eq ForSv`
+- `instance Show ForSv`
+- `instance GetField dso ForSv Party`
+- `instance GetField svName ForSv Text`
+- `instance SetField dso ForSv Party`
+- `instance SetField svName ForSv Text`
 
-<div id="type-splice-dso-svstate-nodestate-84781">
+<span id="type-splice-dso-svstate-forsvnode-12988"></span>
 
-**data** NodeState
+### `data ForSvNode`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-dso-svstate-nodestate-4328">
->
-> NodeState
->
-> </div>
->
-> > | Field             | Type                      | Description                                                                                                |
-> > |-------------------|---------------------------|------------------------------------------------------------------------------------------------------------|
-> > | synchronizerNodes | SynchronizerNodeConfigMap | The config for a synchronizer's CometBFT, sequencer, mediator and scan nodes under control of an SV party. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) NodeState
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) NodeState
->
-> **instance** GetField "state" SvNodeState NodeState
->
-> **instance** GetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
->
-> **instance** SetField "state" SvNodeState NodeState
->
-> **instance** SetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+<span id="constr-splice-dso-svstate-forsvnode-35713"></span>
 
-<div id="type-splice-dso-svstate-rewardstate-93172">
+- `ForSvNode`
 
-**data** RewardState
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party |  |
+| svName | Text |  |
 
-</div>
+Instances:
 
-> Reward collection state of an SV.
->
-> Note that we keep some extra aggregates in this state to make it easier to interpret it. In principle, these could be derived from the transaction history, but that would be much more onerous to implement.
->
-> <div id="constr-splice-dso-svstate-rewardstate-16777">
->
-> RewardState
->
-> </div>
->
-> > | Field              | Type                                                                                                       | Description                                                         |
-> > |--------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-> > | numRoundsMissed    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Number of rounds for which they missed collecting coupons.          |
-> > | numRoundsCollected | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Number of rounds for which they collected coupons.                  |
-> > | lastRoundCollected | Round                                                                                                      | Last round for which they collected reward coupons.                 |
-> > | numCouponsIssued   | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Number of SV reward coupons issued by them for their beneficiaries. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RewardState
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RewardState
->
-> **instance** GetField "lastRoundCollected" RewardState Round
->
-> **instance** GetField "numCouponsIssued" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "numRoundsCollected" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "numRoundsMissed" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "state" SvRewardState RewardState
->
-> **instance** SetField "lastRoundCollected" RewardState Round
->
-> **instance** SetField "numCouponsIssued" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "numRoundsCollected" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "numRoundsMissed" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "state" SvRewardState RewardState
+- `instance HasCheckedFetch SvNodeState ForSvNode`
+- `instance HasCheckedFetch SvStatusReport ForSvNode`
+- `instance Eq ForSvNode`
+- `instance Show ForSvNode`
+- `instance GetField dso ForSvNode Party`
+- `instance GetField sv ForSvNode Party`
+- `instance GetField svName ForSvNode Text`
+- `instance SetField dso ForSvNode Party`
+- `instance SetField sv ForSvNode Party`
+- `instance SetField svName ForSvNode Text`
 
-<div id="type-splice-dso-svstate-svstatus-81954">
+<span id="type-splice-dso-svstate-nodestate-84781"></span>
 
-**data** SvStatus
+### `data NodeState`
 
-</div>
+Constructors:
 
-> The status of an SV as seen from their SV node's perspective. We generally add values here that are expected to regularly increase, so that SV node operators can run alerting off of them.
->
-> <div id="constr-splice-dso-svstate-svstatus-71949">
->
-> SvStatus
->
-> </div>
->
-> > | Field                       | Type                                                                                                              | Description                                                                                                                      |
-> > |-----------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-> > | createdAt                   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The wall clock time of the SV node at the time when the SV node started to gather the data points in this report to submit them. |
-> > | cometBftHeight              | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        | The height of the CometBFT chain at the time of submission                                                                       |
-> > | mediatorSynchronizerTime    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The latest synchronizer time observed on the mediator at the time of submission                                                  |
-> > | participantSynchronizerTime | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The latest synchronizer time observed on the participant at the time of submission                                               |
-> > | latestOpenRound             | Round                                                                                                             | The maximum round number of the OpenMiningRound contracts at the time of submission                                              |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SvStatus
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SvStatus
->
-> **instance** GetField "cometBftHeight" SvStatus [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "createdAt" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "latestOpenRound" SvStatus Round
->
-> **instance** GetField "mediatorSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "participantSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "status" SvStatusReport ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SvStatus)
->
-> **instance** GetField "status" DsoRules_SubmitStatusReport SvStatus
->
-> **instance** SetField "cometBftHeight" SvStatus [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "createdAt" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "latestOpenRound" SvStatus Round
->
-> **instance** SetField "mediatorSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "participantSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "status" SvStatusReport ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SvStatus)
->
-> **instance** SetField "status" DsoRules_SubmitStatusReport SvStatus
+<span id="constr-splice-dso-svstate-nodestate-4328"></span>
 
-{/* COPIED_END */}
+- `NodeState`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| synchronizerNodes | SynchronizerNodeConfigMap | The config for a synchronizer's CometBFT, sequencer, mediator and scan nodes under control of an SV party. |
+
+Instances:
+
+- `instance Eq NodeState`
+- `instance Show NodeState`
+- `instance GetField state SvNodeState NodeState`
+- `instance GetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+- `instance SetField state SvNodeState NodeState`
+- `instance SetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+
+<span id="type-splice-dso-svstate-rewardstate-93172"></span>
+
+### `data RewardState`
+
+Reward collection state of an SV.
+
+Note that we keep some extra aggregates in this state to make it easier to interpret it.
+In principle, these could be derived from the transaction history, but that
+would be much more onerous to implement.
+
+Constructors:
+
+<span id="constr-splice-dso-svstate-rewardstate-16777"></span>
+
+- `RewardState`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| numRoundsMissed | Int | Number of rounds for which they missed collecting coupons. |
+| numRoundsCollected | Int | Number of rounds for which they collected coupons. |
+| lastRoundCollected | Round | Last round for which they collected reward coupons. |
+| numCouponsIssued | Int | Number of SV reward coupons issued by them for their beneficiaries. |
+
+Instances:
+
+- `instance Eq RewardState`
+- `instance Show RewardState`
+- `instance GetField lastRoundCollected RewardState Round`
+- `instance GetField numCouponsIssued RewardState Int`
+- `instance GetField numRoundsCollected RewardState Int`
+- `instance GetField numRoundsMissed RewardState Int`
+- `instance GetField state SvRewardState RewardState`
+- `instance SetField lastRoundCollected RewardState Round`
+- `instance SetField numCouponsIssued RewardState Int`
+- `instance SetField numRoundsCollected RewardState Int`
+- `instance SetField numRoundsMissed RewardState Int`
+- `instance SetField state SvRewardState RewardState`
+
+<span id="type-splice-dso-svstate-svstatus-81954"></span>
+
+### `data SvStatus`
+
+The status of an SV as seen from their SV node's perspective.
+We generally add values here that are expected to regularly increase, so that
+SV node operators can run alerting off of them.
+
+Constructors:
+
+<span id="constr-splice-dso-svstate-svstatus-71949"></span>
+
+- `SvStatus`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| createdAt | Time | The wall clock time of the SV node at the time when the SV node started to<br/><br/>gather the data points in this report to submit them. |
+| cometBftHeight | Int | The height of the CometBFT chain at the time of submission |
+| mediatorSynchronizerTime | Time | The latest synchronizer time observed on the mediator at the time of submission |
+| participantSynchronizerTime | Time | The latest synchronizer time observed on the participant at the time of submission |
+| latestOpenRound | Round | The maximum round number of the OpenMiningRound contracts at the time of submission |
+
+Instances:
+
+- `instance Eq SvStatus`
+- `instance Show SvStatus`
+- `instance GetField cometBftHeight SvStatus Int`
+- `instance GetField createdAt SvStatus Time`
+- `instance GetField latestOpenRound SvStatus Round`
+- `instance GetField mediatorSynchronizerTime SvStatus Time`
+- `instance GetField participantSynchronizerTime SvStatus Time`
+- `instance GetField status SvStatusReport (Optional SvStatus)`
+- `instance GetField status DsoRules_SubmitStatusReport SvStatus`
+- `instance SetField cometBftHeight SvStatus Int`
+- `instance SetField createdAt SvStatus Time`
+- `instance SetField latestOpenRound SvStatus Round`
+- `instance SetField mediatorSynchronizerTime SvStatus Time`
+- `instance SetField participantSynchronizerTime SvStatus Time`
+- `instance SetField status SvStatusReport (Optional SvStatus)`
+- `instance SetField status DsoRules_SubmitStatusReport SvStatus`
+
+## Templates
+
+<span id="type-splice-dso-svstate-svnodestate-44938"></span>
+
+### Template `SvNodeState`
+
+State of a node managed by an SV operator party.
+
+There is exactly one such state per SV operator party.
+Even though every SV can operate at most one node at any one time,
+there can though be multiple SV node states per SV, as the state of offboarded
+nodes is kept around for debugging purposes.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party | The SV operator party identifying the node. |
+| svName | Text | The SV name in whose name the node is operated. |
+| state | NodeState |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dso-svstate-svrewardstate-90395"></span>
+
+### Template `SvRewardState`
+
+State of reward collection for a sv identified by their sv name.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| svName | Text |  |
+| state | RewardState |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dso-svstate-svstatusreport-18374"></span>
+
+### Template `SvStatusReport`
+
+A singleton contract per SV party that is used to regularly submit status reports.
+
+Individual status reports serve as a heartbeat for a specific SV party and its associoated SV node
+; and to distribute that SVs view on the network to all other SVs.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party | The SV party that submitted this report. |
+| svName | Text | The name of the SV operator whose operator party was used to submit this report. |
+| number | Int | The number of this report, starting from 0. |
+| status | Optional SvStatus | None is used when initially creating the contract upon sv addition. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap.mdx
@@ -1,77 +1,87 @@
 ---
 title: "Splice.DsoBootstrap"
-description: "Documentation for Splice.DsoBootstrap"
+description: "Reference documentation for Daml module Splice.DsoBootstrap."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DsoBootstrap.rst" tag="0.6.4" hash="54674734" */}
+<span id="module-splice-dsobootstrap-6192"></span>
 
-## Templates
+# Splice.DsoBootstrap
 
-<div id="type-splice-dsobootstrap-dsobootstrap-38046">
+## Module Snapshot
 
-**template** DsoBootstrap
-
-</div>
-
-> A template for bootstrapping DsoRules and AmuletRules.
->
-> Signatory: dso
->
-> | Field                | Type                                                                                                                                                                                                                                      | Description                                                          |
-> |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
-> | dso                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                       |                                                                      |
-> | sv1Party             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                       | the SV that bootstraps the network                                   |
-> | sv1Name              | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                              | human-readable name of SV1                                           |
-> | sv1RewardWeight      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                | the weight of SV1 in the reward distribution                         |
-> | sv1ParticipantId     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                              | the id of the participant of the SV that bootstraps the synchronizer |
-> | sv1SynchronizerNodes | SynchronizerNodeConfigMap                                                                                                                                                                                                                 | Synchronizer nodes on which this workflow runs                       |
-> | round0Duration       | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                    |                                                                      |
-> | amuletConfig         | AmuletConfig USD                                                                                                                                                                                                                          |                                                                      |
-> | amuletPrice          | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                                                                      |
-> | ansRulesConfig       | AnsRulesConfig                                                                                                                                                                                                                            |                                                                      |
-> | config               | DsoRulesConfig                                                                                                                                                                                                                            |                                                                      |
-> | initialTrafficState  | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState |                                                                      |
-> | isDevNet             | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                              |                                                                      |
-> | initialRound         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |                                                                      |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-dsobootstrap-dsobootstrapbootstrap-56803">
->
->   **Choice** DsoBootstrap_Bootstrap
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoBootstrap_BootstrapResult
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-dsobootstrap-dsobootstrapbootstrapresult-11174">
+<span id="type-splice-dsobootstrap-dsobootstrapbootstrapresult-11174"></span>
 
-**data** DsoBootstrap_BootstrapResult
+### `data DsoBootstrap_BootstrapResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-dsobootstrap-dsobootstrapbootstrapresult-22331">
->
-> DsoBootstrap_BootstrapResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult
+<span id="constr-splice-dsobootstrap-dsobootstrapbootstrapresult-22331"></span>
 
-{/* COPIED_END */}
+- `DsoBootstrap_BootstrapResult`
+
+Instances:
+
+- `instance HasExercise DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult`
+- `instance HasFromAnyChoice DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult`
+- `instance HasToAnyChoice DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult`
+
+## Templates
+
+<span id="type-splice-dsobootstrap-dsobootstrap-38046"></span>
+
+### Template `DsoBootstrap`
+
+A template for bootstrapping DsoRules and AmuletRules.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv1Party | Party | the SV that bootstraps the network |
+| sv1Name | Text | human-readable name of SV1 |
+| sv1RewardWeight | Int | the weight of SV1 in the reward distribution |
+| sv1ParticipantId | Text | the id of the participant of the SV that bootstraps the synchronizer |
+| sv1SynchronizerNodes | SynchronizerNodeConfigMap | Synchronizer nodes on which this workflow runs |
+| round0Duration | RelTime |  |
+| amuletConfig | AmuletConfig USD |  |
+| amuletPrice | Decimal |  |
+| ansRulesConfig | AnsRulesConfig |  |
+| config | DsoRulesConfig |  |
+| initialTrafficState | Map Text TrafficState |  |
+| isDevNet | Bool |  |
+| initialRound | Optional Int |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dsobootstrap-dsobootstrapbootstrap-56803"></span>
+
+#### Choice `DsoBootstrap_Bootstrap`
+
+Controllers: `dso`
+
+Returns: `DsoBootstrap_BootstrapResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules.mdx
@@ -1,3615 +1,3207 @@
 ---
 title: "Splice.DsoRules"
-description: "Documentation for Splice.DsoRules"
+description: "Reference documentation for Daml module Splice.DsoRules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DsoRules.rst" tag="0.6.4" hash="c73ff863" */}
+<span id="module-splice-dsorules-86281"></span>
 
-## Templates
+# Splice.DsoRules
 
-<div id="type-splice-dsorules-bootstrapexternalpartyconfigstateinstruction-72557">
+## Module Snapshot
 
-**template** BootstrapExternalPartyConfigStateInstruction
-
-</div>
-
-> Instruction to bootstrap the external party config state. This exists so that the `ActionRequiringConfirmation` for this is independent of the current rounds which we need so that we can do deduplication by action hash in our automation.
->
-> Signatory: dso
->
-> | Field | Type                                                                                                                | Description |
-> |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-dsorules-confirmation-62984">
-
-**template** Confirmation
-
-</div>
-
-> A confirmation for the SVs to take action as part of standard DSO. Used for executing automated actions in a shortened process. See the comments on `ActionRequiringConfirmation` for details.
->
-> Signatory: dso
->
-> | Field     | Type                                                                                                                | Description |
-> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | confirmer | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | action    | ActionRequiringConfirmation                                                                                         |             |
-> | expiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-dsorules-confirmationexpire-84183">
->
->   **Choice** Confirmation_Expire
->
->   </div>
->
->   Controller: dso
->
->   Returns: Confirmation_ExpireResult
->
->   (no fields)
-
-<div id="type-splice-dsorules-dsorules-35440">
-
-**template** DsoRules
-
-</div>
-
-> Signatory: dso
->
-> | Field               | Type                                                                                                                                                                                                                                                 | Description                                                                                                                       |
-> |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-> | dso                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                  |                                                                                                                                   |
-> | epoch               | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                           |                                                                                                                                   |
-> | svs                 | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) SvInfo           |                                                                                                                                   |
-> | offboardedSvs       | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) OffboardedSvInfo |                                                                                                                                   |
-> | dsoDelegate         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                  | **Deprecated** in favor of delegateless automation.                                                                               |
-> | config              | DsoRulesConfig                                                                                                                                                                                                                                       |                                                                                                                                   |
-> | initialTrafficState | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState            | Map from participant/mediator ID to its traffic state at the time of synchronizer bootstrapping. Used for testing, empty in prod. |
-> | isDevNet            | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                                         |                                                                                                                                   |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-dsorules-dsorulesaddconfirmedsv-22105">
->
->   **Choice** DsoRules_AddConfirmedSv
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_AddConfirmedSvResult
->
->   | Field                    | Type                                                                                                                                                | Description |
->   |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sv                       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                 |             |
->   | svOnboardingConfirmedCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed |             |
->   | earliestRoundCid         | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound       |             |
->   | middleRoundCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound       |             |
->   | latestRoundCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound       |             |
->   | amuletRulesCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules           |             |
->
-> - <div id="type-splice-dsorules-dsorulesaddsv-44293">
->
->   **Choice** DsoRules_AddSv
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_AddSvResult
->
->   | Field              | Type                                                                                                                | Description |
->   |--------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | newSvParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | newSvName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | newSvRewardWeight  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->   | newSvParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | joinedAsOfRound    | Round                                                                                                               |             |
->
-> - <div id="type-splice-dsorules-dsorulesadvanceopenminingrounds-34192">
->
->   **Choice** DsoRules_AdvanceOpenMiningRounds
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_AdvanceOpenMiningRoundsResult
->
->   | Field               | Type                                                                                                                                                                                                                                               | Description |
->   |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | roundToArchiveCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                      |             |
->   | middleRoundCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                      |             |
->   | latestRoundCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                      |             |
->   | amuletPriceVoteCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\]                                                                                                  |             |
->   | sv                  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecord-56787">
->
->   **Choice** DsoRules_AllocateUnallocatedUnclaimedActivityRecord
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
->
->   | Field                                 | Type                                                                                                                                                             | Description                                                                                         |
->   |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
->   | unallocatedUnclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord |                                                                                                     |
->   | amuletRulesCid                        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                        |                                                                                                     |
->   | unclaimedRewardsToBurnCids            | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward\]                | A sufficient list of `UnclaimedReward` to be archived. It must cover at least the requested amount. |
->   | sv                                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |                                                                                                     |
->
-> - <div id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkers-52437">
->
->   **Choice** DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
->   | Field          | Type                                                                                                                                                                                                                                               | Description |
->   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | argument       | AmuletRules_ConvertFeaturedAppActivityMarkers                                                                                                                                                                                                      |             |
->   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesamuletexpire-71495">
->
->   **Choice** DsoRules_Amulet_Expire
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_Amulet_ExpireResult
->
->   | Field     | Type                                                                                                                                                                                                                                               | Description |
->   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                                                                                                               |             |
->   | choiceArg | Amulet_Expire                                                                                                                                                                                                                                      |             |
->   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesamuletexpiretransferinstructions-57305">
->
->   **Choice** DsoRules_Amulet_ExpireTransferInstructions
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_Amulet_ExpireTransferInstructionsResult
->
->   | Field          | Type                                                                                                                                      | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->   | transferInsts  | AmuletRules_Amulet_ExpireTransferInstructions                                                                                             |             |
->   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       |             |
->
-> - <div id="type-splice-dsorules-dsorulesamuletexpirev2-61973">
->
->   **Choice** DsoRules_Amulet_ExpireV2
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_Amulet_ExpireV2Result
->
->   | Field     | Type                                                                                                                                                                                                                                               | Description |
->   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                                                                                                               |             |
->   | choiceArg | Amulet_ExpireV2                                                                                                                                                                                                                                    |             |
->   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequest-55064">
->
->   **Choice** DsoRules_ArchiveOutdatedElectionRequest
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ArchiveOutdatedElectionRequestResult
->
->   | Field      | Type                                                                                                                                                                                                                                               | Description |
->   |------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest                                                                                                      |             |
->   | sv         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesarchivesvonboardingrequest-72075">
->
->   **Choice** DsoRules_ArchiveSvOnboardingRequest
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ArchiveSvOnboardingRequestResult
->
->   | Field                  | Type                                                                                                                                                                                                                                               | Description |
->   |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | svOnboardingRequestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest                                                                                                  |             |
->   | sv                     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstate-94209">
->
->   **Choice** DsoRules_BootstrapExternalPartyConfigState
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_BootstrapExternalPartyConfigStateResult
->
->   | Field                 | Type                                                                                                                                                                       | Description |
->   |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                  |             |
->   | instructionCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction |             |
->   | openMiningRoundTriple | OpenMiningRoundTriple                                                                                                                                                      |             |
->   | sv                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                        |             |
->
-> - <div id="type-splice-dsorules-dsorulescastvote-63161">
->
->   **Choice** DsoRules_CastVote
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"sv" vote)
->
->   Returns: DsoRules_CastVoteResult
->
->   | Field      | Type                                                                                                                                      | Description |
->   |------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest |             |
->   | vote       | Vote                                                                                                                                      |             |
->
-> - <div id="type-splice-dsorules-dsorulesclaimexpiredrewards-16372">
->
->   **Choice** DsoRules_ClaimExpiredRewards
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ClaimExpiredRewardsResult
->
->   | Field          | Type                                                                                                                                                                                                                                               | Description |
->   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | choiceArg      | AmuletRules_ClaimExpiredRewards                                                                                                                                                                                                                    |             |
->   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesclosevoterequest-87527">
->
->   **Choice** DsoRules_CloseVoteRequest
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_CloseVoteRequestResult
->
->   | Field          | Type                                                                                                                                                                                                                                                                       | Description |
->   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | requestCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest                                                                                                                                  |             |
->   | amuletRulesCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules) |             |
->   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                         |             |
->
-> - <div id="type-splice-dsorules-dsorulescollectentryrenewalpayment-93166">
->
->   **Choice** DsoRules_CollectEntryRenewalPayment
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_CollectEntryRenewalPaymentResult
->
->   | Field              | Type                                                                                                                                                                                                                                               | Description |
->   |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | ansEntryContextCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext                                                                                                      |             |
->   | choiceArg          | AnsEntryContext_CollectEntryRenewalPayment                                                                                                                                                                                                         |             |
->   | sv                 | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesconfirmaction-67097">
->
->   **Choice** DsoRules_ConfirmAction
->
->   </div>
->
->   Controller: confirmer
->
->   Returns: DsoRules_ConfirmActionResult
->
->   | Field     | Type                                                                                                                | Description |
->   |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | confirmer | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | action    | ActionRequiringConfirmation                                                                                         |             |
->
-> - <div id="type-splice-dsorules-dsorulesconfirmsvonboarding-94029">
->
->   **Choice** DsoRules_ConfirmSvOnboarding
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_ConfirmSvOnboardingResult
->
->   | Field             | Type                                                                                                                | Description |
->   |-------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | newSvParty        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | newSvName         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | newParticipantId  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | newSvRewardWeight | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
->   | reason            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->
-> - <div id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstruction-1552">
->
->   **Choice** DsoRules_CreateBootstrapExternalPartyConfigStateInstruction
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
->
->   (no fields)
->
-> - <div id="type-splice-dsorules-dsorulescreateexternalpartyamuletrules-62448">
->
->   **Choice** DsoRules_CreateExternalPartyAmuletRules
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_CreateExternalPartyAmuletRulesResult
->
->   (no fields)
->
-> - <div id="type-splice-dsorules-dsorulescreatetransfercommandcounter-44220">
->
->   **Choice** DsoRules_CreateTransferCommandCounter
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_CreateTransferCommandCounterResult
->
->   | Field  | Type                                                                                                                | Description |
->   |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecord-78616">
->
->   **Choice** DsoRules_CreateUnallocatedUnclaimedActivityRecord
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
->
->   | Field       | Type                                                                                                                | Description |
->   |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
->   | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
->
-> - <div id="type-splice-dsorules-dsoruleselectdsodelegate-82924">
->
->   **Choice** DsoRules_ElectDsoDelegate
->
->   </div>
->
->   Controller: actor
->
->   Returns: DsoRules_ElectDsoDelegateResult
->
->   | Field       | Type                                                                                                                                              | Description |
->   |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
->   | requestCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest\] |             |
->
-> - <div id="type-splice-dsorules-dsorulesexecuteconfirmedaction-18028">
->
->   **Choice** DsoRules_ExecuteConfirmedAction
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExecuteConfirmedActionResult
->
->   | Field            | Type                                                                                                                                                                                                                                                                       | Description |
->   |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | action           | ActionRequiringConfirmation                                                                                                                                                                                                                                                |             |
->   | amuletRulesCid   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules) |             |
->   | confirmationCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation\]                                                                                                                             |             |
->   | sv               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                         |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpireamuletallocations-76865">
->
->   **Choice** DsoRules_ExpireAmuletAllocations
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireAmuletAllocationsResult
->
->   | Field             | Type                                                                                                                                                   | Description |
->   |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | extAmuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules |             |
->   | expireAllocations | ExternalPartyAmuletRules_ExpireAmuletAllocations                                                                                                       |             |
->   | sv                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                    |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpireansentry-58167">
->
->   **Choice** DsoRules_ExpireAnsEntry
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireAnsEntryResult
->
->   | Field       | Type                                                                                                                                                                                                                                               | Description |
->   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | ansEntryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry                                                                                                             |             |
->   | choiceArg   | AnsEntry_Expire                                                                                                                                                                                                                                    |             |
->   | sv          | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpiredevelopmentfundcoupon-65446">
->
->   **Choice** DsoRules_ExpireDevelopmentFundCoupon
->
->   </div>
->
->   Expires a DevelopmentFundCoupon and produces an UnclaimedDevelopmentFundCoupon with the same amount.
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireDevelopmentFundCouponResult
->
->   | Field                    | Type                                                                                                                                                | Description |
->   |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | developmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon |             |
->   | sv                       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                 |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpirestaleconfirmation-23846">
->
->   **Choice** DsoRules_ExpireStaleConfirmation
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireStaleConfirmationResult
->
->   | Field                | Type                                                                                                                                                                                                                                               | Description |
->   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | staleConfirmationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation                                                                                                         |             |
->   | sv                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpiresubscription-15972">
->
->   **Choice** DsoRules_ExpireSubscription
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireSubscriptionResult
->
->   | Field                    | Type                                                                                                                                                                                                                                               | Description |
->   |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | ansEntryContextCid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext                                                                                                      |             |
->   | subscriptionIdleStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState                                                                                                |             |
->   | choiceArg                | SubscriptionIdleState_ExpireSubscription                                                                                                                                                                                                           |             |
->   | sv                       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmed-60809">
->
->   **Choice** DsoRules_ExpireSvOnboardingConfirmed
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireSvOnboardingConfirmedResult
->
->   | Field | Type                                                                                                                                                                                                                                               | Description |
->   |-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed                                                                                                |             |
->   | sv    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpiresvonboardingrequest-63611">
->
->   **Choice** DsoRules_ExpireSvOnboardingRequest
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireSvOnboardingRequestResult
->
->   | Field | Type                                                                                                                                                                                                                                               | Description |
->   |-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest                                                                                                  |             |
->   | sv    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpiretransferpreapproval-91729">
->
->   **Choice** DsoRules_ExpireTransferPreapproval
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireTransferPreapprovalResult
->
->   | Field                  | Type                                                                                                                                                                                                                                               | Description |
->   |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval                                                                                                  |             |
->   | sv                     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecord-90041">
->
->   **Choice** DsoRules_ExpireUnallocatedUnclaimedActivityRecord
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
->
->   | Field                                 | Type                                                                                                                                                             | Description |
->   |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | unallocatedUnclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord |             |
->   | sv                                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |             |
->
-> - <div id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecord-57856">
->
->   **Choice** DsoRules_ExpireUnclaimedActivityRecord
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ExpireUnclaimedActivityRecordResult
->
->   | Field                      | Type                                                                                                                                                  | Description |
->   |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | unclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord |             |
->   | sv                         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                   |             |
->
-> - <div id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotes-77719">
->
->   **Choice** DsoRules_GarbageCollectAmuletPriceVotes
->
->   </div>
->
->   Garbage-collect AmuletPriceVotes from removed svs and duplicate ones that might happen due to a too quick removal and re-addition of a sv. We expect this to be run as an OnAssignedContractTrigger for the DsoRules contract.
->
->   Note: we do not archive the AmuletPriceVote of an SV on its removal, as that would allow that SV to block the removal via updating its AmuletPriceVote at the right time.
->
->   TODO(#10063): drop this code in favor of just keeping AmuletPriceVotes around.
->
->   Controller: sv
->
->   Returns: DsoRules_GarbageCollectAmuletPriceVotesResult
->
->   | Field             | Type                                                                                                                                                                                                                                               | Description |
->   |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | nonSvVoteCids     | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\]                                                                                                  |             |
->   | duplicateVoteCids | \[\[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\]\]                                                                                              |             |
->   | sv                | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesgrantfeaturedappright-79910">
->
->   **Choice** DsoRules_GrantFeaturedAppRight
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_GrantFeaturedAppRightResult
->
->   | Field    | Type                                                                                                                | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsoruleslockedamuletexpireamulet-28275">
->
->   **Choice** DsoRules_LockedAmulet_ExpireAmulet
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_LockedAmulet_ExpireAmuletResult
->
->   | Field     | Type                                                                                                                                                                                                                                               | Description |
->   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet                                                                                                         |             |
->   | choiceArg | LockedAmulet_ExpireAmulet                                                                                                                                                                                                                          |             |
->   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2-91833">
->
->   **Choice** DsoRules_LockedAmulet_ExpireAmuletV2
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_LockedAmulet_ExpireAmuletV2Result
->
->   | Field     | Type                                                                                                                                                                                                                                               | Description |
->   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet                                                                                                         |             |
->   | choiceArg | LockedAmulet_ExpireAmuletV2                                                                                                                                                                                                                        |             |
->   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesmergemembertrafficcontracts-34275">
->
->   **Choice** DsoRules_MergeMemberTrafficContracts
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_MergeMemberTrafficContractsResult
->
->   | Field          | Type                                                                                                                                                                                                                                               | Description |
->   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | trafficCids    | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic\]                                                                                                    |             |
->   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesmergesvrewardstate-39851">
->
->   **Choice** DsoRules_MergeSvRewardState
->
->   </div>
->
->   Note this choice only exists to clean up duplicate contracts caused by the bug in \#12495. There should never be duplicates going forward.
->
->   Controller: sv
->
->   Returns: DsoRules_MergeSvRewardStateResult
->
->   | Field           | Type                                                                                                                                                                                                                                               | Description |
->   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | svName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
->   | rewardStateCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState\]                                                                                                    |             |
->   | sv              | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcoupons-23755">
->
->   **Choice** DsoRules_MergeUnclaimedDevelopmentFundCoupons
->
->   </div>
->
->   Batch merge of of development fund coupons.
->
->   Controller: sv
->
->   Returns: DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
->
->   | Field          | Type                                                                                                                                      | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->   | choiceArg      | AmuletRules_MergeUnclaimedDevelopmentFundCoupons                                                                                          |             |
->   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       |             |
->
-> - <div id="type-splice-dsorules-dsorulesmergeunclaimedrewards-12383">
->
->   **Choice** DsoRules_MergeUnclaimedRewards
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_MergeUnclaimedRewardsResult
->
->   | Field               | Type                                                                                                                                                                                                                                               | Description |
->   |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | unclaimedRewardCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward\]                                                                                                  |             |
->   | sv                  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesmergevalidatorlicense-65804">
->
->   **Choice** DsoRules_MergeValidatorLicense
->
->   </div>
->
->   Note: removes the old duplicated licenses and creates a new one with the highest lastReceivedFor round There should never be duplicates going forward.
->
->   Controller: sv
->
->   Returns: DsoRules_MergeValidatorLicenseResult
->
->   | Field                | Type                                                                                                                                                                                                                                               | Description |
->   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | validatorLicenseCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense\]                                                                                                 |             |
->   | sv                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesminingroundclose-28010">
->
->   **Choice** DsoRules_MiningRound_Close
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_MiningRound_CloseResult
->
->   | Field           | Type                                                                                                                                                                                                                                               | Description |
->   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | issuingRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound                                                                                                   |             |
->   | sv              | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesoffboardsv-78636">
->
->   **Choice** DsoRules_OffboardSv
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_OffboardSvResult
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | sv    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesonboardvalidator-23909">
->
->   **Choice** DsoRules_OnboardValidator
->
->   </div>
->
->   Controller: sponsor
->
->   Returns: DsoRules_OnboardValidatorResult
->
->   | Field        | Type                                                                                                                                                                                                                                        | Description |
->   |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sponsor      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
->   | validator    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
->   | version      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->   | contactPoint | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
->
-> - <div id="type-splice-dsorules-dsorulespruneamuletconfigschedule-70948">
->
->   **Choice** DsoRules_PruneAmuletConfigSchedule
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_PruneAmuletConfigScheduleResult
->
->   | Field          | Type                                                                                                                                                                                                                                               | Description |
->   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
->   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesreceivesvrewardcoupon-83972">
->
->   **Choice** DsoRules_ReceiveSvRewardCoupon
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_ReceiveSvRewardCouponResult
->
->   | Field          | Type                                                                                                                                                                                                                                  | Description |
->   |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                   |             |
->   | openRoundCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                         |             |
->   | rewardStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState                                                                                           |             |
->   | beneficiaries  | \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))\] |             |
->
-> - <div id="type-splice-dsorules-dsorulesrequestelection-327">
->
->   **Choice** DsoRules_RequestElection
->
->   </div>
->
->   Controller: requester
->
->   Returns: DsoRules_RequestElectionResult
->
->   | Field     | Type                                                                                                                    | Description |
->   |-----------|-------------------------------------------------------------------------------------------------------------------------|-------------|
->   | requester | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
->   | reason    | ElectionRequestReason                                                                                                   |             |
->   | ranking   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
->
-> - <div id="type-splice-dsorules-dsorulesrequestvote-27270">
->
->   **Choice** DsoRules_RequestVote
->
->   </div>
->
->   Controller: requester
->
->   Returns: DsoRules_RequestVoteResult
->
->   | Field              | Type                                                                                                                                                                                                                                                  | Description |
->   |--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | requester          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                   |             |
->   | action             | ActionRequiringConfirmation                                                                                                                                                                                                                           |             |
->   | reason             | Reason                                                                                                                                                                                                                                                |             |
->   | voteRequestTimeout | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
->   | targetEffectiveAt  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      |             |
->
-> - <div id="type-splice-dsorules-dsorulesrevokefeaturedappright-46223">
->
->   **Choice** DsoRules_RevokeFeaturedAppRight
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_RevokeFeaturedAppRightResult
->
->   | Field    | Type                                                                                                                                           | Description |
->   |----------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | rightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
->
-> - <div id="type-splice-dsorules-dsorulessetconfig-76713">
->
->   **Choice** DsoRules_SetConfig
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_SetConfigResult
->
->   | Field      | Type                                                                                                                                          | Description |
->   |------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | newConfig  | DsoRulesConfig                                                                                                                                |             |
->   | baseConfig | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) DsoRulesConfig |             |
->
-> - <div id="type-splice-dsorules-dsorulessetsynchronizernodeconfig-79561">
->
->   **Choice** DsoRules_SetSynchronizerNodeConfig
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_SetSynchronizerNodeConfigResult
->
->   | Field          | Type                                                                                                                                      | Description |
->   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       |             |
->   | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                              |             |
->   | newNodeConfig  | SynchronizerNodeConfig                                                                                                                    |             |
->   | nodeStateCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState |             |
->
-> - <div id="type-splice-dsorules-dsorulesstartsvonboarding-74859">
->
->   **Choice** DsoRules_StartSvOnboarding
->
->   </div>
->
->   Controller: sponsor
->
->   Returns: DsoRules_StartSvOnboardingResult
->
->   | Field                  | Type                                                                                                                | Description |
->   |------------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | candidateName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | candidateParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | candidateParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | token                  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | sponsor                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulessubmitstatusreport-89950">
->
->   **Choice** DsoRules_SubmitStatusReport
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_SubmitStatusReportResult
->
->   | Field             | Type                                                                                                                                         | Description |
->   |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sv                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                          |             |
->   | previousReportCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport |             |
->   | status            | SvStatus                                                                                                                                     |             |
->
-> - <div id="type-splice-dsorules-dsorulesterminatesubscription-67561">
->
->   **Choice** DsoRules_TerminateSubscription
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_TerminateSubscriptionResult
->
->   | Field                     | Type                                                                                                                                                                                                                                               | Description |
->   |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | ansEntryContextCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext                                                                                                      |             |
->   | terminatedSubscriptionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription                                                                                               |             |
->   | sv                        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-dsorules-dsorulesupdateamuletpricevote-33547">
->
->   **Choice** DsoRules_UpdateAmuletPriceVote
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_UpdateAmuletPriceVoteResult
->
->   | Field       | Type                                                                                                                                          | Description |
->   |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | sv          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                           |             |
->   | voteCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote |             |
->   | amuletPrice | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
->
-> - <div id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstates-33819">
->
->   **Choice** DsoRules_UpdateExternalPartyConfigStates
->
->   </div>
->
->   Controller: sv
->
->   Returns: DsoRules_UpdateExternalPartyConfigStatesResult
->
->   | Field                        | Type                                                                                                                                                   | Description |
->   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | amuletRulesCid               | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules              |             |
->   | externalPartyConfigStateCid0 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->   | externalPartyConfigStateCid1 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->   | openMiningRoundTriple        | OpenMiningRoundTriple                                                                                                                                  |             |
->   | sv                           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                    |             |
->
-> - <div id="type-splice-dsorules-dsorulesupdatesvrewardweight-33689">
->
->   **Choice** DsoRules_UpdateSvRewardWeight
->
->   </div>
->
->   Controller: dso
->
->   Returns: DsoRules_UpdateSvRewardWeightResult
->
->   | Field           | Type                                                                                                                | Description |
->   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | svParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | newRewardWeight | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
-
-<div id="type-splice-dsorules-electionrequest-92680">
-
-**template** ElectionRequest
-
-</div>
-
-> **Deprecated** in favor of delegateless automation.
->
-> A request to elect a new DSO delegate.
->
-> Signatory: dso
->
-> | Field     | Type                                                                                                                    | Description |
-> |-----------|-------------------------------------------------------------------------------------------------------------------------|-------------|
-> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
-> | requester | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
-> | epoch     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)              |             |
-> | reason    | ElectionRequestReason                                                                                                   |             |
-> | ranking   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-dsorules-unallocatedunclaimedactivityrecord-15769">
-
-**template** UnallocatedUnclaimedActivityRecord
-
-</div>
-
-> A governance-approved record representing intent to reward a beneficiary. Once sufficient `UnclaimedReward` contracts are allocated and archived, this contract results in the creation of a mintable `UnclaimedActivityRecord`.
->
-> Signatory: dso
->
-> | Field       | Type                                                                                                                | Description                                                                       |
-> |-------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                   |
-> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the `Amulet` to be minted                                            |
-> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The amount of `Amulet` to be minted                                               |
-> | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | A reason to mint the `Amulet`                                                     |
-> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Selected timestamp defining the lifetime of the UnclaimedActivityRecord contract. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-dsorules-voterequest-12683">
-
-**template** VoteRequest
-
-</div>
-
-> A request for the other svs to vote on the execution of an action requiring confirmation. We use this for implementing on-ledger governance actions triggered by SV operators in a uniform way.
->
-> See the comments on `ActionRequiringConfirmation` for details.
->
-> Version 3, which introduces effectivity in vote request.
->
-> Signatory: dso
->
-> | Field             | Type                                                                                                                                                                                                                                                                       | Description                                                                                                                                                                               |
-> |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> | dso               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                                        |                                                                                                                                                                                           |
-> | requester         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                                               | The SV that requested to execute the action.                                                                                                                                              |
-> | action            | ActionRequiringConfirmation                                                                                                                                                                                                                                                | The action whose confirmation is required.                                                                                                                                                |
-> | reason            | Reason                                                                                                                                                                                                                                                                     | The reason for requesting the execution of the action. Typically a reference to some off-ledger justification.                                                                            |
-> | voteBefore        | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                                          | The time before which votes are accepted, and SHOULD be submitted.                                                                                                                        |
-> | votes             | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) Vote                                          | The votes cast by current or previous SVs. These may be previous SVs in case there was an SV change after the vote was requested.                                                         |
-> | trackingCid       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest) | An optional tracking ContractId to be used for tracking the vote request through its updates. This is always set to the first ContractId of the original vote request (None on creation). |
-> | targetEffectiveAt | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                           | The time when the action is targeted to be made effective. If None, the action is immediately effective upon 2/3 votes in favor.                                                          |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
-
-## Orphan Typeclass Instances
-
-**instance** HasCheckedFetch FeaturedAppRight ForDso
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-dsorules-actionrequiringconfirmation-45397">
-
-**data** ActionRequiringConfirmation
-
-</div>
-
-> Actions that require confirmation from SV nodes before they can be executed.
->
-> There are two processes for executing such actions:
->
-> 1.  Any SV can request a vote to execute such an action upon which the other SV's can respond with their votes for whether they accept the execution or not. This process requires votes from 2/3 of all SVs\* for the action to be considered definitive and it can be used for all actions that require confirmation.
-> 2.  Some of the actions that require confirmations should be executed automatically once the ledger and the wall-clocks of the SV nodes are in a particular state. These actions are confirmed by each SV node automatically once the action's precondition is met. Once 2/3 of all SV's confirmations\* are visible to the DSO delegate it executes them.
->
-> - Simplified for clarity; see `requiredNumVotes` for exact formula.
->
-> Process 2 is an optimization of Process 1 for the case where no disagreement to the action is expected.
->
-> We expect honest SV nodes to only create confirmations for actions whose preconditions are met. We also rely on the execution of these actions to be idempotent, as more than the required number of confirmations can be created.
->
-> Note also that having these two processes also aids in distinguishing between manually initiated ad-hoc votes and the regular confirmations that need to happen during standard DSO.
->
-> <div id="constr-splice-dsorules-arcdsorules-25826">
->
-> ARC_DsoRules
->
-> </div>
->
-> > | Field     | Type                                 | Description |
-> > |-----------|--------------------------------------|-------------|
-> > | dsoAction | DsoRules_ActionRequiringConfirmation |             |
->
-> <div id="constr-splice-dsorules-arcamuletrules-45909">
->
-> ARC_AmuletRules
->
-> </div>
->
-> > | Field             | Type                                    | Description |
-> > |-------------------|-----------------------------------------|-------------|
-> > | amuletRulesAction | AmuletRules_ActionRequiringConfirmation |             |
->
-> <div id="constr-splice-dsorules-arcansentrycontext-51355">
->
-> ARC_AnsEntryContext
->
-> </div>
->
-> > | Field                 | Type                                                                                                                                          | Description |
-> > |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | ansEntryContextCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext |             |
-> > | ansEntryContextAction | AnsEntryContext_ActionRequiringConfirmation                                                                                                   |             |
->
-> <div id="constr-splice-dsorules-extactionrequiringconformation-24220">
->
-> ExtActionRequiringConformation
->
-> </div>
->
-> > | Field          | Type | Description                                                                                                                                                                            |
-> > |----------------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 This on takes care of providing extensibility for the specific variants below. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ActionRequiringConfirmation
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ActionRequiringConfirmation
->
-> **instance** GetField "action" Confirmation ActionRequiringConfirmation
->
-> **instance** GetField "action" DsoRules_ConfirmAction ActionRequiringConfirmation
->
-> **instance** GetField "action" DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation
->
-> **instance** GetField "action" DsoRules_RequestVote ActionRequiringConfirmation
->
-> **instance** GetField "action" VoteRequest ActionRequiringConfirmation
->
-> **instance** GetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
->
-> **instance** GetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
->
-> **instance** GetField "ansEntryContextCid" ActionRequiringConfirmation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
->
-> **instance** GetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
->
-> **instance** GetField "dummyUnitField" ActionRequiringConfirmation ()
->
-> **instance** SetField "action" Confirmation ActionRequiringConfirmation
->
-> **instance** SetField "action" DsoRules_ConfirmAction ActionRequiringConfirmation
->
-> **instance** SetField "action" DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation
->
-> **instance** SetField "action" DsoRules_RequestVote ActionRequiringConfirmation
->
-> **instance** SetField "action" VoteRequest ActionRequiringConfirmation
->
-> **instance** SetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
->
-> **instance** SetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
->
-> **instance** SetField "ansEntryContextCid" ActionRequiringConfirmation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
->
-> **instance** SetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
->
-> **instance** SetField "dummyUnitField" ActionRequiringConfirmation ()
-
-<div id="type-splice-dsorules-amuletrulesactionrequiringconfirmation-62783">
-
-**data** AmuletRules_ActionRequiringConfirmation
-
-</div>
-
-> <div id="constr-splice-dsorules-crarcminingroundstartissuing-47375">
->
-> CRARC_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuing
->
-> </div>
->
-> > Automated action to start an issuing round once the summary of the reward coupons have been computed.
->
-> <div id="constr-splice-dsorules-crarcminingroundarchive-10786">
->
-> CRARC_MiningRound_Archive AmuletRules_MiningRound_Archive
->
-> </div>
->
-> > Automated action to archive a closed mining round once no expired reward coupons are left.
->
-> <div id="constr-splice-dsorules-crarcaddfutureamuletconfigschedule-50004">
->
-> CRARC_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigSchedule
->
-> </div>
->
-> > **Deprecated, use CRARC_SetConfig instead**: Voted action to add a config schedule to the `AmuletRules`.
->
-> <div id="constr-splice-dsorules-crarcremovefutureamuletconfigschedule-28322">
->
-> CRARC_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigSchedule
->
-> </div>
->
-> > **Deprecated, use CRARC_SetConfig instead**: Voted action to remove a config schedule from the `AmuletRules`.
->
-> <div id="constr-splice-dsorules-crarcupdatefutureamuletconfigschedule-3041">
->
-> CRARC_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigSchedule
->
-> </div>
->
-> > **Deprecated, use CRARC_SetConfig instead**: Voted action to update a config schedule in the `AmuletRules`.
->
-> <div id="constr-splice-dsorules-crarcsetconfig-80537">
->
-> CRARC_SetConfig AmuletRules_SetConfig
->
-> </div>
->
-> > Voted action to change the `AmuletConfig`. Not idempotent.
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_ActionRequiringConfirmation
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_ActionRequiringConfirmation
->
-> **instance** GetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
->
-> **instance** SetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
-
-<div id="type-splice-dsorules-ansentrycontextactionrequiringconfirmation-11149">
-
-**data** AnsEntryContext_ActionRequiringConfirmation
-
-</div>
-
-> <div id="constr-splice-dsorules-ansrarccollectinitialentrypayment-99049">
->
-> ANSRARC_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPayment
->
-> </div>
->
-> > Automated action to collect initial payment of an ans entry.
->
-> <div id="constr-splice-dsorules-ansrarcrejectentryinitialpayment-1047">
->
-> ANSRARC_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPayment
->
-> </div>
->
-> > Automated action to reject initial payment of an ans entry.
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AnsEntryContext_ActionRequiringConfirmation
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AnsEntryContext_ActionRequiringConfirmation
->
-> **instance** GetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
->
-> **instance** SetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
-
-<div id="type-splice-dsorules-confirmationexpireresult-10666">
-
-**data** Confirmation_ExpireResult
-
-</div>
-
-> Choice return types
->
-> <div id="constr-splice-dsorules-confirmationexpireresult-43205">
->
-> Confirmation_ExpireResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Confirmation Confirmation_Expire Confirmation_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Confirmation Confirmation_Expire Confirmation_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Confirmation Confirmation_Expire Confirmation_ExpireResult
-
-<div id="type-splice-dsorules-dsorulesconfig-6376">
-
-**data** DsoRulesConfig
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesconfig-32625">
->
-> DsoRulesConfig
->
-> </div>
->
-> > | Field                                   | Type                                                                                                                                                                                                                                                  | Description                                                                                                                                     |
-> > |-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | numUnclaimedRewardsThreshold            | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                            | The minimum number of unclaimed rewards required for merging                                                                                    |
-> > | numMemberTrafficContractsThreshold      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                            | The minimum number of member traffic contracts required for merging                                                                             |
-> > | actionConfirmationTimeout               | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for contracts representing a confirmation                                                                                               |
-> > | svOnboardingRequestTimeout              | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for contracts representing an incomplete onboarding                                                                                     |
-> > | svOnboardingConfirmedTimeout            | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for contracts representing an SV confirmation                                                                                           |
-> > | voteRequestTimeout                      | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for a `VoteRequest` and its associated `Vote` s                                                                                         |
-> > | dsoDelegateInactiveTimeout              | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The amount of time given to the DSO delegate to complete an action it should take care of ^ **Deprecated** in favor of delegateless automation. |
-> > | synchronizerNodeConfigLimits            | SynchronizerNodeConfigLimits                                                                                                                                                                                                                          | Limits to enforce on the svs' `SynchronizerNodeConfig`                                                                                          |
-> > | maxTextLength                           | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                            | Generic upper limit on text fields in choices and contracts.                                                                                    |
-> > | decentralizedSynchronizer               | DsoDecentralizedSynchronizerConfig                                                                                                                                                                                                                    |                                                                                                                                                 |
-> > | nextScheduledSynchronizerUpgrade        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule                                                                                            |                                                                                                                                                 |
-> > | voteCooldownTime                        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | The minimum time between two votes by the same SV.                                                                                              |
-> > | nextScheduledLogicalSynchronizerUpgrade | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule                                                                                     |                                                                                                                                                 |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRulesConfig
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRulesConfig
->
-> **instance** GetField "actionConfirmationTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "baseConfig" DsoRules_SetConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) DsoRulesConfig)
->
-> **instance** GetField "config" DsoBootstrap DsoRulesConfig
->
-> **instance** GetField "config" DsoRules DsoRulesConfig
->
-> **instance** GetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
->
-> **instance** GetField "dsoDelegateInactiveTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "maxTextLength" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "newConfig" DsoRules_SetConfig DsoRulesConfig
->
-> **instance** GetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
->
-> **instance** GetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
->
-> **instance** GetField "numMemberTrafficContractsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "numUnclaimedRewardsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "svOnboardingConfirmedTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "svOnboardingRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
->
-> **instance** GetField "voteCooldownTime" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
->
-> **instance** GetField "voteRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "actionConfirmationTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "baseConfig" DsoRules_SetConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) DsoRulesConfig)
->
-> **instance** SetField "config" DsoBootstrap DsoRulesConfig
->
-> **instance** SetField "config" DsoRules DsoRulesConfig
->
-> **instance** SetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
->
-> **instance** SetField "dsoDelegateInactiveTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "maxTextLength" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "newConfig" DsoRules_SetConfig DsoRulesConfig
->
-> **instance** SetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
->
-> **instance** SetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
->
-> **instance** SetField "numMemberTrafficContractsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "numUnclaimedRewardsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "svOnboardingConfirmedTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "svOnboardingRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
->
-> **instance** SetField "voteCooldownTime" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
->
-> **instance** SetField "voteRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** Patchable DsoRulesConfig
-
-<div id="type-splice-dsorules-dsorulesactionrequiringconfirmation-12600">
-
-**data** DsoRules_ActionRequiringConfirmation
-
-</div>
-
-> <div id="constr-splice-dsorules-srarcaddsv-12841">
->
-> SRARC_AddSv DsoRules_AddSv
->
-> </div>
->
-> > Voted action to directly add an SV
->
-> <div id="constr-splice-dsorules-srarcoffboardsv-63692">
->
-> SRARC_OffboardSv DsoRules_OffboardSv
->
-> </div>
->
-> > Voted action to remove an SV
->
-> <div id="constr-splice-dsorules-srarcconfirmsvonboarding-51509">
->
-> SRARC_ConfirmSvOnboarding DsoRules_ConfirmSvOnboarding
->
-> </div>
->
-> > Automated action to confirm that a party can become an SV.
->
-> <div id="constr-splice-dsorules-srarcgrantfeaturedappright-84890">
->
-> SRARC_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRight
->
-> </div>
->
-> > Voted action to grant a featured app right. Not idempotent.
->
-> <div id="constr-splice-dsorules-srarcrevokefeaturedappright-73851">
->
-> SRARC_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRight
->
-> </div>
->
-> > Revoke a specific featured app right.
->
-> <div id="constr-splice-dsorules-srarcsetconfig-39305">
->
-> SRARC_SetConfig DsoRules_SetConfig
->
-> </div>
->
-> > Voted action to change the `DsoRulesConfig`. Not idempotent.
->
-> <div id="constr-splice-dsorules-srarcupdatesvrewardweight-81705">
->
-> SRARC_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeight
->
-> </div>
->
-> > Voted action to update the reward weight of an SV.
->
-> <div id="constr-splice-dsorules-srarccreateexternalpartyamuletrules-49124">
->
-> SRARC_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRules
->
-> </div>
->
-> > Create ExternalPartyAmuletRules contract if it has not been created as part of network bootstrapping.
->
-> <div id="constr-splice-dsorules-srarccreatetransfercommandcounter-88632">
->
-> SRARC_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounter
->
-> </div>
->
-> > Create TransferCommandCounter contract for the given sender if it does not already exist
->
-> <div id="constr-splice-dsorules-srarccreateunallocatedunclaimedactivityrecord-97784">
->
-> SRARC_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecord
->
-> </div>
->
-> > Voted action to create an UnallocatedUnclaimedActivityRecord contract.
->
-> <div id="constr-splice-dsorules-srarccreatebootstrapexternalpartyconfigstateinstruction-49456">
->
-> SRARC_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstruction
->
-> </div>
->
-> > Create BootstrapExternalPartyConfigStateInstruction
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_ActionRequiringConfirmation
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_ActionRequiringConfirmation
->
-> **instance** GetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
->
-> **instance** SetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
-
-<div id="type-splice-dsorules-dsorulesaddconfirmedsvresult-53040">
-
-**data** DsoRules_AddConfirmedSvResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesaddconfirmedsvresult-81391">
->
-> DsoRules_AddConfirmedSvResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_AddConfirmedSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_AddConfirmedSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult
-
-<div id="type-splice-dsorules-dsorulesaddsvresult-53972">
-
-**data** DsoRules_AddSvResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesaddsvresult-63557">
->
-> DsoRules_AddSvResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_AddSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_AddSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AddSv DsoRules_AddSvResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AddSv DsoRules_AddSvResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AddSv DsoRules_AddSvResult
-
-<div id="type-splice-dsorules-dsorulesadvanceopenminingroundsresult-57405">
-
-**data** DsoRules_AdvanceOpenMiningRoundsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesadvanceopenminingroundsresult-30524">
->
-> DsoRules_AdvanceOpenMiningRoundsResult
->
-> </div>
->
-> > | Field            | Type                                                                                                                                                 | Description |
-> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | summarizingRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound |             |
-> > | openRound        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound        |             |
->
-> **instance** GetField "openRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** GetField "summarizingRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
->
-> **instance** SetField "openRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
->
-> **instance** SetField "summarizingRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult
-
-<div id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-87254">
-
-**data** DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-24573">
->
-> DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
->
-> </div>
->
-> > | Field                      | Type                                                                                                                                                                                                                                                                           | Description |
-> > |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord                                                                                                                          |             |
-> > | optUnclaimedRewardCid      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward) |             |
->
-> **instance** GetField "optUnclaimedRewardCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
->
-> **instance** GetField "unclaimedActivityRecordCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord)
->
-> **instance** SetField "optUnclaimedRewardCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
->
-> **instance** SetField "unclaimedActivityRecordCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
-
-<div id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-72068">
-
-**data** DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-81577">
->
-> DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> </div>
->
-> > | Field  | Type                                                | Description |
-> > |--------|-----------------------------------------------------|-------------|
-> > | result | AmuletRules_ConvertFeaturedAppActivityMarkersResult |             |
->
-> **instance** GetField "result" DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> **instance** SetField "result" DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
-
-<div id="type-splice-dsorules-dsorulesamuletexpireresult-67290">
-
-**data** DsoRules_Amulet_ExpireResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesamuletexpireresult-61799">
->
-> DsoRules_Amulet_ExpireResult
->
-> </div>
->
-> > | Field     | Type                | Description |
-> > |-----------|---------------------|-------------|
-> > | expireSum | AmuletExpireSummary |             |
->
-> **instance** GetField "expireSum" DsoRules_Amulet_ExpireResult AmuletExpireSummary
->
-> **instance** SetField "expireSum" DsoRules_Amulet_ExpireResult AmuletExpireSummary
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult
-
-<div id="type-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-29864">
-
-**data** DsoRules_Amulet_ExpireTransferInstructionsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-36781">
->
-> DsoRules_Amulet_ExpireTransferInstructionsResult
->
-> </div>
->
-> > | Field  | Type                                                | Description |
-> > |--------|-----------------------------------------------------|-------------|
-> > | result | AmuletRules_Amulet_ExpireTransferInstructionsResult |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** GetField "result" DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** SetField "result" DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult
-
-<div id="type-splice-dsorules-dsorulesamuletexpirev2result-94072">
-
-**data** DsoRules_Amulet_ExpireV2Result
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesamuletexpirev2result-84829">
->
-> DsoRules_Amulet_ExpireV2Result
->
-> </div>
->
-> > | Field     | Type                  | Description |
-> > |-----------|-----------------------|-------------|
-> > | expireSum | AmuletExpireV2Summary |             |
->
-> **instance** GetField "expireSum" DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary
->
-> **instance** SetField "expireSum" DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result
-
-<div id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-78881">
-
-**data** DsoRules_ArchiveOutdatedElectionRequestResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-72534">
->
-> DsoRules_ArchiveOutdatedElectionRequestResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult
-
-<div id="type-splice-dsorules-dsorulesarchivesvonboardingrequestresult-76462">
-
-**data** DsoRules_ArchiveSvOnboardingRequestResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesarchivesvonboardingrequestresult-86253">
->
-> DsoRules_ArchiveSvOnboardingRequestResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult
-
-<div id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-77872">
-
-**data** DsoRules_BootstrapExternalPartyConfigStateResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-70741">
->
-> DsoRules_BootstrapExternalPartyConfigStateResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult
-
-<div id="type-splice-dsorules-dsorulescastvoteresult-84724">
-
-**data** DsoRules_CastVoteResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulescastvoteresult-18147">
->
-> DsoRules_CastVoteResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                      | Description |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | voteRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest |             |
->
-> **instance** GetField "voteRequest" DsoRules_CastVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
->
-> **instance** SetField "voteRequest" DsoRules_CastVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CastVote DsoRules_CastVoteResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CastVote DsoRules_CastVoteResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CastVote DsoRules_CastVoteResult
-
-<div id="type-splice-dsorules-dsorulesclaimexpiredrewardsresult-70369">
-
-**data** DsoRules_ClaimExpiredRewardsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesclaimexpiredrewardsresult-56160">
->
-> DsoRules_ClaimExpiredRewardsResult
->
-> </div>
->
-> > | Field           | Type                                                                                                                                                                                                                                                                           | Description |
-> > |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedReward | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward) |             |
->
-> **instance** GetField "unclaimedReward" DsoRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
->
-> **instance** SetField "unclaimedReward" DsoRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult
-
-<div id="type-splice-dsorules-dsorulesclosevoterequestresult-49382">
-
-**data** DsoRules_CloseVoteRequestResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesclosevoterequestresult-14349">
->
-> DsoRules_CloseVoteRequestResult
->
-> </div>
->
-> > | Field            | Type                                                                                                              | Description                                                   |
-> > |------------------|-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-> > | request          | VoteRequest                                                                                                       | The original vote request.                                    |
-> > | completedAt      | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | When the vote request was completed.                          |
-> > | offboardedVoters | \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]  | SVs that voted but were offboarded before the vote completed. |
-> > | abstainingSvs    | \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]  | SVs that did not vote.                                        |
-> > | outcome          | VoteRequestOutcome                                                                                                | The final result of the vote.                                 |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CloseVoteRequestResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CloseVoteRequestResult
->
-> **instance** GetField "abstainingSvs" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
->
-> **instance** GetField "completedAt" DsoRules_CloseVoteRequestResult [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "offboardedVoters" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
->
-> **instance** GetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
->
-> **instance** GetField "request" DsoRules_CloseVoteRequestResult VoteRequest
->
-> **instance** SetField "abstainingSvs" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
->
-> **instance** SetField "completedAt" DsoRules_CloseVoteRequestResult [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "offboardedVoters" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
->
-> **instance** SetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
->
-> **instance** SetField "request" DsoRules_CloseVoteRequestResult VoteRequest
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult
-
-<div id="type-splice-dsorules-dsorulescollectentryrenewalpaymentresult-57091">
-
-**data** DsoRules_CollectEntryRenewalPaymentResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulescollectentryrenewalpaymentresult-87832">
->
-> DsoRules_CollectEntryRenewalPaymentResult
->
-> </div>
->
-> > | Field             | Type                                                                                                                                                | Description |
-> > |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | ansEntry          | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
-> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
->
-> **instance** GetField "ansEntry" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** GetField "subscriptionState" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "ansEntry" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
->
-> **instance** SetField "subscriptionState" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult
-
-<div id="type-splice-dsorules-dsorulesconfirmactionresult-28024">
-
-**data** DsoRules_ConfirmActionResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesconfirmactionresult-48341">
->
-> DsoRules_ConfirmActionResult
->
-> </div>
->
-> > | Field        | Type                                                                                                                                       | Description |
-> > |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | confirmation | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation |             |
->
-> **instance** GetField "confirmation" DsoRules_ConfirmActionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation)
->
-> **instance** SetField "confirmation" DsoRules_ConfirmActionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult
-
-<div id="type-splice-dsorules-dsorulesconfirmsvonboardingresult-99416">
-
-**data** DsoRules_ConfirmSvOnboardingResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesconfirmsvonboardingresult-46665">
->
-> DsoRules_ConfirmSvOnboardingResult
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                | Description |
-> > |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | onboardingConfirmed | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed |             |
->
-> **instance** GetField "onboardingConfirmed" DsoRules_ConfirmSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed)
->
-> **instance** SetField "onboardingConfirmed" DsoRules_ConfirmSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult
-
-<div id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-32985">
-
-**data** DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-84146">
->
-> DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                                                       | Description |
-> > |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | instructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
->
-> **instance** GetField "instructionCid" DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction)
->
-> **instance** SetField "instructionCid" DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
-
-<div id="type-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-12409">
-
-**data** DsoRules_CreateExternalPartyAmuletRulesResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-52650">
->
-> DsoRules_CreateExternalPartyAmuletRulesResult
->
-> </div>
->
-> > | Field                       | Type                                                                                                                                                   | Description |
-> > |-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | externalPartyAmuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CreateExternalPartyAmuletRulesResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CreateExternalPartyAmuletRulesResult
->
-> **instance** GetField "externalPartyAmuletRulesCid" DsoRules_CreateExternalPartyAmuletRulesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules)
->
-> **instance** SetField "externalPartyAmuletRulesCid" DsoRules_CreateExternalPartyAmuletRulesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult
-
-<div id="type-splice-dsorules-dsorulescreatetransfercommandcounterresult-97297">
-
-**data** DsoRules_CreateTransferCommandCounterResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulescreatetransfercommandcounterresult-46310">
->
-> DsoRules_CreateTransferCommandCounterResult
->
-> </div>
->
-> > | Field                     | Type                                                                                                                                                 | Description |
-> > |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | transferCommandCounterCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CreateTransferCommandCounterResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CreateTransferCommandCounterResult
->
-> **instance** GetField "transferCommandCounterCid" DsoRules_CreateTransferCommandCounterResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter)
->
-> **instance** SetField "transferCommandCounterCid" DsoRules_CreateTransferCommandCounterResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult
-
-<div id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-76541">
-
-**data** DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-18490">
->
-> DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
->
-> </div>
->
-> > | Field                                 | Type                                                                                                                                                             | Description |
-> > |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unallocatedUnclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord |             |
->
-> **instance** GetField "unallocatedUnclaimedActivityRecordCid" DsoRules_CreateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord)
->
-> **instance** SetField "unallocatedUnclaimedActivityRecordCid" DsoRules_CreateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
-
-<div id="type-splice-dsorules-dsoruleselectdsodelegateresult-99561">
-
-**data** DsoRules_ElectDsoDelegateResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsoruleselectdsodelegateresult-71514">
->
-> DsoRules_ElectDsoDelegateResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_ElectDsoDelegateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_ElectDsoDelegateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult
-
-<div id="type-splice-dsorules-dsorulesexecuteconfirmedactionresult-43893">
-
-**data** DsoRules_ExecuteConfirmedActionResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexecuteconfirmedactionresult-89578">
->
-> DsoRules_ExecuteConfirmedActionResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult
-
-<div id="type-splice-dsorules-dsorulesexpireamuletallocationsresult-27100">
-
-**data** DsoRules_ExpireAmuletAllocationsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpireamuletallocationsresult-29457">
->
-> DsoRules_ExpireAmuletAllocationsResult
->
-> </div>
->
-> > | Field  | Type                                                   | Description |
-> > |--------|--------------------------------------------------------|-------------|
-> > | result | ExternalPartyAmuletRules_ExpireAmuletAllocationsResult |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_ExpireAmuletAllocationsResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_ExpireAmuletAllocationsResult
->
-> **instance** GetField "result" DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> **instance** SetField "result" DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult
-
-<div id="type-splice-dsorules-dsorulesexpireansentryresult-16762">
-
-**data** DsoRules_ExpireAnsEntryResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpireansentryresult-6565">
->
-> DsoRules_ExpireAnsEntryResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult
-
-<div id="type-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-36543">
-
-**data** DsoRules_ExpireDevelopmentFundCouponResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-44574">
->
-> DsoRules_ExpireDevelopmentFundCouponResult
->
-> </div>
->
-> > | Field  | Type                                  | Description |
-> > |--------|---------------------------------------|-------------|
-> > | result | DevelopmentFundCoupon_DsoExpireResult |             |
->
-> **instance** GetField "result" DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult
->
-> **instance** SetField "result" DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult
-
-<div id="type-splice-dsorules-dsorulesexpirestaleconfirmationresult-27719">
-
-**data** DsoRules_ExpireStaleConfirmationResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpirestaleconfirmationresult-33614">
->
-> DsoRules_ExpireStaleConfirmationResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult
-
-<div id="type-splice-dsorules-dsorulesexpiresubscriptionresult-45469">
-
-**data** DsoRules_ExpireSubscriptionResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpiresubscriptionresult-70870">
->
-> DsoRules_ExpireSubscriptionResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult
-
-<div id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-38796">
-
-**data** DsoRules_ExpireSvOnboardingConfirmedResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-53333">
->
-> DsoRules_ExpireSvOnboardingConfirmedResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_ExpireSvOnboardingConfirmedResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_ExpireSvOnboardingConfirmedResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult
-
-<div id="type-splice-dsorules-dsorulesexpiresvonboardingrequestresult-2670">
-
-**data** DsoRules_ExpireSvOnboardingRequestResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpiresvonboardingrequestresult-9407">
->
-> DsoRules_ExpireSvOnboardingRequestResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult
-
-<div id="type-splice-dsorules-dsorulesexpiretransferpreapprovalresult-76064">
-
-**data** DsoRules_ExpireTransferPreapprovalResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpiretransferpreapprovalresult-84197">
->
-> DsoRules_ExpireTransferPreapprovalResult
->
-> </div>
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_ExpireTransferPreapprovalResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_ExpireTransferPreapprovalResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult
-
-<div id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-30228">
-
-**data** DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-25947">
->
-> DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
-
-<div id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-92345">
-
-**data** DsoRules_ExpireUnclaimedActivityRecordResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-78492">
->
-> DsoRules_ExpireUnclaimedActivityRecordResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedRewardCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
->
-> **instance** GetField "unclaimedRewardCid" DsoRules_ExpireUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** SetField "unclaimedRewardCid" DsoRules_ExpireUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult
-
-<div id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-20154">
-
-**data** DsoRules_GarbageCollectAmuletPriceVotesResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-33073">
->
-> DsoRules_GarbageCollectAmuletPriceVotesResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult
-
-<div id="type-splice-dsorules-dsorulesgrantfeaturedapprightresult-6067">
-
-**data** DsoRules_GrantFeaturedAppRightResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesgrantfeaturedapprightresult-3282">
->
-> DsoRules_GrantFeaturedAppRightResult
->
-> </div>
->
-> > | Field            | Type                                                                                                                                           | Description |
-> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | featuredAppRight | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
->
-> **instance** GetField "featuredAppRight" DsoRules_GrantFeaturedAppRightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** SetField "featuredAppRight" DsoRules_GrantFeaturedAppRightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult
-
-<div id="type-splice-dsorules-dsoruleslockedamuletexpireamuletresult-11398">
-
-**data** DsoRules_LockedAmulet_ExpireAmuletResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletresult-46735">
->
-> DsoRules_LockedAmulet_ExpireAmuletResult
->
-> </div>
->
-> > | Field     | Type                | Description |
-> > |-----------|---------------------|-------------|
-> > | expireSum | AmuletExpireSummary |             |
->
-> **instance** GetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary
->
-> **instance** SetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult
-
-<div id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-75516">
-
-**data** DsoRules_LockedAmulet_ExpireAmuletV2Result
-
-</div>
-
-> <div id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-22605">
->
-> DsoRules_LockedAmulet_ExpireAmuletV2Result
->
-> </div>
->
-> > | Field     | Type                  | Description |
-> > |-----------|-----------------------|-------------|
-> > | expireSum | AmuletExpireV2Summary |             |
->
-> **instance** GetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
->
-> **instance** SetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result
-
-<div id="type-splice-dsorules-dsorulesmergemembertrafficcontractsresult-1402">
-
-**data** DsoRules_MergeMemberTrafficContractsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesmergemembertrafficcontractsresult-22987">
->
-> DsoRules_MergeMemberTrafficContractsResult
->
-> </div>
->
-> > | Field         | Type                                                                                                                                        | Description |
-> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | memberTraffic | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic |             |
->
-> **instance** GetField "memberTraffic" DsoRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
->
-> **instance** SetField "memberTraffic" DsoRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult
-
-<div id="type-splice-dsorules-dsorulesmergesvrewardstateresult-26494">
-
-**data** DsoRules_MergeSvRewardStateResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesmergesvrewardstateresult-58441">
->
-> DsoRules_MergeSvRewardStateResult
->
-> </div>
->
-> > | Field         | Type                                                                                                                                        | Description |
-> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | svRewardState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState |             |
->
-> **instance** GetField "svRewardState" DsoRules_MergeSvRewardStateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
->
-> **instance** SetField "svRewardState" DsoRules_MergeSvRewardStateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult
-
-<div id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-91402">
-
-**data** DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-95789">
->
-> DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> </div>
->
-> > | Field  | Type                                                   | Description |
-> > |--------|--------------------------------------------------------|-------------|
-> > | result | AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult |             |
->
-> **instance** GetField "result" DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> **instance** SetField "result" DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
-
-<div id="type-splice-dsorules-dsorulesmergeunclaimedrewardsresult-75266">
-
-**data** DsoRules_MergeUnclaimedRewardsResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesmergeunclaimedrewardsresult-90979">
->
-> DsoRules_MergeUnclaimedRewardsResult
->
-> </div>
->
-> > | Field           | Type                                                                                                                                          | Description |
-> > |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | unclaimedReward | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
->
-> **instance** GetField "unclaimedReward" DsoRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** SetField "unclaimedReward" DsoRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult
-
-<div id="type-splice-dsorules-dsorulesmergevalidatorlicenseresult-11621">
-
-**data** DsoRules_MergeValidatorLicenseResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesmergevalidatorlicenseresult-87256">
->
-> DsoRules_MergeValidatorLicenseResult
->
-> </div>
->
-> > | Field            | Type                                                                                                                                           | Description |
-> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | validatorLicense | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
->
-> **instance** GetField "validatorLicense" DsoRules_MergeValidatorLicenseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** SetField "validatorLicense" DsoRules_MergeValidatorLicenseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult
-
-<div id="type-splice-dsorules-dsorulesminingroundcloseresult-29143">
-
-**data** DsoRules_MiningRound_CloseResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesminingroundcloseresult-49506">
->
-> DsoRules_MiningRound_CloseResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                            | Description |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | closedRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
->
-> **instance** GetField "closedRound" DsoRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
->
-> **instance** SetField "closedRound" DsoRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult
-
-<div id="type-splice-dsorules-dsorulesoffboardsvresult-15733">
-
-**data** DsoRules_OffboardSvResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesoffboardsvresult-15494">
->
-> DsoRules_OffboardSvResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_OffboardSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_OffboardSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult
-
-<div id="type-splice-dsorules-dsorulesonboardvalidatorresult-97208">
-
-**data** DsoRules_OnboardValidatorResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesonboardvalidatorresult-75375">
->
-> DsoRules_OnboardValidatorResult
->
-> </div>
->
-> > | Field            | Type                                                                                                                                           | Description |
-> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | validatorLicense | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
->
-> **instance** GetField "validatorLicense" DsoRules_OnboardValidatorResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** SetField "validatorLicense" DsoRules_OnboardValidatorResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult
-
-<div id="type-splice-dsorules-dsorulespruneamuletconfigscheduleresult-66013">
-
-**data** DsoRules_PruneAmuletConfigScheduleResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulespruneamuletconfigscheduleresult-2640">
->
-> DsoRules_PruneAmuletConfigScheduleResult
->
-> </div>
->
-> > | Field          | Type                                                                                                                                      | Description |
-> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
->
-> **instance** GetField "amuletRulesCid" DsoRules_PruneAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** SetField "amuletRulesCid" DsoRules_PruneAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult
-
-<div id="type-splice-dsorules-dsorulesreceivesvrewardcouponresult-91325">
-
-**data** DsoRules_ReceiveSvRewardCouponResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesreceivesvrewardcouponresult-74804">
->
-> DsoRules_ReceiveSvRewardCouponResult
->
-> </div>
->
-> > | Field           | Type                                                                                                                                             | Description |
-> > |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | svRewardState   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState      |             |
-> > | svRewardCoupons | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\] |             |
->
-> **instance** GetField "svRewardCoupons" DsoRules_ReceiveSvRewardCouponResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\]
->
-> **instance** GetField "svRewardState" DsoRules_ReceiveSvRewardCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
->
-> **instance** SetField "svRewardCoupons" DsoRules_ReceiveSvRewardCouponResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\]
->
-> **instance** SetField "svRewardState" DsoRules_ReceiveSvRewardCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult
-
-<div id="type-splice-dsorules-dsorulesrequestelectionresult-48590">
-
-**data** DsoRules_RequestElectionResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesrequestelectionresult-48843">
->
-> DsoRules_RequestElectionResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | electionRequestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest |             |
->
-> **instance** GetField "electionRequestCid" DsoRules_RequestElectionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest)
->
-> **instance** SetField "electionRequestCid" DsoRules_RequestElectionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult
-
-<div id="type-splice-dsorules-dsorulesrequestvoteresult-78559">
-
-**data** DsoRules_RequestVoteResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesrequestvoteresult-22502">
->
-> DsoRules_RequestVoteResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                      | Description |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | voteRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest |             |
->
-> **instance** GetField "voteRequest" DsoRules_RequestVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
->
-> **instance** SetField "voteRequest" DsoRules_RequestVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult
-
-<div id="type-splice-dsorules-dsorulesrevokefeaturedapprightresult-31874">
-
-**data** DsoRules_RevokeFeaturedAppRightResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesrevokefeaturedapprightresult-56949">
->
-> DsoRules_RevokeFeaturedAppRightResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult
-
-<div id="type-splice-dsorules-dsorulessetconfigresult-20888">
-
-**data** DsoRules_SetConfigResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulessetconfigresult-7861">
->
-> DsoRules_SetConfigResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_SetConfig DsoRules_SetConfigResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_SetConfig DsoRules_SetConfigResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_SetConfig DsoRules_SetConfigResult
-
-<div id="type-splice-dsorules-dsorulessetsynchronizernodeconfigresult-80120">
-
-**data** DsoRules_SetSynchronizerNodeConfigResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulessetsynchronizernodeconfigresult-93925">
->
-> DsoRules_SetSynchronizerNodeConfigResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                      | Description |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | svNodeState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState |             |
->
-> **instance** GetField "svNodeState" DsoRules_SetSynchronizerNodeConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState)
->
-> **instance** SetField "svNodeState" DsoRules_SetSynchronizerNodeConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult
-
-<div id="type-splice-dsorules-dsorulesstartsvonboardingresult-18158">
-
-**data** DsoRules_StartSvOnboardingResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesstartsvonboardingresult-27583">
->
-> DsoRules_StartSvOnboardingResult
->
-> </div>
->
-> > | Field             | Type                                                                                                                                              | Description |
-> > |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | onboardingRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest |             |
->
-> **instance** GetField "onboardingRequest" DsoRules_StartSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest)
->
-> **instance** SetField "onboardingRequest" DsoRules_StartSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult
-
-<div id="type-splice-dsorules-dsorulessubmitstatusreportresult-52083">
-
-**data** DsoRules_SubmitStatusReportResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulessubmitstatusreportresult-24832">
->
-> DsoRules_SubmitStatusReportResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                         | Description |
-> > |-----------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newReport | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport |             |
->
-> **instance** GetField "newReport" DsoRules_SubmitStatusReportResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport)
->
-> **instance** SetField "newReport" DsoRules_SubmitStatusReportResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult
-
-<div id="type-splice-dsorules-dsorulesterminatesubscriptionresult-840">
-
-**data** DsoRules_TerminateSubscriptionResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesterminatesubscriptionresult-26229">
->
-> DsoRules_TerminateSubscriptionResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult
-
-<div id="type-splice-dsorules-dsorulesupdateamuletpricevoteresult-31774">
-
-**data** DsoRules_UpdateAmuletPriceVoteResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesupdateamuletpricevoteresult-27803">
->
-> DsoRules_UpdateAmuletPriceVoteResult
->
-> </div>
->
-> > | Field           | Type                                                                                                                                          | Description |
-> > |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletPriceVote | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote |             |
->
-> **instance** GetField "amuletPriceVote" DsoRules_UpdateAmuletPriceVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote)
->
-> **instance** SetField "amuletPriceVote" DsoRules_UpdateAmuletPriceVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult
-
-<div id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-26858">
-
-**data** DsoRules_UpdateExternalPartyConfigStatesResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-3139">
->
-> DsoRules_UpdateExternalPartyConfigStatesResult
->
-> </div>
->
-> > | Field                          | Type                                                                                                                                                   | Description |
-> > |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newExternalPartyConfigStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** GetField "newExternalPartyConfigStateCid" DsoRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
->
-> **instance** SetField "newExternalPartyConfigStateCid" DsoRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult
-
-<div id="type-splice-dsorules-dsorulesupdatesvrewardweightresult-38140">
-
-**data** DsoRules_UpdateSvRewardWeightResult
-
-</div>
-
-> <div id="constr-splice-dsorules-dsorulesupdatesvrewardweightresult-2499">
->
-> DsoRules_UpdateSvRewardWeightResult
->
-> </div>
->
-> > | Field       | Type                                                                                                                                   | Description |
-> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
->
-> **instance** GetField "newDsoRules" DsoRules_UpdateSvRewardWeightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** SetField "newDsoRules" DsoRules_UpdateSvRewardWeightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult
-
-<div id="type-splice-dsorules-dsosummary-18963">
-
-**data** DsoSummary
-
-</div>
-
-> <div id="constr-splice-dsorules-dsosummary-70086">
->
-> DsoSummary
->
-> </div>
->
-> > | Field            | Type                                                                                                                | Description                                                                          |
-> > |------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-> > | dsoDelegate      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | **Deprecated** in favor of delegateless automation.                                  |
-> > | numSvs           | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |                                                                                      |
-> > | requiredNumVotes | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The number of votes required for considering a confirmation, or a request for a vote |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoSummary
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoSummary
->
-> **instance** GetField "dsoDelegate" DsoSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "numSvs" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "requiredNumVotes" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "dsoDelegate" DsoSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "numSvs" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "requiredNumVotes" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
-
-<div id="type-splice-dsorules-electionrequestreason-11906">
-
-**data** ElectionRequestReason
-
-</div>
-
-> **Deprecated** in favor of delegateless automation.
->
-> <div id="constr-splice-dsorules-errdsodelegateunavailable-67703">
->
-> ERR_DsoDelegateUnavailable
->
-> </div>
->
-> <div id="constr-splice-dsorules-errotherreason-56585">
->
-> ERR_OtherReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> </div>
->
-> <div id="constr-splice-dsorules-extelectionrequestreason-65169">
->
-> ExtElectionRequestReason
->
-> </div>
->
-> > | Field          | Type | Description                                                                                             |
-> > |----------------|------|---------------------------------------------------------------------------------------------------------|
-> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ElectionRequestReason
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ElectionRequestReason
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ElectionRequestReason
->
-> **instance** GetField "dummyUnitField" ElectionRequestReason ()
->
-> **instance** GetField "reason" DsoRules_RequestElection ElectionRequestReason
->
-> **instance** GetField "reason" ElectionRequest ElectionRequestReason
->
-> **instance** SetField "dummyUnitField" ElectionRequestReason ()
->
-> **instance** SetField "reason" DsoRules_RequestElection ElectionRequestReason
->
-> **instance** SetField "reason" ElectionRequest ElectionRequestReason
-
-<div id="type-splice-dsorules-logicalsynchronizerupgradeschedule-67809">
-
-**data** LogicalSynchronizerUpgradeSchedule
-
-</div>
-
-> <div id="constr-splice-dsorules-logicalsynchronizerupgradeschedule-50336">
->
-> LogicalSynchronizerUpgradeSchedule
->
-> </div>
->
-> > | Field                                  | Type                                                                                                              | Description                                                                                                                                                                                                                         |
-> > |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | topologyFreezeTime                     | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time at which topology transactions will be frozen. Note that this time is used by the automation to initiate the topology transactions for freezing. The actual freeze time is the effective time of the topology transaction. |
-> > | upgradeTime                            | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time at which the upgrade to the new physical synchronizer will happen.                                                                                                                                                         |
-> > | newPhysicalSynchronizerSerial          | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        | The serial of the new physical synchronizer. Usually just the serial of the old physical synchronizer + 1.                                                                                                                          |
-> > | newPhysicalSynchronizerProtocolVersion | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      | The protocol version of the new physical synchronizer                                                                                                                                                                               |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) LogicalSynchronizerUpgradeSchedule
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) LogicalSynchronizerUpgradeSchedule
->
-> **instance** GetField "newPhysicalSynchronizerProtocolVersion" LogicalSynchronizerUpgradeSchedule [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "newPhysicalSynchronizerSerial" LogicalSynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
->
-> **instance** GetField "topologyFreezeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "upgradeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "newPhysicalSynchronizerProtocolVersion" LogicalSynchronizerUpgradeSchedule [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "newPhysicalSynchronizerSerial" LogicalSynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
->
-> **instance** SetField "topologyFreezeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "upgradeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** Patchable LogicalSynchronizerUpgradeSchedule
-
-<div id="type-splice-dsorules-offboardedsvinfo-61414">
-
-**data** OffboardedSvInfo
-
-</div>
-
-> Information about offboarded svs
->
-> <div id="constr-splice-dsorules-offboardedsvinfo-34519">
->
-> OffboardedSvInfo
->
-> </div>
->
-> > | Field         | Type                                                                                                         | Description                          |
-> > |---------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------|
-> > | name          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Human-readable name; must be unique. |
-> > | participantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Participant ID of the offboarded SV. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) OffboardedSvInfo
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) OffboardedSvInfo
->
-> **instance** GetField "name" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "offboardedSvs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) OffboardedSvInfo)
->
-> **instance** GetField "participantId" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "name" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "offboardedSvs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) OffboardedSvInfo)
->
-> **instance** SetField "participantId" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
-
-<div id="type-splice-dsorules-reason-36941">
-
-**data** Reason
-
-</div>
-
-> <div id="constr-splice-dsorules-reason-51132">
->
-> Reason
->
-> </div>
->
-> > | Field | Type                                                                                                         | Description                                                                                            |
-> > |-------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-> > | url   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Url pointing to additional background on the reason, e.g., using a https://w3c-ccg.github.io/hashlink/ |
-> > | body  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Freeform text intended for human consumption.                                                          |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Reason
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Reason
->
-> **instance** GetField "body" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "reason" DsoRules_RequestVote Reason
->
-> **instance** GetField "reason" Vote Reason
->
-> **instance** GetField "reason" VoteRequest Reason
->
-> **instance** GetField "url" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "body" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "reason" DsoRules_RequestVote Reason
->
-> **instance** SetField "reason" Vote Reason
->
-> **instance** SetField "reason" VoteRequest Reason
->
-> **instance** SetField "url" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
-
-<div id="type-splice-dsorules-svinfo-76274">
-
-**data** SvInfo
-
-</div>
-
-> Information about SVs relevant to DSO governance.
->
-> <div id="constr-splice-dsorules-svinfo-69131">
->
-> SvInfo
->
-> </div>
->
-> > | Field           | Type                                                                                                         | Description                                                                                                                                   |
-> > |-----------------|--------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-> > | name            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Human-readable name; must be unique.                                                                                                          |
-> > | joinedAsOfRound | Round                                                                                                        | Round in which the SV joined                                                                                                                  |
-> > | svRewardWeight  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)   | Weight of the SV in the SV reward distribution.                                                                                               |
-> > | participantId   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Participant ID of the SV, stored here as PartyToParticipant mappings are tracked via state on the DsoRules + SvOnboardingConfirmed contracts. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SvInfo
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SvInfo
->
-> **instance** GetField "joinedAsOfRound" SvInfo Round
->
-> **instance** GetField "name" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "participantId" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "svRewardWeight" SvInfo [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "svs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) SvInfo)
->
-> **instance** SetField "joinedAsOfRound" SvInfo Round
->
-> **instance** SetField "name" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "participantId" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "svRewardWeight" SvInfo [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "svs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) SvInfo)
-
-<div id="type-splice-dsorules-synchronizerupgradeschedule-64447">
-
-**data** SynchronizerUpgradeSchedule
-
-</div>
-
-> <div id="constr-splice-dsorules-synchronizerupgradeschedule-53308">
->
-> SynchronizerUpgradeSchedule
->
-> </div>
->
-> > | Field       | Type                                                                                                              | Description                                            |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-> > | time        | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time at which the migration is scheduled to start. |
-> > | migrationId | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        | The incremental integer ID of the migration.           |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerUpgradeSchedule
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerUpgradeSchedule
->
-> **instance** GetField "migrationId" SynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
->
-> **instance** GetField "time" SynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "migrationId" SynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
->
-> **instance** SetField "time" SynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** Patchable SynchronizerUpgradeSchedule
-
-<div id="type-splice-dsorules-trafficstate-38069">
-
-**data** TrafficState
-
-</div>
-
-> <div id="constr-splice-dsorules-trafficstate-23304">
->
-> TrafficState
->
-> </div>
->
-> > | Field           | Type                                                                                                       | Description                                                                             |
-> > |-----------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
-> > | consumedTraffic | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Bytes of extra traffic consumed before the decentralized synchronizer was bootstrapped. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TrafficState
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TrafficState
->
-> **instance** GetField "consumedTraffic" TrafficState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** GetField "initialTrafficState" DsoBootstrap ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
->
-> **instance** GetField "initialTrafficState" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
->
-> **instance** SetField "consumedTraffic" TrafficState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "initialTrafficState" DsoBootstrap ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
->
-> **instance** SetField "initialTrafficState" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
-
-<div id="type-splice-dsorules-vote-50851">
-
-**data** Vote
-
-</div>
-
-> A vote cast by an SV.
->
-> <div id="constr-splice-dsorules-vote-51690">
->
-> Vote
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                                                                                                             | Description                                                               |
-> > |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-> > | sv        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The SV party used to submit the vote.                                     |
-> > | accept    | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                                     | Whether the responder accepted the request to execute the action or not.  |
-> > | reason    | Reason                                                                                                                                                                                                                                           | The reason for voting this way.                                           |
-> > | optCastAt | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time when the vote was cast. Used to rate-limit the casting of votes. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Vote
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Vote
->
-> **instance** GetField "accept" Vote [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** GetField "optCastAt" Vote ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
->
-> **instance** GetField "reason" Vote Reason
->
-> **instance** GetField "sv" Vote [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "vote" DsoRules_CastVote Vote
->
-> **instance** GetField "votes" VoteRequest ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) Vote)
->
-> **instance** SetField "accept" Vote [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
->
-> **instance** SetField "optCastAt" Vote ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
->
-> **instance** SetField "reason" Vote Reason
->
-> **instance** SetField "sv" Vote [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "vote" DsoRules_CastVote Vote
->
-> **instance** SetField "votes" VoteRequest ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) Vote)
-
-<div id="type-splice-dsorules-voterequestoutcome-63724">
-
-**data** VoteRequestOutcome
-
-</div>
-
-> <div id="constr-splice-dsorules-vroacceptedbutactionfailed-51100">
->
-> VRO_AcceptedButActionFailed
->
-> </div>
->
-> > | Field       | Type                                                                                                         | Description                 |
-> > |-------------|--------------------------------------------------------------------------------------------------------------|-----------------------------|
-> > | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Description of the failure. |
->
-> <div id="constr-splice-dsorules-vroaccepted-67803">
->
-> VRO_Accepted
->
-> </div>
->
-> > | Field       | Type                                                                                                              | Description                             |
-> > |-------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
-> > | effectiveAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Time when the action will be effective. |
->
-> <div id="constr-splice-dsorules-vrorejected-43182">
->
-> VRO_Rejected
->
-> </div>
->
-> <div id="constr-splice-dsorules-vroexpired-35522">
->
-> VRO_Expired
->
-> </div>
->
-> <div id="constr-splice-dsorules-extvoterequestoutcome-76073">
->
-> ExtVoteRequestOutcome
->
-> </div>
->
-> > | Field          | Type | Description |
-> > |----------------|------|-------------|
-> > | dummyUnitField | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) VoteRequestOutcome
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) VoteRequestOutcome
->
-> **instance** GetField "description" VoteRequestOutcome [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "dummyUnitField" VoteRequestOutcome ()
->
-> **instance** GetField "effectiveAt" VoteRequestOutcome [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** GetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
->
-> **instance** SetField "description" VoteRequestOutcome [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dummyUnitField" VoteRequestOutcome ()
->
-> **instance** SetField "effectiveAt" VoteRequestOutcome [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** SetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
-
-<div id="type-splice-dsorules-votingstate-60200">
-
-**data** VotingState a
-
-</div>
-
-> **Deprecated** in favor of delegateless automation. Functions implementing instant-runoff voting
->
-> <div id="constr-splice-dsorules-votingstate-26047">
->
-> VotingState
->
-> </div>
->
-> > | Field    | Type                                                                                                                        | Description                                                                                                                                   |
-> > |----------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-> > | rankings | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) a \[\[a\]\] | Candidate and the remaining rankings in case that candidate is eliminated.                                                                    |
-> > | loosers  | Set a              | Loosers are tracked explicitly and removed lazily to avoid the cubic runtime that would result from filtering the remaining rankings eagerly. |
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (VotingState a)
->
-> **instance** ([Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a) =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (VotingState a)
->
-> **instance** GetField "loosers" (VotingState a) (Set a)
->
-> **instance** GetField "rankings" (VotingState a) ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) a \[\[a\]\])
->
-> **instance** SetField "loosers" (VotingState a) (Set a)
->
-> **instance** SetField "rankings" (VotingState a) ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) a \[\[a\]\])
+<span id="type-splice-dsorules-actionrequiringconfirmation-45397"></span>
+
+### `data ActionRequiringConfirmation`
+
+Actions that require confirmation from SV nodes before they can be executed.
+
+There are two processes for executing such actions:
+1. Any SV can request a vote to execute such an action upon which the other SV's
+   can respond with their votes for whether they accept the execution or not.
+   This process requires votes from 2/3 of all SVs* for the action to be considered definitive
+   and it can be used for all actions that require confirmation.
+2. Some of the actions that require confirmations should be executed automatically
+   once the ledger and the wall-clocks of the SV nodes are in a particular state.
+   These actions are confirmed by each SV node automatically once the action's precondition is met.
+   Once 2/3 of all SV's confirmations* are visible to the DSO delegate it executes them.
+
+* Simplified for clarity; see `requiredNumVotes` for exact formula.
+
+Process 2 is an optimization of Process 1 for the case where no disagreement to the
+action is expected.
+
+We expect honest SV nodes to only create confirmations for actions
+whose preconditions are met. We also rely on the execution of these actions to be
+idempotent, as more than the required number of confirmations can be created.
+
+Note also that having these two processes also aids in distinguishing between manually initiated
+ad-hoc votes and the regular confirmations that need to happen during standard DSO.
+
+Constructors:
+
+<span id="constr-splice-dsorules-arcdsorules-25826"></span>
+
+- `ARC_DsoRules`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dsoAction | DsoRules_ActionRequiringConfirmation |  |
+
+<span id="constr-splice-dsorules-arcamuletrules-45909"></span>
+
+- `ARC_AmuletRules`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesAction | AmuletRules_ActionRequiringConfirmation |  |
+
+<span id="constr-splice-dsorules-arcansentrycontext-51355"></span>
+
+- `ARC_AnsEntryContext`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| ansEntryContextAction | AnsEntryContext_ActionRequiringConfirmation |  |
+
+<span id="constr-splice-dsorules-extactionrequiringconformation-24220"></span>
+
+- `ExtActionRequiringConformation`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0<br/><br/>This on takes care of providing extensibility for the specific variants below. |
+
+Instances:
+
+- `instance Eq ActionRequiringConfirmation`
+- `instance Show ActionRequiringConfirmation`
+- `instance GetField action Confirmation ActionRequiringConfirmation`
+- `instance GetField action DsoRules_ConfirmAction ActionRequiringConfirmation`
+- `instance GetField action DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation`
+- `instance GetField action DsoRules_RequestVote ActionRequiringConfirmation`
+- `instance GetField action VoteRequest ActionRequiringConfirmation`
+- `instance GetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+- `instance GetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+- `instance GetField ansEntryContextCid ActionRequiringConfirmation (ContractId AnsEntryContext)`
+- `instance GetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+- `instance GetField dummyUnitField ActionRequiringConfirmation ()`
+- `instance SetField action Confirmation ActionRequiringConfirmation`
+- `instance SetField action DsoRules_ConfirmAction ActionRequiringConfirmation`
+- `instance SetField action DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation`
+- `instance SetField action DsoRules_RequestVote ActionRequiringConfirmation`
+- `instance SetField action VoteRequest ActionRequiringConfirmation`
+- `instance SetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+- `instance SetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+- `instance SetField ansEntryContextCid ActionRequiringConfirmation (ContractId AnsEntryContext)`
+- `instance SetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+- `instance SetField dummyUnitField ActionRequiringConfirmation ()`
+
+<span id="type-splice-dsorules-amuletrulesactionrequiringconfirmation-62783"></span>
+
+### `data AmuletRules_ActionRequiringConfirmation`
+
+Constructors:
+
+<span id="constr-splice-dsorules-crarcminingroundstartissuing-47375"></span>
+
+- `CRARC_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuing`
+
+Automated action to start an issuing round once the summary of the reward coupons have been computed.
+
+<span id="constr-splice-dsorules-crarcminingroundarchive-10786"></span>
+
+- `CRARC_MiningRound_Archive AmuletRules_MiningRound_Archive`
+
+Automated action to archive a closed mining round once no expired reward coupons are left.
+
+<span id="constr-splice-dsorules-crarcaddfutureamuletconfigschedule-50004"></span>
+
+- `CRARC_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigSchedule`
+
+**Deprecated, use CRARC_SetConfig instead**: Voted action to add a config schedule to the `AmuletRules`.
+
+<span id="constr-splice-dsorules-crarcremovefutureamuletconfigschedule-28322"></span>
+
+- `CRARC_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigSchedule`
+
+**Deprecated, use CRARC_SetConfig instead**: Voted action to remove a config schedule from the `AmuletRules`.
+
+<span id="constr-splice-dsorules-crarcupdatefutureamuletconfigschedule-3041"></span>
+
+- `CRARC_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigSchedule`
+
+**Deprecated, use CRARC_SetConfig instead**: Voted action to update a config schedule in the `AmuletRules`.
+
+<span id="constr-splice-dsorules-crarcsetconfig-80537"></span>
+
+- `CRARC_SetConfig AmuletRules_SetConfig`
+
+Voted action to change the `AmuletConfig`. Not idempotent.
+
+Instances:
+
+- `instance Eq AmuletRules_ActionRequiringConfirmation`
+- `instance Show AmuletRules_ActionRequiringConfirmation`
+- `instance GetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+- `instance SetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+
+<span id="type-splice-dsorules-ansentrycontextactionrequiringconfirmation-11149"></span>
+
+### `data AnsEntryContext_ActionRequiringConfirmation`
+
+Constructors:
+
+<span id="constr-splice-dsorules-ansrarccollectinitialentrypayment-99049"></span>
+
+- `ANSRARC_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPayment`
+
+Automated action to collect initial payment of an ans entry.
+
+<span id="constr-splice-dsorules-ansrarcrejectentryinitialpayment-1047"></span>
+
+- `ANSRARC_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPayment`
+
+Automated action to reject initial payment of an ans entry.
+
+Instances:
+
+- `instance Eq AnsEntryContext_ActionRequiringConfirmation`
+- `instance Show AnsEntryContext_ActionRequiringConfirmation`
+- `instance GetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+- `instance SetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+
+<span id="type-splice-dsorules-confirmationexpireresult-10666"></span>
+
+### `data Confirmation_ExpireResult`
+
+Choice return types
+
+Constructors:
+
+<span id="constr-splice-dsorules-confirmationexpireresult-43205"></span>
+
+- `Confirmation_ExpireResult`
+
+Instances:
+
+- `instance HasExercise Confirmation Confirmation_Expire Confirmation_ExpireResult`
+- `instance HasFromAnyChoice Confirmation Confirmation_Expire Confirmation_ExpireResult`
+- `instance HasToAnyChoice Confirmation Confirmation_Expire Confirmation_ExpireResult`
+
+<span id="type-splice-dsorules-dsorulesconfig-6376"></span>
+
+### `data DsoRulesConfig`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesconfig-32625"></span>
+
+- `DsoRulesConfig`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| numUnclaimedRewardsThreshold | Int | The minimum number of unclaimed rewards required for merging |
+| numMemberTrafficContractsThreshold | Int | The minimum number of member traffic contracts required for merging |
+| actionConfirmationTimeout | RelTime | The TTL for contracts representing a confirmation |
+| svOnboardingRequestTimeout | RelTime | The TTL for contracts representing an incomplete onboarding |
+| svOnboardingConfirmedTimeout | RelTime | The TTL for contracts representing an SV confirmation |
+| voteRequestTimeout | RelTime | The TTL for a `VoteRequest` and its associated `Vote` s |
+| dsoDelegateInactiveTimeout | RelTime | The amount of time given to the DSO delegate to complete an action it should take care of<br/><br/>^ __Deprecated__ in favor of delegateless automation. |
+| synchronizerNodeConfigLimits | SynchronizerNodeConfigLimits | Limits to enforce on the svs' `SynchronizerNodeConfig` |
+| maxTextLength | Int | Generic upper limit on text fields in choices and contracts. |
+| decentralizedSynchronizer | DsoDecentralizedSynchronizerConfig |  |
+| nextScheduledSynchronizerUpgrade | Optional SynchronizerUpgradeSchedule |  |
+| voteCooldownTime | Optional RelTime | The minimum time between two votes by the same SV. |
+| nextScheduledLogicalSynchronizerUpgrade | Optional LogicalSynchronizerUpgradeSchedule |  |
+
+Instances:
+
+- `instance Patchable DsoRulesConfig`
+- `instance Eq DsoRulesConfig`
+- `instance Show DsoRulesConfig`
+- `instance GetField actionConfirmationTimeout DsoRulesConfig RelTime`
+- `instance GetField baseConfig DsoRules_SetConfig (Optional DsoRulesConfig)`
+- `instance GetField config DsoBootstrap DsoRulesConfig`
+- `instance GetField config DsoRules DsoRulesConfig`
+- `instance GetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance GetField dsoDelegateInactiveTimeout DsoRulesConfig RelTime`
+- `instance GetField maxTextLength DsoRulesConfig Int`
+- `instance GetField newConfig DsoRules_SetConfig DsoRulesConfig`
+- `instance GetField nextScheduledLogicalSynchronizerUpgrade DsoRulesConfig (Optional LogicalSynchronizerUpgradeSchedule)`
+- `instance GetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance GetField numMemberTrafficContractsThreshold DsoRulesConfig Int`
+- `instance GetField numUnclaimedRewardsThreshold DsoRulesConfig Int`
+- `instance GetField svOnboardingConfirmedTimeout DsoRulesConfig RelTime`
+- `instance GetField svOnboardingRequestTimeout DsoRulesConfig RelTime`
+- `instance GetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+- `instance GetField voteCooldownTime DsoRulesConfig (Optional RelTime)`
+- `instance GetField voteRequestTimeout DsoRulesConfig RelTime`
+- `instance SetField actionConfirmationTimeout DsoRulesConfig RelTime`
+- `instance SetField baseConfig DsoRules_SetConfig (Optional DsoRulesConfig)`
+- `instance SetField config DsoBootstrap DsoRulesConfig`
+- `instance SetField config DsoRules DsoRulesConfig`
+- `instance SetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance SetField dsoDelegateInactiveTimeout DsoRulesConfig RelTime`
+- `instance SetField maxTextLength DsoRulesConfig Int`
+- `instance SetField newConfig DsoRules_SetConfig DsoRulesConfig`
+- `instance SetField nextScheduledLogicalSynchronizerUpgrade DsoRulesConfig (Optional LogicalSynchronizerUpgradeSchedule)`
+- `instance SetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance SetField numMemberTrafficContractsThreshold DsoRulesConfig Int`
+- `instance SetField numUnclaimedRewardsThreshold DsoRulesConfig Int`
+- `instance SetField svOnboardingConfirmedTimeout DsoRulesConfig RelTime`
+- `instance SetField svOnboardingRequestTimeout DsoRulesConfig RelTime`
+- `instance SetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+- `instance SetField voteCooldownTime DsoRulesConfig (Optional RelTime)`
+- `instance SetField voteRequestTimeout DsoRulesConfig RelTime`
+
+<span id="type-splice-dsorules-dsorulesactionrequiringconfirmation-12600"></span>
+
+### `data DsoRules_ActionRequiringConfirmation`
+
+Constructors:
+
+<span id="constr-splice-dsorules-srarcaddsv-12841"></span>
+
+- `SRARC_AddSv DsoRules_AddSv`
+
+Voted action to directly add an SV
+
+<span id="constr-splice-dsorules-srarcoffboardsv-63692"></span>
+
+- `SRARC_OffboardSv DsoRules_OffboardSv`
+
+Voted action to remove an SV
+
+<span id="constr-splice-dsorules-srarcconfirmsvonboarding-51509"></span>
+
+- `SRARC_ConfirmSvOnboarding DsoRules_ConfirmSvOnboarding`
+
+Automated action to confirm that a party can become an SV.
+
+<span id="constr-splice-dsorules-srarcgrantfeaturedappright-84890"></span>
+
+- `SRARC_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRight`
+
+Voted action to grant a featured app right. Not idempotent.
+
+<span id="constr-splice-dsorules-srarcrevokefeaturedappright-73851"></span>
+
+- `SRARC_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRight`
+
+Revoke a specific featured app right.
+
+<span id="constr-splice-dsorules-srarcsetconfig-39305"></span>
+
+- `SRARC_SetConfig DsoRules_SetConfig`
+
+Voted action to change the `DsoRulesConfig`. Not idempotent.
+
+<span id="constr-splice-dsorules-srarcupdatesvrewardweight-81705"></span>
+
+- `SRARC_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeight`
+
+Voted action to update the reward weight of an SV.
+
+<span id="constr-splice-dsorules-srarccreateexternalpartyamuletrules-49124"></span>
+
+- `SRARC_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRules`
+
+Create ExternalPartyAmuletRules contract if it has not been created as part of network bootstrapping.
+
+<span id="constr-splice-dsorules-srarccreatetransfercommandcounter-88632"></span>
+
+- `SRARC_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounter`
+
+Create TransferCommandCounter contract for the given sender if it does not already exist
+
+<span id="constr-splice-dsorules-srarccreateunallocatedunclaimedactivityrecord-97784"></span>
+
+- `SRARC_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecord`
+
+Voted action to create an UnallocatedUnclaimedActivityRecord contract.
+
+<span id="constr-splice-dsorules-srarccreatebootstrapexternalpartyconfigstateinstruction-49456"></span>
+
+- `SRARC_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstruction`
+
+Create BootstrapExternalPartyConfigStateInstruction
+
+Instances:
+
+- `instance Eq DsoRules_ActionRequiringConfirmation`
+- `instance Show DsoRules_ActionRequiringConfirmation`
+- `instance GetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+- `instance SetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+
+<span id="type-splice-dsorules-dsorulesaddconfirmedsvresult-53040"></span>
+
+### `data DsoRules_AddConfirmedSvResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesaddconfirmedsvresult-81391"></span>
+
+- `DsoRules_AddConfirmedSvResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_AddConfirmedSvResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_AddConfirmedSvResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult`
+
+<span id="type-splice-dsorules-dsorulesaddsvresult-53972"></span>
+
+### `data DsoRules_AddSvResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesaddsvresult-63557"></span>
+
+- `DsoRules_AddSvResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_AddSvResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_AddSvResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_AddSv DsoRules_AddSvResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AddSv DsoRules_AddSvResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AddSv DsoRules_AddSvResult`
+
+<span id="type-splice-dsorules-dsorulesadvanceopenminingroundsresult-57405"></span>
+
+### `data DsoRules_AdvanceOpenMiningRoundsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesadvanceopenminingroundsresult-30524"></span>
+
+- `DsoRules_AdvanceOpenMiningRoundsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| summarizingRound | ContractId SummarizingMiningRound |  |
+| openRound | ContractId OpenMiningRound |  |
+
+Instances:
+
+- `instance GetField openRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance GetField summarizingRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance SetField openRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance SetField summarizingRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance HasExercise DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult`
+
+<span id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-87254"></span>
+
+### `data DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-24573"></span>
+
+- `DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedActivityRecordCid | ContractId UnclaimedActivityRecord |  |
+| optUnclaimedRewardCid | Optional (ContractId UnclaimedReward) |  |
+
+Instances:
+
+- `instance GetField optUnclaimedRewardCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (Optional (ContractId UnclaimedReward))`
+- `instance GetField unclaimedActivityRecordCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (ContractId UnclaimedActivityRecord)`
+- `instance SetField optUnclaimedRewardCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (Optional (ContractId UnclaimedReward))`
+- `instance SetField unclaimedActivityRecordCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (ContractId UnclaimedActivityRecord)`
+- `instance HasExercise DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+<span id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-72068"></span>
+
+### `data DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-81577"></span>
+
+- `DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | AmuletRules_ConvertFeaturedAppActivityMarkersResult |  |
+
+Instances:
+
+- `instance GetField result DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance SetField result DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasExercise DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+<span id="type-splice-dsorules-dsorulesamuletexpireresult-67290"></span>
+
+### `data DsoRules_Amulet_ExpireResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesamuletexpireresult-61799"></span>
+
+- `DsoRules_Amulet_ExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_Amulet_ExpireResult AmuletExpireSummary`
+- `instance SetField expireSum DsoRules_Amulet_ExpireResult AmuletExpireSummary`
+- `instance HasExercise DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult`
+- `instance HasToAnyChoice DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult`
+
+<span id="type-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-29864"></span>
+
+### `data DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-36781"></span>
+
+- `DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | AmuletRules_Amulet_ExpireTransferInstructionsResult |  |
+
+Instances:
+
+- `instance Eq DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance Show DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance GetField result DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance SetField result DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasExercise DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+<span id="type-splice-dsorules-dsorulesamuletexpirev2result-94072"></span>
+
+### `data DsoRules_Amulet_ExpireV2Result`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesamuletexpirev2result-84829"></span>
+
+- `DsoRules_Amulet_ExpireV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance SetField expireSum DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance HasExercise DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result`
+- `instance HasFromAnyChoice DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result`
+- `instance HasToAnyChoice DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result`
+
+<span id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-78881"></span>
+
+### `data DsoRules_ArchiveOutdatedElectionRequestResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-72534"></span>
+
+- `DsoRules_ArchiveOutdatedElectionRequestResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult`
+
+<span id="type-splice-dsorules-dsorulesarchivesvonboardingrequestresult-76462"></span>
+
+### `data DsoRules_ArchiveSvOnboardingRequestResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesarchivesvonboardingrequestresult-86253"></span>
+
+- `DsoRules_ArchiveSvOnboardingRequestResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult`
+
+<span id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-77872"></span>
+
+### `data DsoRules_BootstrapExternalPartyConfigStateResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-70741"></span>
+
+- `DsoRules_BootstrapExternalPartyConfigStateResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasToAnyChoice DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult`
+
+<span id="type-splice-dsorules-dsorulescastvoteresult-84724"></span>
+
+### `data DsoRules_CastVoteResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulescastvoteresult-18147"></span>
+
+- `DsoRules_CastVoteResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| voteRequest | ContractId VoteRequest |  |
+
+Instances:
+
+- `instance GetField voteRequest DsoRules_CastVoteResult (ContractId VoteRequest)`
+- `instance SetField voteRequest DsoRules_CastVoteResult (ContractId VoteRequest)`
+- `instance HasExercise DsoRules DsoRules_CastVote DsoRules_CastVoteResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CastVote DsoRules_CastVoteResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CastVote DsoRules_CastVoteResult`
+
+<span id="type-splice-dsorules-dsorulesclaimexpiredrewardsresult-70369"></span>
+
+### `data DsoRules_ClaimExpiredRewardsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesclaimexpiredrewardsresult-56160"></span>
+
+- `DsoRules_ClaimExpiredRewardsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedReward | Optional (ContractId UnclaimedReward) |  |
+
+Instances:
+
+- `instance GetField unclaimedReward DsoRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance SetField unclaimedReward DsoRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance HasExercise DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult`
+
+<span id="type-splice-dsorules-dsorulesclosevoterequestresult-49382"></span>
+
+### `data DsoRules_CloseVoteRequestResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesclosevoterequestresult-14349"></span>
+
+- `DsoRules_CloseVoteRequestResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| request | VoteRequest | The original vote request. |
+| completedAt | Time | When the vote request was completed. |
+| offboardedVoters | [Text] | SVs that voted but were offboarded before the vote completed. |
+| abstainingSvs | [Text] | SVs that did not vote. |
+| outcome | VoteRequestOutcome | The final result of the vote. |
+
+Instances:
+
+- `instance Eq DsoRules_CloseVoteRequestResult`
+- `instance Show DsoRules_CloseVoteRequestResult`
+- `instance GetField abstainingSvs DsoRules_CloseVoteRequestResult [Text]`
+- `instance GetField completedAt DsoRules_CloseVoteRequestResult Time`
+- `instance GetField offboardedVoters DsoRules_CloseVoteRequestResult [Text]`
+- `instance GetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+- `instance GetField request DsoRules_CloseVoteRequestResult VoteRequest`
+- `instance SetField abstainingSvs DsoRules_CloseVoteRequestResult [Text]`
+- `instance SetField completedAt DsoRules_CloseVoteRequestResult Time`
+- `instance SetField offboardedVoters DsoRules_CloseVoteRequestResult [Text]`
+- `instance SetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+- `instance SetField request DsoRules_CloseVoteRequestResult VoteRequest`
+- `instance HasExercise DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult`
+
+<span id="type-splice-dsorules-dsorulescollectentryrenewalpaymentresult-57091"></span>
+
+### `data DsoRules_CollectEntryRenewalPaymentResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulescollectentryrenewalpaymentresult-87832"></span>
+
+- `DsoRules_CollectEntryRenewalPaymentResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntry | ContractId AnsEntry |  |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField ansEntry DsoRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionState DsoRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField ansEntry DsoRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionState DsoRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult`
+
+<span id="type-splice-dsorules-dsorulesconfirmactionresult-28024"></span>
+
+### `data DsoRules_ConfirmActionResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesconfirmactionresult-48341"></span>
+
+- `DsoRules_ConfirmActionResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| confirmation | ContractId Confirmation |  |
+
+Instances:
+
+- `instance GetField confirmation DsoRules_ConfirmActionResult (ContractId Confirmation)`
+- `instance SetField confirmation DsoRules_ConfirmActionResult (ContractId Confirmation)`
+- `instance HasExercise DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult`
+
+<span id="type-splice-dsorules-dsorulesconfirmsvonboardingresult-99416"></span>
+
+### `data DsoRules_ConfirmSvOnboardingResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesconfirmsvonboardingresult-46665"></span>
+
+- `DsoRules_ConfirmSvOnboardingResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| onboardingConfirmed | ContractId SvOnboardingConfirmed |  |
+
+Instances:
+
+- `instance GetField onboardingConfirmed DsoRules_ConfirmSvOnboardingResult (ContractId SvOnboardingConfirmed)`
+- `instance SetField onboardingConfirmed DsoRules_ConfirmSvOnboardingResult (ContractId SvOnboardingConfirmed)`
+- `instance HasExercise DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult`
+
+<span id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-32985"></span>
+
+### `data DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-84146"></span>
+
+- `DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| instructionCid | ContractId BootstrapExternalPartyConfigStateInstruction |  |
+
+Instances:
+
+- `instance Eq DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance Show DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance GetField instructionCid DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult (ContractId BootstrapExternalPartyConfigStateInstruction)`
+- `instance SetField instructionCid DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult (ContractId BootstrapExternalPartyConfigStateInstruction)`
+- `instance HasExercise DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+<span id="type-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-12409"></span>
+
+### `data DsoRules_CreateExternalPartyAmuletRulesResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-52650"></span>
+
+- `DsoRules_CreateExternalPartyAmuletRulesResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyAmuletRulesCid | ContractId ExternalPartyAmuletRules |  |
+
+Instances:
+
+- `instance Eq DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance Show DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance GetField externalPartyAmuletRulesCid DsoRules_CreateExternalPartyAmuletRulesResult (ContractId ExternalPartyAmuletRules)`
+- `instance SetField externalPartyAmuletRulesCid DsoRules_CreateExternalPartyAmuletRulesResult (ContractId ExternalPartyAmuletRules)`
+- `instance HasExercise DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult`
+
+<span id="type-splice-dsorules-dsorulescreatetransfercommandcounterresult-97297"></span>
+
+### `data DsoRules_CreateTransferCommandCounterResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulescreatetransfercommandcounterresult-46310"></span>
+
+- `DsoRules_CreateTransferCommandCounterResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferCommandCounterCid | ContractId TransferCommandCounter |  |
+
+Instances:
+
+- `instance Eq DsoRules_CreateTransferCommandCounterResult`
+- `instance Show DsoRules_CreateTransferCommandCounterResult`
+- `instance GetField transferCommandCounterCid DsoRules_CreateTransferCommandCounterResult (ContractId TransferCommandCounter)`
+- `instance SetField transferCommandCounterCid DsoRules_CreateTransferCommandCounterResult (ContractId TransferCommandCounter)`
+- `instance HasExercise DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult`
+
+<span id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-76541"></span>
+
+### `data DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-18490"></span>
+
+- `DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unallocatedUnclaimedActivityRecordCid | ContractId UnallocatedUnclaimedActivityRecord |  |
+
+Instances:
+
+- `instance GetField unallocatedUnclaimedActivityRecordCid DsoRules_CreateUnallocatedUnclaimedActivityRecordResult (ContractId UnallocatedUnclaimedActivityRecord)`
+- `instance SetField unallocatedUnclaimedActivityRecordCid DsoRules_CreateUnallocatedUnclaimedActivityRecordResult (ContractId UnallocatedUnclaimedActivityRecord)`
+- `instance HasExercise DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+<span id="type-splice-dsorules-dsoruleselectdsodelegateresult-99561"></span>
+
+### `data DsoRules_ElectDsoDelegateResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsoruleselectdsodelegateresult-71514"></span>
+
+- `DsoRules_ElectDsoDelegateResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_ElectDsoDelegateResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_ElectDsoDelegateResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult`
+
+<span id="type-splice-dsorules-dsorulesexecuteconfirmedactionresult-43893"></span>
+
+### `data DsoRules_ExecuteConfirmedActionResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexecuteconfirmedactionresult-89578"></span>
+
+- `DsoRules_ExecuteConfirmedActionResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult`
+
+<span id="type-splice-dsorules-dsorulesexpireamuletallocationsresult-27100"></span>
+
+### `data DsoRules_ExpireAmuletAllocationsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpireamuletallocationsresult-29457"></span>
+
+- `DsoRules_ExpireAmuletAllocationsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | ExternalPartyAmuletRules_ExpireAmuletAllocationsResult |  |
+
+Instances:
+
+- `instance Eq DsoRules_ExpireAmuletAllocationsResult`
+- `instance Show DsoRules_ExpireAmuletAllocationsResult`
+- `instance GetField result DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance SetField result DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance HasExercise DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult`
+
+<span id="type-splice-dsorules-dsorulesexpireansentryresult-16762"></span>
+
+### `data DsoRules_ExpireAnsEntryResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpireansentryresult-6565"></span>
+
+- `DsoRules_ExpireAnsEntryResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult`
+
+<span id="type-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-36543"></span>
+
+### `data DsoRules_ExpireDevelopmentFundCouponResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-44574"></span>
+
+- `DsoRules_ExpireDevelopmentFundCouponResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | DevelopmentFundCoupon_DsoExpireResult |  |
+
+Instances:
+
+- `instance GetField result DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult`
+- `instance SetField result DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult`
+- `instance HasExercise DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult`
+
+<span id="type-splice-dsorules-dsorulesexpirestaleconfirmationresult-27719"></span>
+
+### `data DsoRules_ExpireStaleConfirmationResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpirestaleconfirmationresult-33614"></span>
+
+- `DsoRules_ExpireStaleConfirmationResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult`
+
+<span id="type-splice-dsorules-dsorulesexpiresubscriptionresult-45469"></span>
+
+### `data DsoRules_ExpireSubscriptionResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpiresubscriptionresult-70870"></span>
+
+- `DsoRules_ExpireSubscriptionResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult`
+
+<span id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-38796"></span>
+
+### `data DsoRules_ExpireSvOnboardingConfirmedResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-53333"></span>
+
+- `DsoRules_ExpireSvOnboardingConfirmedResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_ExpireSvOnboardingConfirmedResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_ExpireSvOnboardingConfirmedResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult`
+
+<span id="type-splice-dsorules-dsorulesexpiresvonboardingrequestresult-2670"></span>
+
+### `data DsoRules_ExpireSvOnboardingRequestResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpiresvonboardingrequestresult-9407"></span>
+
+- `DsoRules_ExpireSvOnboardingRequestResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult`
+
+<span id="type-splice-dsorules-dsorulesexpiretransferpreapprovalresult-76064"></span>
+
+### `data DsoRules_ExpireTransferPreapprovalResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpiretransferpreapprovalresult-84197"></span>
+
+- `DsoRules_ExpireTransferPreapprovalResult`
+
+Instances:
+
+- `instance Eq DsoRules_ExpireTransferPreapprovalResult`
+- `instance Show DsoRules_ExpireTransferPreapprovalResult`
+- `instance HasExercise DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult`
+
+<span id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-30228"></span>
+
+### `data DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-25947"></span>
+
+- `DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+<span id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-92345"></span>
+
+### `data DsoRules_ExpireUnclaimedActivityRecordResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-78492"></span>
+
+- `DsoRules_ExpireUnclaimedActivityRecordResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid DsoRules_ExpireUnclaimedActivityRecordResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedRewardCid DsoRules_ExpireUnclaimedActivityRecordResult (ContractId UnclaimedReward)`
+- `instance HasExercise DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult`
+
+<span id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-20154"></span>
+
+### `data DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-33073"></span>
+
+- `DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult`
+- `instance HasToAnyChoice DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+<span id="type-splice-dsorules-dsorulesgrantfeaturedapprightresult-6067"></span>
+
+### `data DsoRules_GrantFeaturedAppRightResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesgrantfeaturedapprightresult-3282"></span>
+
+- `DsoRules_GrantFeaturedAppRightResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRight | ContractId FeaturedAppRight |  |
+
+Instances:
+
+- `instance GetField featuredAppRight DsoRules_GrantFeaturedAppRightResult (ContractId FeaturedAppRight)`
+- `instance SetField featuredAppRight DsoRules_GrantFeaturedAppRightResult (ContractId FeaturedAppRight)`
+- `instance HasExercise DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult`
+- `instance HasToAnyChoice DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult`
+
+<span id="type-splice-dsorules-dsoruleslockedamuletexpireamuletresult-11398"></span>
+
+### `data DsoRules_LockedAmulet_ExpireAmuletResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletresult-46735"></span>
+
+- `DsoRules_LockedAmulet_ExpireAmuletResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance SetField expireSum DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance HasExercise DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult`
+- `instance HasToAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult`
+
+<span id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-75516"></span>
+
+### `data DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-22605"></span>
+
+- `DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance SetField expireSum DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance HasExercise DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result`
+- `instance HasFromAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result`
+- `instance HasToAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+<span id="type-splice-dsorules-dsorulesmergemembertrafficcontractsresult-1402"></span>
+
+### `data DsoRules_MergeMemberTrafficContractsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesmergemembertrafficcontractsresult-22987"></span>
+
+- `DsoRules_MergeMemberTrafficContractsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| memberTraffic | ContractId MemberTraffic |  |
+
+Instances:
+
+- `instance GetField memberTraffic DsoRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance SetField memberTraffic DsoRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance HasExercise DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult`
+
+<span id="type-splice-dsorules-dsorulesmergesvrewardstateresult-26494"></span>
+
+### `data DsoRules_MergeSvRewardStateResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesmergesvrewardstateresult-58441"></span>
+
+- `DsoRules_MergeSvRewardStateResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svRewardState | ContractId SvRewardState |  |
+
+Instances:
+
+- `instance GetField svRewardState DsoRules_MergeSvRewardStateResult (ContractId SvRewardState)`
+- `instance SetField svRewardState DsoRules_MergeSvRewardStateResult (ContractId SvRewardState)`
+- `instance HasExercise DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult`
+
+<span id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-91402"></span>
+
+### `data DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-95789"></span>
+
+- `DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult |  |
+
+Instances:
+
+- `instance GetField result DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance SetField result DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasExercise DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+<span id="type-splice-dsorules-dsorulesmergeunclaimedrewardsresult-75266"></span>
+
+### `data DsoRules_MergeUnclaimedRewardsResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesmergeunclaimedrewardsresult-90979"></span>
+
+- `DsoRules_MergeUnclaimedRewardsResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedReward | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedReward DsoRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedReward DsoRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance HasExercise DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult`
+
+<span id="type-splice-dsorules-dsorulesmergevalidatorlicenseresult-11621"></span>
+
+### `data DsoRules_MergeValidatorLicenseResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesmergevalidatorlicenseresult-87256"></span>
+
+- `DsoRules_MergeValidatorLicenseResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorLicense | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField validatorLicense DsoRules_MergeValidatorLicenseResult (ContractId ValidatorLicense)`
+- `instance SetField validatorLicense DsoRules_MergeValidatorLicenseResult (ContractId ValidatorLicense)`
+- `instance HasExercise DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult`
+
+<span id="type-splice-dsorules-dsorulesminingroundcloseresult-29143"></span>
+
+### `data DsoRules_MiningRound_CloseResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesminingroundcloseresult-49506"></span>
+
+- `DsoRules_MiningRound_CloseResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRound | ContractId ClosedMiningRound |  |
+
+Instances:
+
+- `instance GetField closedRound DsoRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance SetField closedRound DsoRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance HasExercise DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult`
+
+<span id="type-splice-dsorules-dsorulesoffboardsvresult-15733"></span>
+
+### `data DsoRules_OffboardSvResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesoffboardsvresult-15494"></span>
+
+- `DsoRules_OffboardSvResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_OffboardSvResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_OffboardSvResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult`
+- `instance HasToAnyChoice DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult`
+
+<span id="type-splice-dsorules-dsorulesonboardvalidatorresult-97208"></span>
+
+### `data DsoRules_OnboardValidatorResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesonboardvalidatorresult-75375"></span>
+
+- `DsoRules_OnboardValidatorResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorLicense | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField validatorLicense DsoRules_OnboardValidatorResult (ContractId ValidatorLicense)`
+- `instance SetField validatorLicense DsoRules_OnboardValidatorResult (ContractId ValidatorLicense)`
+- `instance HasExercise DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult`
+- `instance HasToAnyChoice DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult`
+
+<span id="type-splice-dsorules-dsorulespruneamuletconfigscheduleresult-66013"></span>
+
+### `data DsoRules_PruneAmuletConfigScheduleResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulespruneamuletconfigscheduleresult-2640"></span>
+
+- `DsoRules_PruneAmuletConfigScheduleResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField amuletRulesCid DsoRules_PruneAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField amuletRulesCid DsoRules_PruneAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult`
+- `instance HasToAnyChoice DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult`
+
+<span id="type-splice-dsorules-dsorulesreceivesvrewardcouponresult-91325"></span>
+
+### `data DsoRules_ReceiveSvRewardCouponResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesreceivesvrewardcouponresult-74804"></span>
+
+- `DsoRules_ReceiveSvRewardCouponResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svRewardState | ContractId SvRewardState |  |
+| svRewardCoupons | [ContractId SvRewardCoupon] |  |
+
+Instances:
+
+- `instance GetField svRewardCoupons DsoRules_ReceiveSvRewardCouponResult [ContractId SvRewardCoupon]`
+- `instance GetField svRewardState DsoRules_ReceiveSvRewardCouponResult (ContractId SvRewardState)`
+- `instance SetField svRewardCoupons DsoRules_ReceiveSvRewardCouponResult [ContractId SvRewardCoupon]`
+- `instance SetField svRewardState DsoRules_ReceiveSvRewardCouponResult (ContractId SvRewardState)`
+- `instance HasExercise DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult`
+
+<span id="type-splice-dsorules-dsorulesrequestelectionresult-48590"></span>
+
+### `data DsoRules_RequestElectionResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesrequestelectionresult-48843"></span>
+
+- `DsoRules_RequestElectionResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| electionRequestCid | ContractId ElectionRequest |  |
+
+Instances:
+
+- `instance GetField electionRequestCid DsoRules_RequestElectionResult (ContractId ElectionRequest)`
+- `instance SetField electionRequestCid DsoRules_RequestElectionResult (ContractId ElectionRequest)`
+- `instance HasExercise DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult`
+
+<span id="type-splice-dsorules-dsorulesrequestvoteresult-78559"></span>
+
+### `data DsoRules_RequestVoteResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesrequestvoteresult-22502"></span>
+
+- `DsoRules_RequestVoteResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| voteRequest | ContractId VoteRequest |  |
+
+Instances:
+
+- `instance GetField voteRequest DsoRules_RequestVoteResult (ContractId VoteRequest)`
+- `instance SetField voteRequest DsoRules_RequestVoteResult (ContractId VoteRequest)`
+- `instance HasExercise DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult`
+- `instance HasToAnyChoice DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult`
+
+<span id="type-splice-dsorules-dsorulesrevokefeaturedapprightresult-31874"></span>
+
+### `data DsoRules_RevokeFeaturedAppRightResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesrevokefeaturedapprightresult-56949"></span>
+
+- `DsoRules_RevokeFeaturedAppRightResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult`
+- `instance HasToAnyChoice DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult`
+
+<span id="type-splice-dsorules-dsorulessetconfigresult-20888"></span>
+
+### `data DsoRules_SetConfigResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulessetconfigresult-7861"></span>
+
+- `DsoRules_SetConfigResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_SetConfigResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_SetConfigResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_SetConfig DsoRules_SetConfigResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_SetConfig DsoRules_SetConfigResult`
+- `instance HasToAnyChoice DsoRules DsoRules_SetConfig DsoRules_SetConfigResult`
+
+<span id="type-splice-dsorules-dsorulessetsynchronizernodeconfigresult-80120"></span>
+
+### `data DsoRules_SetSynchronizerNodeConfigResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulessetsynchronizernodeconfigresult-93925"></span>
+
+- `DsoRules_SetSynchronizerNodeConfigResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svNodeState | ContractId SvNodeState |  |
+
+Instances:
+
+- `instance GetField svNodeState DsoRules_SetSynchronizerNodeConfigResult (ContractId SvNodeState)`
+- `instance SetField svNodeState DsoRules_SetSynchronizerNodeConfigResult (ContractId SvNodeState)`
+- `instance HasExercise DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult`
+- `instance HasToAnyChoice DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult`
+
+<span id="type-splice-dsorules-dsorulesstartsvonboardingresult-18158"></span>
+
+### `data DsoRules_StartSvOnboardingResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesstartsvonboardingresult-27583"></span>
+
+- `DsoRules_StartSvOnboardingResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| onboardingRequest | ContractId SvOnboardingRequest |  |
+
+Instances:
+
+- `instance GetField onboardingRequest DsoRules_StartSvOnboardingResult (ContractId SvOnboardingRequest)`
+- `instance SetField onboardingRequest DsoRules_StartSvOnboardingResult (ContractId SvOnboardingRequest)`
+- `instance HasExercise DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult`
+- `instance HasToAnyChoice DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult`
+
+<span id="type-splice-dsorules-dsorulessubmitstatusreportresult-52083"></span>
+
+### `data DsoRules_SubmitStatusReportResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulessubmitstatusreportresult-24832"></span>
+
+- `DsoRules_SubmitStatusReportResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newReport | ContractId SvStatusReport |  |
+
+Instances:
+
+- `instance GetField newReport DsoRules_SubmitStatusReportResult (ContractId SvStatusReport)`
+- `instance SetField newReport DsoRules_SubmitStatusReportResult (ContractId SvStatusReport)`
+- `instance HasExercise DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult`
+- `instance HasToAnyChoice DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult`
+
+<span id="type-splice-dsorules-dsorulesterminatesubscriptionresult-840"></span>
+
+### `data DsoRules_TerminateSubscriptionResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesterminatesubscriptionresult-26229"></span>
+
+- `DsoRules_TerminateSubscriptionResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult`
+
+<span id="type-splice-dsorules-dsorulesupdateamuletpricevoteresult-31774"></span>
+
+### `data DsoRules_UpdateAmuletPriceVoteResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesupdateamuletpricevoteresult-27803"></span>
+
+- `DsoRules_UpdateAmuletPriceVoteResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletPriceVote | ContractId AmuletPriceVote |  |
+
+Instances:
+
+- `instance GetField amuletPriceVote DsoRules_UpdateAmuletPriceVoteResult (ContractId AmuletPriceVote)`
+- `instance SetField amuletPriceVote DsoRules_UpdateAmuletPriceVoteResult (ContractId AmuletPriceVote)`
+- `instance HasExercise DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult`
+- `instance HasToAnyChoice DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult`
+
+<span id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-26858"></span>
+
+### `data DsoRules_UpdateExternalPartyConfigStatesResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-3139"></span>
+
+- `DsoRules_UpdateExternalPartyConfigStatesResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newExternalPartyConfigStateCid | ContractId ExternalPartyConfigState |  |
+
+Instances:
+
+- `instance Eq DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance Show DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance GetField newExternalPartyConfigStateCid DsoRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance SetField newExternalPartyConfigStateCid DsoRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance HasExercise DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasToAnyChoice DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult`
+
+<span id="type-splice-dsorules-dsorulesupdatesvrewardweightresult-38140"></span>
+
+### `data DsoRules_UpdateSvRewardWeightResult`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsorulesupdatesvrewardweightresult-2499"></span>
+
+- `DsoRules_UpdateSvRewardWeightResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_UpdateSvRewardWeightResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_UpdateSvRewardWeightResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult`
+- `instance HasToAnyChoice DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult`
+
+<span id="type-splice-dsorules-dsosummary-18963"></span>
+
+### `data DsoSummary`
+
+Constructors:
+
+<span id="constr-splice-dsorules-dsosummary-70086"></span>
+
+- `DsoSummary`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dsoDelegate | Party | __Deprecated__ in favor of delegateless automation. |
+| numSvs | Int |  |
+| requiredNumVotes | Int | The number of votes required for considering a confirmation, or a request for a vote |
+
+Instances:
+
+- `instance Eq DsoSummary`
+- `instance Show DsoSummary`
+- `instance GetField dsoDelegate DsoSummary Party`
+- `instance GetField numSvs DsoSummary Int`
+- `instance GetField requiredNumVotes DsoSummary Int`
+- `instance SetField dsoDelegate DsoSummary Party`
+- `instance SetField numSvs DsoSummary Int`
+- `instance SetField requiredNumVotes DsoSummary Int`
+
+<span id="type-splice-dsorules-electionrequestreason-11906"></span>
+
+### `data ElectionRequestReason`
+
+__Deprecated__ in favor of delegateless automation.
+
+Constructors:
+
+<span id="constr-splice-dsorules-errdsodelegateunavailable-67703"></span>
+
+- `ERR_DsoDelegateUnavailable`
+
+<span id="constr-splice-dsorules-errotherreason-56585"></span>
+
+- `ERR_OtherReason Text`
+
+<span id="constr-splice-dsorules-extelectionrequestreason-65169"></span>
+
+- `ExtElectionRequestReason`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+
+Instances:
+
+- `instance Eq ElectionRequestReason`
+- `instance Ord ElectionRequestReason`
+- `instance Show ElectionRequestReason`
+- `instance GetField dummyUnitField ElectionRequestReason ()`
+- `instance GetField reason DsoRules_RequestElection ElectionRequestReason`
+- `instance GetField reason ElectionRequest ElectionRequestReason`
+- `instance SetField dummyUnitField ElectionRequestReason ()`
+- `instance SetField reason DsoRules_RequestElection ElectionRequestReason`
+- `instance SetField reason ElectionRequest ElectionRequestReason`
+
+<span id="type-splice-dsorules-logicalsynchronizerupgradeschedule-67809"></span>
+
+### `data LogicalSynchronizerUpgradeSchedule`
+
+Constructors:
+
+<span id="constr-splice-dsorules-logicalsynchronizerupgradeschedule-50336"></span>
+
+- `LogicalSynchronizerUpgradeSchedule`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| topologyFreezeTime | Time | The time at which topology transactions will be frozen. Note that this time is used by the automation<br/><br/>to initiate the topology transactions for freezing. The actual freeze time is the effective time of the topology transaction. |
+| upgradeTime | Time | The time at which the upgrade to the new physical synchronizer will happen. |
+| newPhysicalSynchronizerSerial | Int | The serial of the new physical synchronizer. Usually just the serial of the old physical synchronizer + 1. |
+| newPhysicalSynchronizerProtocolVersion | Text | The protocol version of the new physical synchronizer |
+
+Instances:
+
+- `instance Patchable LogicalSynchronizerUpgradeSchedule`
+- `instance Eq LogicalSynchronizerUpgradeSchedule`
+- `instance Show LogicalSynchronizerUpgradeSchedule`
+- `instance GetField newPhysicalSynchronizerProtocolVersion LogicalSynchronizerUpgradeSchedule Text`
+- `instance GetField newPhysicalSynchronizerSerial LogicalSynchronizerUpgradeSchedule Int`
+- `instance GetField nextScheduledLogicalSynchronizerUpgrade DsoRulesConfig (Optional LogicalSynchronizerUpgradeSchedule)`
+- `instance GetField topologyFreezeTime LogicalSynchronizerUpgradeSchedule Time`
+- `instance GetField upgradeTime LogicalSynchronizerUpgradeSchedule Time`
+- `instance SetField newPhysicalSynchronizerProtocolVersion LogicalSynchronizerUpgradeSchedule Text`
+- `instance SetField newPhysicalSynchronizerSerial LogicalSynchronizerUpgradeSchedule Int`
+- `instance SetField nextScheduledLogicalSynchronizerUpgrade DsoRulesConfig (Optional LogicalSynchronizerUpgradeSchedule)`
+- `instance SetField topologyFreezeTime LogicalSynchronizerUpgradeSchedule Time`
+- `instance SetField upgradeTime LogicalSynchronizerUpgradeSchedule Time`
+
+<span id="type-splice-dsorules-offboardedsvinfo-61414"></span>
+
+### `data OffboardedSvInfo`
+
+Information about offboarded svs
+
+Constructors:
+
+<span id="constr-splice-dsorules-offboardedsvinfo-34519"></span>
+
+- `OffboardedSvInfo`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| name | Text | Human-readable name; must be unique. |
+| participantId | Text | Participant ID of the offboarded SV. |
+
+Instances:
+
+- `instance Eq OffboardedSvInfo`
+- `instance Show OffboardedSvInfo`
+- `instance GetField name OffboardedSvInfo Text`
+- `instance GetField offboardedSvs DsoRules (Map Party OffboardedSvInfo)`
+- `instance GetField participantId OffboardedSvInfo Text`
+- `instance SetField name OffboardedSvInfo Text`
+- `instance SetField offboardedSvs DsoRules (Map Party OffboardedSvInfo)`
+- `instance SetField participantId OffboardedSvInfo Text`
+
+<span id="type-splice-dsorules-reason-36941"></span>
+
+### `data Reason`
+
+Constructors:
+
+<span id="constr-splice-dsorules-reason-51132"></span>
+
+- `Reason`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| url | Text | Url pointing to additional background on the reason, e.g., using a https://w3c-ccg.github.io/hashlink/ |
+| body | Text | Freeform text intended for human consumption. |
+
+Instances:
+
+- `instance Eq Reason`
+- `instance Show Reason`
+- `instance GetField body Reason Text`
+- `instance GetField reason DsoRules_RequestVote Reason`
+- `instance GetField reason Vote Reason`
+- `instance GetField reason VoteRequest Reason`
+- `instance GetField url Reason Text`
+- `instance SetField body Reason Text`
+- `instance SetField reason DsoRules_RequestVote Reason`
+- `instance SetField reason Vote Reason`
+- `instance SetField reason VoteRequest Reason`
+- `instance SetField url Reason Text`
+
+<span id="type-splice-dsorules-svinfo-76274"></span>
+
+### `data SvInfo`
+
+Information about SVs relevant to DSO governance.
+
+Constructors:
+
+<span id="constr-splice-dsorules-svinfo-69131"></span>
+
+- `SvInfo`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| name | Text | Human-readable name; must be unique. |
+| joinedAsOfRound | Round | Round in which the SV joined |
+| svRewardWeight | Int | Weight of the SV in the SV reward distribution. |
+| participantId | Text | Participant ID of the SV, stored here as PartyToParticipant mappings are tracked via state on the DsoRules + SvOnboardingConfirmed contracts. |
+
+Instances:
+
+- `instance Eq SvInfo`
+- `instance Show SvInfo`
+- `instance GetField joinedAsOfRound SvInfo Round`
+- `instance GetField name SvInfo Text`
+- `instance GetField participantId SvInfo Text`
+- `instance GetField svRewardWeight SvInfo Int`
+- `instance GetField svs DsoRules (Map Party SvInfo)`
+- `instance SetField joinedAsOfRound SvInfo Round`
+- `instance SetField name SvInfo Text`
+- `instance SetField participantId SvInfo Text`
+- `instance SetField svRewardWeight SvInfo Int`
+- `instance SetField svs DsoRules (Map Party SvInfo)`
+
+<span id="type-splice-dsorules-synchronizerupgradeschedule-64447"></span>
+
+### `data SynchronizerUpgradeSchedule`
+
+Constructors:
+
+<span id="constr-splice-dsorules-synchronizerupgradeschedule-53308"></span>
+
+- `SynchronizerUpgradeSchedule`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| time | Time | The time at which the migration is scheduled to start. |
+| migrationId | Int | The incremental integer ID of the migration. |
+
+Instances:
+
+- `instance Patchable SynchronizerUpgradeSchedule`
+- `instance Eq SynchronizerUpgradeSchedule`
+- `instance Show SynchronizerUpgradeSchedule`
+- `instance GetField migrationId SynchronizerUpgradeSchedule Int`
+- `instance GetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance GetField time SynchronizerUpgradeSchedule Time`
+- `instance SetField migrationId SynchronizerUpgradeSchedule Int`
+- `instance SetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance SetField time SynchronizerUpgradeSchedule Time`
+
+<span id="type-splice-dsorules-trafficstate-38069"></span>
+
+### `data TrafficState`
+
+Constructors:
+
+<span id="constr-splice-dsorules-trafficstate-23304"></span>
+
+- `TrafficState`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| consumedTraffic | Int | Bytes of extra traffic consumed before the decentralized synchronizer was bootstrapped. |
+
+Instances:
+
+- `instance Eq TrafficState`
+- `instance Show TrafficState`
+- `instance GetField consumedTraffic TrafficState Int`
+- `instance GetField initialTrafficState DsoBootstrap (Map Text TrafficState)`
+- `instance GetField initialTrafficState DsoRules (Map Text TrafficState)`
+- `instance SetField consumedTraffic TrafficState Int`
+- `instance SetField initialTrafficState DsoBootstrap (Map Text TrafficState)`
+- `instance SetField initialTrafficState DsoRules (Map Text TrafficState)`
+
+<span id="type-splice-dsorules-vote-50851"></span>
+
+### `data Vote`
+
+A vote cast by an SV.
+
+Constructors:
+
+<span id="constr-splice-dsorules-vote-51690"></span>
+
+- `Vote`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party | The SV party used to submit the vote. |
+| accept | Bool | Whether the responder accepted the request to execute the action or not. |
+| reason | Reason | The reason for voting this way. |
+| optCastAt | Optional Time | The time when the vote was cast. Used to rate-limit the casting of votes. |
+
+Instances:
+
+- `instance Eq Vote`
+- `instance Show Vote`
+- `instance GetField accept Vote Bool`
+- `instance GetField optCastAt Vote (Optional Time)`
+- `instance GetField reason Vote Reason`
+- `instance GetField sv Vote Party`
+- `instance GetField vote DsoRules_CastVote Vote`
+- `instance GetField votes VoteRequest (Map Text Vote)`
+- `instance SetField accept Vote Bool`
+- `instance SetField optCastAt Vote (Optional Time)`
+- `instance SetField reason Vote Reason`
+- `instance SetField sv Vote Party`
+- `instance SetField vote DsoRules_CastVote Vote`
+- `instance SetField votes VoteRequest (Map Text Vote)`
+
+<span id="type-splice-dsorules-voterequestoutcome-63724"></span>
+
+### `data VoteRequestOutcome`
+
+Constructors:
+
+<span id="constr-splice-dsorules-vroacceptedbutactionfailed-51100"></span>
+
+- `VRO_AcceptedButActionFailed`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| description | Text | Description of the failure. |
+
+<span id="constr-splice-dsorules-vroaccepted-67803"></span>
+
+- `VRO_Accepted`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| effectiveAt | Time | Time when the action will be effective. |
+
+<span id="constr-splice-dsorules-vrorejected-43182"></span>
+
+- `VRO_Rejected`
+
+<span id="constr-splice-dsorules-vroexpired-35522"></span>
+
+- `VRO_Expired`
+
+<span id="constr-splice-dsorules-extvoterequestoutcome-76073"></span>
+
+- `ExtVoteRequestOutcome`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () |  |
+
+Instances:
+
+- `instance Eq VoteRequestOutcome`
+- `instance Show VoteRequestOutcome`
+- `instance GetField description VoteRequestOutcome Text`
+- `instance GetField dummyUnitField VoteRequestOutcome ()`
+- `instance GetField effectiveAt VoteRequestOutcome Time`
+- `instance GetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+- `instance SetField description VoteRequestOutcome Text`
+- `instance SetField dummyUnitField VoteRequestOutcome ()`
+- `instance SetField effectiveAt VoteRequestOutcome Time`
+- `instance SetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+
+<span id="type-splice-dsorules-votingstate-60200"></span>
+
+### `data VotingState a`
+
+__Deprecated__ in favor of delegateless automation.
+Functions implementing instant-runoff voting
+
+Constructors:
+
+<span id="constr-splice-dsorules-votingstate-26047"></span>
+
+- `VotingState`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rankings | Map a [[a]] | Candidate and the remaining rankings in case that candidate is eliminated. |
+| loosers | Set a | Loosers are tracked explicitly and removed lazily to avoid the cubic runtime<br/><br/>that would result from filtering the remaining rankings eagerly. |
+
+Instances:
+
+- `instance Ord a => Eq (VotingState a)`
+- `instance (Show a, Ord a) => Show (VotingState a)`
+- `instance GetField loosers (VotingState a) (Set a)`
+- `instance GetField rankings (VotingState a) (Map a [[a]])`
+- `instance SetField loosers (VotingState a) (Set a)`
+- `instance SetField rankings (VotingState a) (Map a [[a]])`
 
 ## Functions
 
-<div id="function-splice-dsorules-getvotecooldowntime-44916">
+<span id="function-splice-dsorules-getvotecooldowntime-44916"></span>
 
-getVoteCooldownTime
-: DsoRulesConfig -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+### `getVoteCooldownTime`
+
+```daml
+getVoteCooldownTime : DsoRulesConfig -> RelTime
+```
 
 Read the `voteCooldownTime` from the `DsoRulesConfig` with a default value of 1 minute.
 
-</div>
+<span id="function-splice-dsorules-pruneatleastone-36934"></span>
 
-<div id="function-splice-dsorules-pruneatleastone-36934">
+### `pruneAtLeastOne`
 
-pruneAtLeastOne
-: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) (Schedule t a)
+```daml
+pruneAtLeastOne : Ord t => t -> Schedule t a -> Optional (Schedule t a)
+```
 
-</div>
+<span id="function-splice-dsorules-summarizedso-49860"></span>
 
-<div id="function-splice-dsorules-summarizedso-49860">
+### `summarizeDso`
 
-summarizeDso
-: DsoRules -\> DsoSummary
+```daml
+summarizeDso : DsoRules -> DsoSummary
+```
 
-</div>
+<span id="function-splice-dsorules-executeactionrequiringconfirmation-87907"></span>
 
-<div id="function-splice-dsorules-executeactionrequiringconfirmation-87907">
+### `executeActionRequiringConfirmation`
 
-executeActionRequiringConfirmation
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules) -\> ActionRequiringConfirmation -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+executeActionRequiringConfirmation : Party -> ContractId DsoRules -> Optional (ContractId AmuletRules) -> ActionRequiringConfirmation -> Update ()
+```
 
-Execute an action which requires certain number of confirmations from SVs. Each confirmed action can at most be executed once.
+Execute an action which requires certain number of confirmations from SVs.
+Each confirmed action can at most be executed once.
 
-</div>
+<span id="function-splice-dsorules-requirewellformedreason-26428"></span>
 
-<div id="function-splice-dsorules-requirewellformedreason-26428">
+### `requireWellformedReason`
 
-requireWellformedReason
-: DsoRulesConfig -\> Reason -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+requireWellformedReason : DsoRulesConfig -> Reason -> Update ()
+```
 
-</div>
+<span id="function-splice-dsorules-requirewellformedvote-94014"></span>
 
-<div id="function-splice-dsorules-requirewellformedvote-94014">
+### `requireWellformedVote`
 
-requireWellformedVote
-: DsoRulesConfig -\> Vote -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+requireWellformedVote : DsoRulesConfig -> Vote -> Update ()
+```
 
-</div>
+<span id="function-splice-dsorules-ensurenotexpired-58839"></span>
 
-<div id="function-splice-dsorules-ensurenotexpired-58839">
+### `ensureNotExpired`
 
-ensureNotExpired
-: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+ensureNotExpired : Time -> Update ()
+```
 
-</div>
+<span id="function-splice-dsorules-actionrequiringconfirmationeffectiveat-38122"></span>
 
-<div id="function-splice-dsorules-actionrequiringconfirmationeffectiveat-38122">
+### `actionRequiringConfirmationEffectiveAt`
 
-actionRequiringConfirmationEffectiveAt
-: ActionRequiringConfirmation -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+```daml
+actionRequiringConfirmationEffectiveAt : ActionRequiringConfirmation -> Optional Time
+```
 
 Get the future-dated effectiveAt of an action requiring confirmation.
 
-</div>
+<span id="function-splice-dsorules-getsvinfo-85569"></span>
 
-<div id="function-splice-dsorules-getsvinfo-85569">
+### `getSvInfo`
 
-getSvInfo
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> DsoRules -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) SvInfo
+```daml
+getSvInfo : Party -> DsoRules -> Update SvInfo
+```
 
-</div>
+<span id="function-splice-dsorules-lookupsvinfobyname-29850"></span>
 
-<div id="function-splice-dsorules-lookupsvinfobyname-29850">
+### `lookupSvInfoByName`
 
-lookupSvInfoByName
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> DsoRules -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), SvInfo)
+```daml
+lookupSvInfoByName : Text -> DsoRules -> Optional (Party, SvInfo)
+```
 
-</div>
+<span id="function-splice-dsorules-svhasbeenonboardedbefore-57101"></span>
 
-<div id="function-splice-dsorules-svhasbeenonboardedbefore-57101">
+### `svHasBeenOnboardedBefore`
 
-svHasBeenOnboardedBefore
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> DsoRules -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+svHasBeenOnboardedBefore : Text -> DsoRules -> Bool
+```
 
-Returns True if an SV with that name is either currently onboarded or an SV with that name has been onboarded before and is now in offboardedSvs.
+Returns True if an SV with that name is either currently onboarded
+or an SV with that name has been onboarded before and is now in offboardedSvs.
 
-</div>
+<span id="function-splice-dsorules-ensureneveroperatednode-60956"></span>
 
-<div id="function-splice-dsorules-ensureneveroperatednode-60956">
+### `ensureNeverOperatedNode`
 
-ensureNeverOperatedNode
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> DsoRules -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+ensureNeverOperatedNode : Party -> DsoRules -> Update ()
+```
 
-</div>
+<span id="function-splice-dsorules-dsorulesaddsv-73633"></span>
 
-<div id="function-splice-dsorules-dsorulesaddsv-73633">
+### `dsoRules_addSv`
 
-dsoRules_addSv
-: DsoRules -\> DsoRules_AddSv -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+```daml
+dsoRules_addSv : DsoRules -> DsoRules_AddSv -> Update (ContractId DsoRules)
+```
 
-</div>
+<span id="function-splice-dsorules-createpersvcontracts-25068"></span>
 
-<div id="function-splice-dsorules-createpersvcontracts-25068">
+### `createPerSvContracts`
 
-createPerSvContracts
-: DsoRules -\> DsoRules_AddSv -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+createPerSvContracts : DsoRules -> DsoRules_AddSv -> Update ()
+```
 
-</div>
+<span id="function-splice-dsorules-createpersvpartycontracts-3309"></span>
 
-<div id="function-splice-dsorules-createpersvpartycontracts-3309">
+### `createPerSvPartyContracts`
 
-createPerSvPartyContracts
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> SynchronizerNodeConfigMap -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+createPerSvPartyContracts : Party -> Party -> Text -> SynchronizerNodeConfigMap -> Optional Decimal -> RelTime -> Update ()
+```
 
-</div>
+<span id="function-splice-dsorules-getandvalidatesvparty-72916"></span>
 
-<div id="function-splice-dsorules-getandvalidatesvparty-72916">
+### `getAndValidateSvParty`
 
-getAndValidateSvParty
-: DsoRules -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+```daml
+getAndValidateSvParty : DsoRules -> Optional Party -> Update Party
+```
 
-</div>
+<span id="function-splice-dsorules-enforcecooldown-11925"></span>
 
-<div id="function-splice-dsorules-enforcecooldown-11925">
+### `enforceCooldown`
 
-enforceCooldown
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+enforceCooldown : Text -> RelTime -> Optional Time -> Update ()
+```
 
 Enforce that an action is not performed again before a cooldown period has passed.
 
-</div>
+## Templates
 
-{/* COPIED_END */}
+<span id="type-splice-dsorules-bootstrapexternalpartyconfigstateinstruction-72557"></span>
+
+### Template `BootstrapExternalPartyConfigStateInstruction`
+
+Instruction to bootstrap the external party config state.
+This exists so that the `ActionRequiringConfirmation` for this is independent of the
+current rounds which we need so that we can do deduplication by action hash
+in our automation.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dsorules-confirmation-62984"></span>
+
+### Template `Confirmation`
+
+A confirmation for the SVs to take action as part of standard DSO.
+Used for executing automated actions in a shortened process.
+See the comments on `ActionRequiringConfirmation` for details.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| confirmer | Party |  |
+| action | ActionRequiringConfirmation |  |
+| expiresAt | Time |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dsorules-confirmationexpire-84183"></span>
+
+#### Choice `Confirmation_Expire`
+
+Controllers: `dso`
+
+Returns: `Confirmation_ExpireResult`
+
+<span id="type-splice-dsorules-dsorules-35440"></span>
+
+### Template `DsoRules`
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| epoch | Int |  |
+| svs | Map Party SvInfo |  |
+| offboardedSvs | Map Party OffboardedSvInfo |  |
+| dsoDelegate | Party | __Deprecated__ in favor of delegateless automation. |
+| config | DsoRulesConfig |  |
+| initialTrafficState | Map Text TrafficState | Map from participant/mediator ID to its traffic state at the time of synchronizer bootstrapping. Used for testing, empty in prod. |
+| isDevNet | Bool |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dsorules-dsorulesaddconfirmedsv-22105"></span>
+
+#### Choice `DsoRules_AddConfirmedSv`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AddConfirmedSvResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| svOnboardingConfirmedCid | ContractId SvOnboardingConfirmed |  |
+| earliestRoundCid | ContractId OpenMiningRound |  |
+| middleRoundCid | ContractId OpenMiningRound |  |
+| latestRoundCid | ContractId OpenMiningRound |  |
+| amuletRulesCid | ContractId AmuletRules |  |
+
+<span id="type-splice-dsorules-dsorulesaddsv-44293"></span>
+
+#### Choice `DsoRules_AddSv`
+
+Controllers: `dso`
+
+Returns: `DsoRules_AddSvResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newSvParty | Party |  |
+| newSvName | Text |  |
+| newSvRewardWeight | Int |  |
+| newSvParticipantId | Text |  |
+| joinedAsOfRound | Round |  |
+
+<span id="type-splice-dsorules-dsorulesadvanceopenminingrounds-34192"></span>
+
+#### Choice `DsoRules_AdvanceOpenMiningRounds`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AdvanceOpenMiningRoundsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| roundToArchiveCid | ContractId OpenMiningRound |  |
+| middleRoundCid | ContractId OpenMiningRound |  |
+| latestRoundCid | ContractId OpenMiningRound |  |
+| amuletPriceVoteCids | [ContractId AmuletPriceVote] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecord-56787"></span>
+
+#### Choice `DsoRules_AllocateUnallocatedUnclaimedActivityRecord`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unallocatedUnclaimedActivityRecordCid | ContractId UnallocatedUnclaimedActivityRecord |  |
+| amuletRulesCid | ContractId AmuletRules |  |
+| unclaimedRewardsToBurnCids | [ContractId UnclaimedReward] | A sufficient list of `UnclaimedReward` to be archived.<br/><br/>It must cover at least the requested amount. |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkers-52437"></span>
+
+#### Choice `DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| argument | AmuletRules_ConvertFeaturedAppActivityMarkers |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesamuletexpire-71495"></span>
+
+#### Choice `DsoRules_Amulet_Expire`
+
+Controllers: `sv`
+
+Returns: `DsoRules_Amulet_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Amulet |  |
+| choiceArg | Amulet_Expire |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesamuletexpiretransferinstructions-57305"></span>
+
+#### Choice `DsoRules_Amulet_ExpireTransferInstructions`
+
+Controllers: `sv`
+
+Returns: `DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| transferInsts | AmuletRules_Amulet_ExpireTransferInstructions |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesamuletexpirev2-61973"></span>
+
+#### Choice `DsoRules_Amulet_ExpireV2`
+
+Controllers: `sv`
+
+Returns: `DsoRules_Amulet_ExpireV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Amulet |  |
+| choiceArg | Amulet_ExpireV2 |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequest-55064"></span>
+
+#### Choice `DsoRules_ArchiveOutdatedElectionRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ArchiveOutdatedElectionRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId ElectionRequest |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesarchivesvonboardingrequest-72075"></span>
+
+#### Choice `DsoRules_ArchiveSvOnboardingRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ArchiveSvOnboardingRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svOnboardingRequestCid | ContractId SvOnboardingRequest |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstate-94209"></span>
+
+#### Choice `DsoRules_BootstrapExternalPartyConfigState`
+
+Controllers: `sv`
+
+Returns: `DsoRules_BootstrapExternalPartyConfigStateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| instructionCid | ContractId BootstrapExternalPartyConfigStateInstruction |  |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulescastvote-63161"></span>
+
+#### Choice `DsoRules_CastVote`
+
+Controllers: `(DA.Internal.Record.getField @"sv" vote)`
+
+Returns: `DsoRules_CastVoteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId VoteRequest |  |
+| vote | Vote |  |
+
+<span id="type-splice-dsorules-dsorulesclaimexpiredrewards-16372"></span>
+
+#### Choice `DsoRules_ClaimExpiredRewards`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ClaimExpiredRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| choiceArg | AmuletRules_ClaimExpiredRewards |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesclosevoterequest-87527"></span>
+
+#### Choice `DsoRules_CloseVoteRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_CloseVoteRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId VoteRequest |  |
+| amuletRulesCid | Optional (ContractId AmuletRules) |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulescollectentryrenewalpayment-93166"></span>
+
+#### Choice `DsoRules_CollectEntryRenewalPayment`
+
+Controllers: `sv`
+
+Returns: `DsoRules_CollectEntryRenewalPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| choiceArg | AnsEntryContext_CollectEntryRenewalPayment |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesconfirmaction-67097"></span>
+
+#### Choice `DsoRules_ConfirmAction`
+
+Controllers: `confirmer`
+
+Returns: `DsoRules_ConfirmActionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| confirmer | Party |  |
+| action | ActionRequiringConfirmation |  |
+
+<span id="type-splice-dsorules-dsorulesconfirmsvonboarding-94029"></span>
+
+#### Choice `DsoRules_ConfirmSvOnboarding`
+
+Controllers: `dso`
+
+Returns: `DsoRules_ConfirmSvOnboardingResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newSvParty | Party |  |
+| newSvName | Text |  |
+| newParticipantId | Text |  |
+| newSvRewardWeight | Int |  |
+| reason | Text |  |
+
+<span id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstruction-1552"></span>
+
+#### Choice `DsoRules_CreateBootstrapExternalPartyConfigStateInstruction`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+<span id="type-splice-dsorules-dsorulescreateexternalpartyamuletrules-62448"></span>
+
+#### Choice `DsoRules_CreateExternalPartyAmuletRules`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateExternalPartyAmuletRulesResult`
+
+<span id="type-splice-dsorules-dsorulescreatetransfercommandcounter-44220"></span>
+
+#### Choice `DsoRules_CreateTransferCommandCounter`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateTransferCommandCounterResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+
+<span id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecord-78616"></span>
+
+#### Choice `DsoRules_CreateUnallocatedUnclaimedActivityRecord`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party |  |
+| amount | Decimal |  |
+| reason | Text |  |
+| expiresAt | Time |  |
+
+<span id="type-splice-dsorules-dsoruleselectdsodelegate-82924"></span>
+
+#### Choice `DsoRules_ElectDsoDelegate`
+
+Controllers: `actor`
+
+Returns: `DsoRules_ElectDsoDelegateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| requestCids | [ContractId ElectionRequest] |  |
+
+<span id="type-splice-dsorules-dsorulesexecuteconfirmedaction-18028"></span>
+
+#### Choice `DsoRules_ExecuteConfirmedAction`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExecuteConfirmedActionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| action | ActionRequiringConfirmation |  |
+| amuletRulesCid | Optional (ContractId AmuletRules) |  |
+| confirmationCids | [ContractId Confirmation] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpireamuletallocations-76865"></span>
+
+#### Choice `DsoRules_ExpireAmuletAllocations`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireAmuletAllocationsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extAmuletRulesCid | ContractId ExternalPartyAmuletRules |  |
+| expireAllocations | ExternalPartyAmuletRules_ExpireAmuletAllocations |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpireansentry-58167"></span>
+
+#### Choice `DsoRules_ExpireAnsEntry`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireAnsEntryResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryCid | ContractId AnsEntry |  |
+| choiceArg | AnsEntry_Expire |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpiredevelopmentfundcoupon-65446"></span>
+
+#### Choice `DsoRules_ExpireDevelopmentFundCoupon`
+
+Expires a DevelopmentFundCoupon and produces an UnclaimedDevelopmentFundCoupon with the same amount.
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireDevelopmentFundCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| developmentFundCouponCid | ContractId DevelopmentFundCoupon |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpirestaleconfirmation-23846"></span>
+
+#### Choice `DsoRules_ExpireStaleConfirmation`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireStaleConfirmationResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| staleConfirmationCid | ContractId Confirmation |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpiresubscription-15972"></span>
+
+#### Choice `DsoRules_ExpireSubscription`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| subscriptionIdleStateCid | ContractId SubscriptionIdleState |  |
+| choiceArg | SubscriptionIdleState_ExpireSubscription |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmed-60809"></span>
+
+#### Choice `DsoRules_ExpireSvOnboardingConfirmed`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireSvOnboardingConfirmedResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId SvOnboardingConfirmed |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpiresvonboardingrequest-63611"></span>
+
+#### Choice `DsoRules_ExpireSvOnboardingRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireSvOnboardingRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId SvOnboardingRequest |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpiretransferpreapproval-91729"></span>
+
+#### Choice `DsoRules_ExpireTransferPreapproval`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireTransferPreapprovalResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecord-90041"></span>
+
+#### Choice `DsoRules_ExpireUnallocatedUnclaimedActivityRecord`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unallocatedUnclaimedActivityRecordCid | ContractId UnallocatedUnclaimedActivityRecord |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecord-57856"></span>
+
+#### Choice `DsoRules_ExpireUnclaimedActivityRecord`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedActivityRecordCid | ContractId UnclaimedActivityRecord |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotes-77719"></span>
+
+#### Choice `DsoRules_GarbageCollectAmuletPriceVotes`
+
+Garbage-collect AmuletPriceVotes from removed svs and duplicate ones that might
+happen due to a too quick removal and re-addition of a sv.
+We expect this to be run as an OnAssignedContractTrigger for the DsoRules contract.
+
+Note: we do not archive the AmuletPriceVote of an SV on its removal,
+as that would allow that SV to block the removal via updating its AmuletPriceVote at the right time.
+
+TODO(#10063): drop this code in favor of just keeping AmuletPriceVotes around.
+
+Controllers: `sv`
+
+Returns: `DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| nonSvVoteCids | [ContractId AmuletPriceVote] |  |
+| duplicateVoteCids | [[ContractId AmuletPriceVote]] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesgrantfeaturedappright-79910"></span>
+
+#### Choice `DsoRules_GrantFeaturedAppRight`
+
+Controllers: `dso`
+
+Returns: `DsoRules_GrantFeaturedAppRightResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party |  |
+
+<span id="type-splice-dsorules-dsoruleslockedamuletexpireamulet-28275"></span>
+
+#### Choice `DsoRules_LockedAmulet_ExpireAmulet`
+
+Controllers: `sv`
+
+Returns: `DsoRules_LockedAmulet_ExpireAmuletResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId LockedAmulet |  |
+| choiceArg | LockedAmulet_ExpireAmulet |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2-91833"></span>
+
+#### Choice `DsoRules_LockedAmulet_ExpireAmuletV2`
+
+Controllers: `sv`
+
+Returns: `DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId LockedAmulet |  |
+| choiceArg | LockedAmulet_ExpireAmuletV2 |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesmergemembertrafficcontracts-34275"></span>
+
+#### Choice `DsoRules_MergeMemberTrafficContracts`
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeMemberTrafficContractsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| trafficCids | [ContractId MemberTraffic] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesmergesvrewardstate-39851"></span>
+
+#### Choice `DsoRules_MergeSvRewardState`
+
+Note this choice only exists to clean up duplicate contracts caused by the bug in #12495.
+There should never be duplicates going forward.
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeSvRewardStateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svName | Text |  |
+| rewardStateCids | [ContractId SvRewardState] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcoupons-23755"></span>
+
+#### Choice `DsoRules_MergeUnclaimedDevelopmentFundCoupons`
+
+Batch merge of of development fund coupons.
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| choiceArg | AmuletRules_MergeUnclaimedDevelopmentFundCoupons |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesmergeunclaimedrewards-12383"></span>
+
+#### Choice `DsoRules_MergeUnclaimedRewards`
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeUnclaimedRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| unclaimedRewardCids | [ContractId UnclaimedReward] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesmergevalidatorlicense-65804"></span>
+
+#### Choice `DsoRules_MergeValidatorLicense`
+
+Note: removes the old duplicated licenses and creates a new one with the highest lastReceivedFor round
+There should never be duplicates going forward.
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeValidatorLicenseResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorLicenseCids | [ContractId ValidatorLicense] |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesminingroundclose-28010"></span>
+
+#### Choice `DsoRules_MiningRound_Close`
+
+Controllers: `sv`
+
+Returns: `DsoRules_MiningRound_CloseResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| issuingRoundCid | ContractId IssuingMiningRound |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesoffboardsv-78636"></span>
+
+#### Choice `DsoRules_OffboardSv`
+
+Controllers: `dso`
+
+Returns: `DsoRules_OffboardSvResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesonboardvalidator-23909"></span>
+
+#### Choice `DsoRules_OnboardValidator`
+
+Controllers: `sponsor`
+
+Returns: `DsoRules_OnboardValidatorResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sponsor | Party |  |
+| validator | Party |  |
+| version | Optional Text |  |
+| contactPoint | Optional Text |  |
+
+<span id="type-splice-dsorules-dsorulespruneamuletconfigschedule-70948"></span>
+
+#### Choice `DsoRules_PruneAmuletConfigSchedule`
+
+Controllers: `sv`
+
+Returns: `DsoRules_PruneAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesreceivesvrewardcoupon-83972"></span>
+
+#### Choice `DsoRules_ReceiveSvRewardCoupon`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ReceiveSvRewardCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| openRoundCid | ContractId OpenMiningRound |  |
+| rewardStateCid | ContractId SvRewardState |  |
+| beneficiaries | [(Party, Int)] |  |
+
+<span id="type-splice-dsorules-dsorulesrequestelection-327"></span>
+
+#### Choice `DsoRules_RequestElection`
+
+Controllers: `requester`
+
+Returns: `DsoRules_RequestElectionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requester | Party |  |
+| reason | ElectionRequestReason |  |
+| ranking | [Party] |  |
+
+<span id="type-splice-dsorules-dsorulesrequestvote-27270"></span>
+
+#### Choice `DsoRules_RequestVote`
+
+Controllers: `requester`
+
+Returns: `DsoRules_RequestVoteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requester | Party |  |
+| action | ActionRequiringConfirmation |  |
+| reason | Reason |  |
+| voteRequestTimeout | Optional RelTime |  |
+| targetEffectiveAt | Optional Time |  |
+
+<span id="type-splice-dsorules-dsorulesrevokefeaturedappright-46223"></span>
+
+#### Choice `DsoRules_RevokeFeaturedAppRight`
+
+Controllers: `dso`
+
+Returns: `DsoRules_RevokeFeaturedAppRightResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rightCid | ContractId FeaturedAppRight |  |
+
+<span id="type-splice-dsorules-dsorulessetconfig-76713"></span>
+
+#### Choice `DsoRules_SetConfig`
+
+Controllers: `dso`
+
+Returns: `DsoRules_SetConfigResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newConfig | DsoRulesConfig |  |
+| baseConfig | Optional DsoRulesConfig |  |
+
+<span id="type-splice-dsorules-dsorulessetsynchronizernodeconfig-79561"></span>
+
+#### Choice `DsoRules_SetSynchronizerNodeConfig`
+
+Controllers: `sv`
+
+Returns: `DsoRules_SetSynchronizerNodeConfigResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| synchronizerId | Text |  |
+| newNodeConfig | SynchronizerNodeConfig |  |
+| nodeStateCid | ContractId SvNodeState |  |
+
+<span id="type-splice-dsorules-dsorulesstartsvonboarding-74859"></span>
+
+#### Choice `DsoRules_StartSvOnboarding`
+
+Controllers: `sponsor`
+
+Returns: `DsoRules_StartSvOnboardingResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| candidateName | Text |  |
+| candidateParty | Party |  |
+| candidateParticipantId | Text |  |
+| token | Text |  |
+| sponsor | Party |  |
+
+<span id="type-splice-dsorules-dsorulessubmitstatusreport-89950"></span>
+
+#### Choice `DsoRules_SubmitStatusReport`
+
+Controllers: `sv`
+
+Returns: `DsoRules_SubmitStatusReportResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| previousReportCid | ContractId SvStatusReport |  |
+| status | SvStatus |  |
+
+<span id="type-splice-dsorules-dsorulesterminatesubscription-67561"></span>
+
+#### Choice `DsoRules_TerminateSubscription`
+
+Controllers: `sv`
+
+Returns: `DsoRules_TerminateSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| terminatedSubscriptionCid | ContractId TerminatedSubscription |  |
+| sv | Optional Party |  |
+
+<span id="type-splice-dsorules-dsorulesupdateamuletpricevote-33547"></span>
+
+#### Choice `DsoRules_UpdateAmuletPriceVote`
+
+Controllers: `sv`
+
+Returns: `DsoRules_UpdateAmuletPriceVoteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| voteCid | ContractId AmuletPriceVote |  |
+| amuletPrice | Decimal |  |
+
+<span id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstates-33819"></span>
+
+#### Choice `DsoRules_UpdateExternalPartyConfigStates`
+
+Controllers: `sv`
+
+Returns: `DsoRules_UpdateExternalPartyConfigStatesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| externalPartyConfigStateCid0 | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigStateCid1 | ContractId ExternalPartyConfigState |  |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+| sv | Party |  |
+
+<span id="type-splice-dsorules-dsorulesupdatesvrewardweight-33689"></span>
+
+#### Choice `DsoRules_UpdateSvRewardWeight`
+
+Controllers: `dso`
+
+Returns: `DsoRules_UpdateSvRewardWeightResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svParty | Party |  |
+| newRewardWeight | Int |  |
+
+<span id="type-splice-dsorules-electionrequest-92680"></span>
+
+### Template `ElectionRequest`
+
+__Deprecated__ in favor of delegateless automation.
+
+A request to elect a new DSO delegate.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| requester | Party |  |
+| epoch | Int |  |
+| reason | ElectionRequestReason |  |
+| ranking | [Party] |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dsorules-unallocatedunclaimedactivityrecord-15769"></span>
+
+### Template `UnallocatedUnclaimedActivityRecord`
+
+A governance-approved record representing intent to reward a beneficiary.
+Once sufficient `UnclaimedReward` contracts are allocated and archived,
+this contract results in the creation of a mintable `UnclaimedActivityRecord`.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| beneficiary | Party | The owner of the `Amulet` to be minted |
+| amount | Decimal | The amount of `Amulet` to be minted |
+| reason | Text | A reason to mint the `Amulet` |
+| expiresAt | Time | Selected timestamp defining the lifetime of the UnclaimedActivityRecord contract. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-dsorules-voterequest-12683"></span>
+
+### Template `VoteRequest`
+
+A request for the other svs to vote on the execution of an action requiring confirmation.
+We use this for implementing on-ledger governance actions triggered by SV operators in a uniform way.
+
+See the comments on `ActionRequiringConfirmation` for details.
+
+Version 3, which introduces effectivity in vote request.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| requester | Text | The SV that requested to execute the action. |
+| action | ActionRequiringConfirmation | The action whose confirmation is required. |
+| reason | Reason | The reason for requesting the execution of the action. Typically a reference to some off-ledger justification. |
+| voteBefore | Time | The time before which votes are accepted, and SHOULD be submitted. |
+| votes | Map Text Vote | The votes cast by current or previous SVs. These may be previous SVs in case<br/><br/>there was an SV change after the vote was requested. |
+| trackingCid | Optional (ContractId VoteRequest) | An optional tracking ContractId to be used for tracking the vote request through its updates.<br/><br/>This is always set to the first ContractId of the original vote request (None on creation). |
+| targetEffectiveAt | Optional Time | The time when the action is targeted to be made effective. If None, the action is immediately effective upon 2/3 votes in favor. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+## Orphan Typeclass Instances
+
+- `instance HasCheckedFetch FeaturedAppRight ForDso`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding.mdx
@@ -1,130 +1,136 @@
 ---
 title: "Splice.SvOnboarding"
-description: "Documentation for Splice.SvOnboarding"
+description: "Reference documentation for Daml module Splice.SvOnboarding."
 ---
 
-{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-SvOnboarding.rst" tag="0.6.4" hash="f6ca8a1c" */}
+<span id="module-splice-svonboarding-92564"></span>
 
-## Templates
+# Splice.SvOnboarding
 
-<div id="type-splice-svonboarding-svonboardingconfirmed-6814">
+## Module Snapshot
 
-**template** SvOnboardingConfirmed
-
-</div>
-
-> A confirmation for approval of a candidate SV.
->
-> Once this contract is created, the workflows to onboard that SVs node starts.
->
-> Signatory: dso
->
-> | Field           | Type                                                                                                                | Description                         |
-> |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|
-> | svParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                     |
-> | svName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                     |
-> | svRewardWeight  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |                                     |
-> | svParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                     |
-> | reason          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                     |
-> | dso             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                     |
-> | expiresAt       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When this contract can be archived. |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-svonboarding-svonboardingconfirmedexpire-37945">
->
->   **Choice** SvOnboardingConfirmed_Expire
->
->   </div>
->
->   Controller: dso
->
->   Returns: SvOnboardingConfirmed_ExpireResult
->
->   (no fields)
-
-<div id="type-splice-svonboarding-svonboardingrequest-71856">
-
-**template** SvOnboardingRequest
-
-</div>
-
-> Template used by the SVs to collect confirmations for the onboarding of an SV candidate. The existence of this contract triggers SV automation that creates confirmation contracts for the candidate if the token is a valid `SvOnboardingToken` and matches an `ApprovedSvIdentity`.
->
-> Signatory: dso
->
-> | Field                  | Type                                                                                                                | Description                                                                          |
-> |------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-> | candidateName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Human-readable name of the SV candidate. Must match the one in `ApprovedSvIdentity`! |
-> | candidateParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | PartyId of the candidate SV party.                                                   |
-> | candidateParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | ParticipantId of the candidate SV.                                                   |
-> | token                  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | An encoded and signed `SvOnboardingToken` that confirms the candidate's identity.    |
-> | sponsor                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The established SV node that created this contract.                                  |
-> | dso                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                      |
-> | expiresAt              | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When this contract can be archived even if the onboarding did not succeed.           |
->
-> - **Choice** Archive
->
->   Controller: dso
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-svonboarding-svonboardingrequestexpire-23755">
->
->   **Choice** SvOnboardingRequest_Expire
->
->   </div>
->
->   Controller: dso
->
->   Returns: SvOnboardingRequest_ExpireResult
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-svonboarding-svonboardingconfirmedexpireresult-89548">
+<span id="type-splice-svonboarding-svonboardingconfirmedexpireresult-89548"></span>
 
-**data** SvOnboardingConfirmed_ExpireResult
+### `data SvOnboardingConfirmed_ExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-svonboarding-svonboardingconfirmedexpireresult-55325">
->
-> SvOnboardingConfirmed_ExpireResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult
+<span id="constr-splice-svonboarding-svonboardingconfirmedexpireresult-55325"></span>
 
-<div id="type-splice-svonboarding-svonboardingrequestexpireresult-6542">
+- `SvOnboardingConfirmed_ExpireResult`
 
-**data** SvOnboardingRequest_ExpireResult
+Instances:
 
-</div>
+- `instance HasExercise SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult`
+- `instance HasFromAnyChoice SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult`
+- `instance HasToAnyChoice SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult`
 
-> <div id="constr-splice-svonboarding-svonboardingrequestexpireresult-87875">
->
-> SvOnboardingRequest_ExpireResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult
+<span id="type-splice-svonboarding-svonboardingrequestexpireresult-6542"></span>
 
-{/* COPIED_END */}
+### `data SvOnboardingRequest_ExpireResult`
+
+Constructors:
+
+<span id="constr-splice-svonboarding-svonboardingrequestexpireresult-87875"></span>
+
+- `SvOnboardingRequest_ExpireResult`
+
+Instances:
+
+- `instance HasExercise SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult`
+- `instance HasFromAnyChoice SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult`
+- `instance HasToAnyChoice SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult`
+
+## Templates
+
+<span id="type-splice-svonboarding-svonboardingconfirmed-6814"></span>
+
+### Template `SvOnboardingConfirmed`
+
+A confirmation for approval of a candidate SV.
+
+Once this contract is created, the workflows to onboard that SVs node starts.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svParty | Party |  |
+| svName | Text |  |
+| svRewardWeight | Int |  |
+| svParticipantId | Text |  |
+| reason | Text |  |
+| dso | Party |  |
+| expiresAt | Time | When this contract can be archived. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-svonboarding-svonboardingconfirmedexpire-37945"></span>
+
+#### Choice `SvOnboardingConfirmed_Expire`
+
+Controllers: `dso`
+
+Returns: `SvOnboardingConfirmed_ExpireResult`
+
+<span id="type-splice-svonboarding-svonboardingrequest-71856"></span>
+
+### Template `SvOnboardingRequest`
+
+Template used by the SVs to collect confirmations for the onboarding of an SV candidate.
+The existence of this contract triggers SV automation that creates confirmation contracts for
+the candidate if the token is a valid `SvOnboardingToken` and matches an `ApprovedSvIdentity`.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| candidateName | Text | Human-readable name of the SV candidate. Must match the one in `ApprovedSvIdentity`! |
+| candidateParty | Party | PartyId of the candidate SV party. |
+| candidateParticipantId | Text | ParticipantId of the candidate SV. |
+| token | Text | An encoded and signed `SvOnboardingToken` that confirms the candidate's identity. |
+| sponsor | Party | The established SV node that created this contract. |
+| dso | Party |  |
+| expiresAt | Time | When this contract can be archived even if the onboarding did not succeed. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<span id="type-splice-svonboarding-svonboardingrequestexpire-23755"></span>
+
+#### Choice `SvOnboardingRequest_Expire`
+
+Controllers: `dso`
+
+Returns: `SvOnboardingRequest_ExpireResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index.mdx
@@ -1,14 +1,195 @@
 ---
-title: "splice-test-trading-app docs"
-description: "Documentation for splice-test-trading-app docs"
+title: "splice-token-test-trading-app"
+description: "Reference documentation for splice-token-test-trading-app modules."
 ---
 
-{/* COPIED_START source="splice:token-standard/examples/splice-token-test-trading-app/docs/index.rst" tag="0.6.4" hash="ec7fa10a" */}
+<div class="x2mdx-ref-hero">
 
-A trading app example built on top of the allocation APIs of the Canton Network Token Standard.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-Serves both as an example as well as a test suite for the token standard APIs. See `splice-token-standard-test-docs` for the test harness that uses this trading app example for testing allocation usage and implementations.
 
-- [Splice.Testing.Apps.TradingApp](/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp)
+  <h1 class="x2mdx-ref-title">splice-token-test-trading-app</h1>
 
-{/* COPIED_END */}
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-token-test-trading-app, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Testing.Apps.TradingApp</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">An example of how to build an OTC trading app for multi-leg standard token trades.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp.mdx
@@ -1,181 +1,205 @@
 ---
 title: "Splice.Testing.Apps.TradingApp"
-description: "Documentation for Splice.Testing.Apps.TradingApp"
+description: "Reference documentation for Daml module Splice.Testing.Apps.TradingApp."
 ---
 
-{/* COPIED_START source="splice:token-standard/examples/splice-token-test-trading-app/docs/Splice-Testing-Apps-TradingApp.rst" tag="0.6.4" hash="c0da3034" */}
+<span id="module-splice-testing-apps-tradingapp-19891"></span>
+
+# Splice.Testing.Apps.TradingApp
 
 An example of how to build an OTC trading app for multi-leg standard token trades.
 
 Used as part of the testing infrastructure to test the DvP workflows based on the token standard.
 
-## Templates
+## Module Snapshot
 
-<div id="type-splice-testing-apps-tradingapp-otctrade-80775">
-
-**template** OTCTrade
-
-</div>
-
-> Signatory: venue, tradingParties transferLegs
->
-> | Field        | Type                                                                                                                                           | Description |
-> |--------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> | venue        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                            |             |
-> | transferLegs | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg            |             |
-> | tradeCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal |             |
-> | createdAt    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                              |             |
-> | prepareUntil | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                              |             |
-> | settleBefore | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                              |             |
->
-> - **Choice** Archive
->
->   Controller: venue, tradingParties transferLegs
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-testing-apps-tradingapp-otctradecancel-34465">
->
->   **Choice** OTCTrade_Cancel
->
->   </div>
->
->   Controller: venue
->
->   Returns: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Allocation_CancelResult)
->
->   | Field                  | Type                                                                                                                                                                                                                                                                          | Description |
->   |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | allocationsWithContext | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation, ExtraArgs) |             |
->
-> - <div id="type-splice-testing-apps-tradingapp-otctradesettle-9210">
->
->   **Choice** OTCTrade_Settle
->
->   </div>
->
->   Controller: venue
->
->   Returns: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) Allocation_ExecuteTransferResult
->
->   | Field                  | Type                                                                                                                                                                                                                                                                          | Description |
->   |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | allocationsWithContext | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation, ExtraArgs) |             |
->
-> - **interface instance** AllocationRequest **for** OTCTrade
-
-<div id="type-splice-testing-apps-tradingapp-otctradeproposal-78093">
-
-**template** OTCTradeProposal
-
-</div>
-
-> Signatory: approvers
->
-> | Field        | Type                                                                                                                                                                                                                                                                            | Description                             |
-> |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
-> | venue        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                                             |                                         |
-> | tradeCid     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal) |                                         |
-> | transferLegs | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg                                                                                                                                             |                                         |
-> | approvers    | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                                                                                                                                                         | Parties that have approved the proposal |
->
-> - **Choice** Archive
->
->   Controller: approvers
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-testing-apps-tradingapp-otctradeproposalaccept-97549">
->
->   **Choice** OTCTradeProposal_Accept
->
->   </div>
->
->   Controller: approver
->
->   Returns: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal
->
->   | Field    | Type                                                                                                                | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | approver | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-testing-apps-tradingapp-otctradeproposalinitiatesettlement-54617">
->
->   **Choice** OTCTradeProposal_InitiateSettlement
->
->   </div>
->
->   Controller: venue
->
->   Returns: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTrade
->
->   | Field        | Type                                                                                                              | Description |
->   |--------------|-------------------------------------------------------------------------------------------------------------------|-------------|
->   | prepareUntil | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
->   | settleBefore | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
->
-> - <div id="type-splice-testing-apps-tradingapp-otctradeproposalreject-13148">
->
->   **Choice** OTCTradeProposal_Reject
->
->   </div>
->
->   Controller: trader
->
->   Returns: ()
->
->   | Field  | Type                                                                                                                | Description |
->   |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | trader | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Functions
 
-<div id="function-splice-testing-apps-tradingapp-tradeallocations-16894">
+<span id="function-splice-testing-apps-tradingapp-tradeallocations-16894"></span>
 
-tradeAllocations
-: SettlementInfo -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AllocationSpecification
+### `tradeAllocations`
 
-</div>
+```daml
+tradeAllocations : SettlementInfo -> TextMap TransferLeg -> TextMap AllocationSpecification
+```
 
-<div id="function-splice-testing-apps-tradingapp-tradingparties-11886">
+<span id="function-splice-testing-apps-tradingapp-tradingparties-11886"></span>
 
-tradingParties
-: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg -\> Set [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+### `tradingParties`
 
-</div>
+```daml
+tradingParties : TextMap TransferLeg -> Set Party
+```
 
-<div id="function-splice-testing-apps-tradingapp-require-88127">
+<span id="function-splice-testing-apps-tradingapp-require-88127"></span>
 
-require
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+### `require`
 
-Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
 
-</div>
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
 
-<div id="function-splice-testing-apps-tradingapp-maketraderef-67526">
+<span id="function-splice-testing-apps-tradingapp-maketraderef-67526"></span>
 
-makeTradeRef
-: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal -\> Reference
+### `makeTradeRef`
 
-</div>
+```daml
+makeTradeRef : ContractId OTCTradeProposal -> Reference
+```
 
-<div id="function-splice-testing-apps-tradingapp-ziptextmaps-57279">
+<span id="function-splice-testing-apps-tradingapp-ziptextmaps-57279"></span>
 
-zipTextMaps
-: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) b -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a, [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) b)
+### `zipTextMaps`
 
-</div>
+```daml
+zipTextMaps : TextMap a -> TextMap b -> TextMap (Optional a, Optional b)
+```
 
-<div id="function-splice-testing-apps-tradingapp-fortextmapwithkey-78275">
+<span id="function-splice-testing-apps-tradingapp-fortextmapwithkey-78275"></span>
 
-forTextMapWithKey
-: [Applicative](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-applicative-9257) f =\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) a -\> ([Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> a -\> f b) -\> f ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) b)
+### `forTextMapWithKey`
 
-</div>
+```daml
+forTextMapWithKey : Applicative f => TextMap a -> (Text -> a -> f b) -> f (TextMap b)
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-testing-apps-tradingapp-otctrade-80775"></span>
+
+### Template `OTCTrade`
+
+Signatories: `venue`, `tradingParties transferLegs`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| venue | Party |  |
+| transferLegs | TextMap TransferLeg |  |
+| tradeCid | ContractId OTCTradeProposal |  |
+| createdAt | Time |  |
+| prepareUntil | Time |  |
+| settleBefore | Time |  |
+
+Interface Instances:
+- `AllocationRequest` for `OTCTrade`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `venue`, `tradingParties transferLegs`
+
+Returns: `()`
+
+<span id="type-splice-testing-apps-tradingapp-otctradecancel-34465"></span>
+
+#### Choice `OTCTrade_Cancel`
+
+Controllers: `venue`
+
+Returns: `TextMap (Optional Allocation_CancelResult)`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationsWithContext | TextMap (ContractId Allocation, ExtraArgs) |  |
+
+<span id="type-splice-testing-apps-tradingapp-otctradesettle-9210"></span>
+
+#### Choice `OTCTrade_Settle`
+
+Controllers: `venue`
+
+Returns: `TextMap Allocation_ExecuteTransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationsWithContext | TextMap (ContractId Allocation, ExtraArgs) |  |
+
+<span id="type-splice-testing-apps-tradingapp-otctradeproposal-78093"></span>
+
+### Template `OTCTradeProposal`
+
+Signatories: `approvers`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| venue | Party |  |
+| tradeCid | Optional (ContractId OTCTradeProposal) |  |
+| transferLegs | TextMap TransferLeg |  |
+| approvers | [Party] | Parties that have approved the proposal |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `approvers`
+
+Returns: `()`
+
+<span id="type-splice-testing-apps-tradingapp-otctradeproposalaccept-97549"></span>
+
+#### Choice `OTCTradeProposal_Accept`
+
+Controllers: `approver`
+
+Returns: `ContractId OTCTradeProposal`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| approver | Party |  |
+
+<span id="type-splice-testing-apps-tradingapp-otctradeproposalinitiatesettlement-54617"></span>
+
+#### Choice `OTCTradeProposal_InitiateSettlement`
+
+Controllers: `venue`
+
+Returns: `ContractId OTCTrade`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| prepareUntil | Time |  |
+| settleBefore | Time |  |
+
+<span id="type-splice-testing-apps-tradingapp-otctradeproposalreject-13148"></span>
+
+#### Choice `OTCTradeProposal_Reject`
+
+Controllers: `trader`
+
+Returns: `()`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trader | Party |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index.mdx
@@ -1,12 +1,195 @@
 ---
-title: "splice-util-batched-markers docs"
-description: "Documentation for splice-util-batched-markers docs"
+title: "splice-util-batched-markers"
+description: "Reference documentation for splice-util-batched-markers modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-batched-markers/docs/index.rst" tag="0.6.4" hash="1636b7a2" */}
+<div class="x2mdx-ref-hero">
 
-This package provides the `BatchedMarkersProxy` contract which can be used to create a batch of `FeaturedAppActivityMarkers` in a transaction with a single view which is more efficient to process. To use it first create one long-lived `BatchedMarkersProxy` contract and then use `BatchedMarkersProxy_CreateMarkers` to create the actual markers. Note that for this to work all beneficiaries and the provider must have vetted the DAR.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-- [Splice.Util.FeaturedApp.BatchedMarkersProxy](/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy)
 
-{/* COPIED_END */}
+  <h1 class="x2mdx-ref-title">splice-util-batched-markers</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-util-batched-markers, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Util.FeaturedApp.BatchedMarkersProxy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module provides a BatchedMarkersProxy that can be used</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy.mdx
@@ -1,194 +1,192 @@
 ---
 title: "Splice.Util.FeaturedApp.BatchedMarkersProxy"
-description: "Documentation for Splice.Util.FeaturedApp.BatchedMarkersProxy"
+description: "Reference documentation for Daml module Splice.Util.FeaturedApp.BatchedMarkersProxy."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-batched-markers/docs/Splice-Util-FeaturedApp-BatchedMarkersProxy.rst" tag="0.6.4" hash="224dec62" */}
+<span id="module-splice-util-featuredapp-batchedmarkersproxy-25197"></span>
 
-This module provides a BatchedMarkersProxy that can be used to create multiple markers in one view.
+# Splice.Util.FeaturedApp.BatchedMarkersProxy
 
-## Templates
+This module provides a BatchedMarkersProxy that can be used
 
-<div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxy-55016">
+to create multiple markers in one view.
 
-**template** BatchedMarkersProxy
+## Module Snapshot
 
-</div>
-
-> Signatory: provider
->
-> | Field    | Type                                                                                                                | Description |
-> |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> | dso      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: provider
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkers-27654">
->
->   **Choice** BatchedMarkersProxy_CreateMarkers
->
->   </div>
->
->   Controller: provider
->
->   Returns: BatchedMarkersProxy_CreateMarkersResult
->
->   | Field               | Type                                                                                                                                           | Description |
->   |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
->   | batches             | \[RewardBatch\]                                                                                                                                |             |
->
-> - <div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2-19116">
->
->   **Choice** BatchedMarkersProxy_CreateMarkersV2
->
->   </div>
->
->   Controller: provider
->
->   Returns: BatchedMarkersProxy_CreateMarkersV2Result
->
->   | Field               | Type                                                                                                                                           | Description |
->   |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
->   | batches             | \[RewardBatchV2\]                                                                                                                              |             |
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-99671">
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-99671"></span>
 
-**data** BatchedMarkersProxy_CreateMarkersResult
+### `data BatchedMarkersProxy_CreateMarkersResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-77896">
->
-> BatchedMarkersProxy_CreateMarkersResult
->
-> </div>
->
-> > | Field   | Type                                                | Description |
-> > |---------|-----------------------------------------------------|-------------|
-> > | results | \[\[FeaturedAppRight_CreateActivityMarkerResult\]\] |             |
->
-> **instance** GetField "results" BatchedMarkersProxy_CreateMarkersResult \[\[FeaturedAppRight_CreateActivityMarkerResult\]\]
->
-> **instance** SetField "results" BatchedMarkersProxy_CreateMarkersResult \[\[FeaturedAppRight_CreateActivityMarkerResult\]\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult
+<span id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-77896"></span>
 
-<div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2result-28373">
+- `BatchedMarkersProxy_CreateMarkersResult`
 
-**data** BatchedMarkersProxy_CreateMarkersV2Result
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [[FeaturedAppRight_CreateActivityMarkerResult]] |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2result-1154">
->
-> BatchedMarkersProxy_CreateMarkersV2Result
->
-> </div>
->
-> > | Field   | Type                                            | Description |
-> > |---------|-------------------------------------------------|-------------|
-> > | results | \[FeaturedAppRight_CreateActivityMarkerResult\] |             |
->
-> **instance** GetField "results" BatchedMarkersProxy_CreateMarkersV2Result \[FeaturedAppRight_CreateActivityMarkerResult\]
->
-> **instance** SetField "results" BatchedMarkersProxy_CreateMarkersV2Result \[FeaturedAppRight_CreateActivityMarkerResult\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result
+- `instance GetField results BatchedMarkersProxy_CreateMarkersResult [[FeaturedAppRight_CreateActivityMarkerResult]]`
+- `instance SetField results BatchedMarkersProxy_CreateMarkersResult [[FeaturedAppRight_CreateActivityMarkerResult]]`
+- `instance HasExercise BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult`
+- `instance HasFromAnyChoice BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult`
+- `instance HasToAnyChoice BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult`
 
-<div id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-19803">
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2result-28373"></span>
 
-**data** RewardBatch
+### `data BatchedMarkersProxy_CreateMarkersV2Result`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-87344">
->
-> RewardBatch
->
-> </div>
->
-> > | Field         | Type                                                                                                       | Description |
-> > |---------------|------------------------------------------------------------------------------------------------------------|-------------|
-> > | beneficiaries | \[AppRewardBeneficiary\]                                                                                   |             |
-> > | numMarkers    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RewardBatch
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RewardBatch
->
-> **instance** GetField "batches" BatchedMarkersProxy_CreateMarkers \[RewardBatch\]
->
-> **instance** GetField "beneficiaries" RewardBatch \[AppRewardBeneficiary\]
->
-> **instance** GetField "numMarkers" RewardBatch [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** SetField "batches" BatchedMarkersProxy_CreateMarkers \[RewardBatch\]
->
-> **instance** SetField "beneficiaries" RewardBatch \[AppRewardBeneficiary\]
->
-> **instance** SetField "numMarkers" RewardBatch [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+<span id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2result-1154"></span>
 
-<div id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatchv2-80405">
+- `BatchedMarkersProxy_CreateMarkersV2Result`
 
-**data** RewardBatchV2
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [FeaturedAppRight_CreateActivityMarkerResult] |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatchv2-45814">
->
-> RewardBatchV2
->
-> </div>
->
-> > | Field         | Type                                                                                                               | Description                                             |
-> > |---------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-> > | beneficiaries | \[AppRewardBeneficiary\]                                                                                           |                                                         |
-> > | markerWeight  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The total weight of the markers that should be created. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RewardBatchV2
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RewardBatchV2
->
-> **instance** GetField "batches" BatchedMarkersProxy_CreateMarkersV2 \[RewardBatchV2\]
->
-> **instance** GetField "beneficiaries" RewardBatchV2 \[AppRewardBeneficiary\]
->
-> **instance** GetField "markerWeight" RewardBatchV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "batches" BatchedMarkersProxy_CreateMarkersV2 \[RewardBatchV2\]
->
-> **instance** SetField "beneficiaries" RewardBatchV2 \[AppRewardBeneficiary\]
->
-> **instance** SetField "markerWeight" RewardBatchV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+- `instance GetField results BatchedMarkersProxy_CreateMarkersV2Result [FeaturedAppRight_CreateActivityMarkerResult]`
+- `instance SetField results BatchedMarkersProxy_CreateMarkersV2Result [FeaturedAppRight_CreateActivityMarkerResult]`
+- `instance HasExercise BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result`
+- `instance HasFromAnyChoice BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result`
+- `instance HasToAnyChoice BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result`
+
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-19803"></span>
+
+### `data RewardBatch`
+
+Constructors:
+
+<span id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-87344"></span>
+
+- `RewardBatch`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] |  |
+| numMarkers | Int |  |
+
+Instances:
+
+- `instance Eq RewardBatch`
+- `instance Show RewardBatch`
+- `instance GetField batches BatchedMarkersProxy_CreateMarkers [RewardBatch]`
+- `instance GetField beneficiaries RewardBatch [AppRewardBeneficiary]`
+- `instance GetField numMarkers RewardBatch Int`
+- `instance SetField batches BatchedMarkersProxy_CreateMarkers [RewardBatch]`
+- `instance SetField beneficiaries RewardBatch [AppRewardBeneficiary]`
+- `instance SetField numMarkers RewardBatch Int`
+
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatchv2-80405"></span>
+
+### `data RewardBatchV2`
+
+Constructors:
+
+<span id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatchv2-45814"></span>
+
+- `RewardBatchV2`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] |  |
+| markerWeight | Decimal | The total weight of the markers that should be created. |
+
+Instances:
+
+- `instance Eq RewardBatchV2`
+- `instance Show RewardBatchV2`
+- `instance GetField batches BatchedMarkersProxy_CreateMarkersV2 [RewardBatchV2]`
+- `instance GetField beneficiaries RewardBatchV2 [AppRewardBeneficiary]`
+- `instance GetField markerWeight RewardBatchV2 Decimal`
+- `instance SetField batches BatchedMarkersProxy_CreateMarkersV2 [RewardBatchV2]`
+- `instance SetField beneficiaries RewardBatchV2 [AppRewardBeneficiary]`
+- `instance SetField markerWeight RewardBatchV2 Decimal`
 
 ## Functions
 
-<div id="function-splice-util-featuredapp-batchedmarkersproxy-require-64969">
+<span id="function-splice-util-featuredapp-batchedmarkersproxy-require-64969"></span>
 
-require
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+### `require`
 
-Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
 
-</div>
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxy-55016"></span>
+
+### Template `BatchedMarkersProxy`
+
+Signatories: `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party |  |
+| dso | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `provider`
+
+Returns: `()`
+
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkers-27654"></span>
+
+#### Choice `BatchedMarkersProxy_CreateMarkers`
+
+Controllers: `provider`
+
+Returns: `BatchedMarkersProxy_CreateMarkersResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+| batches | [RewardBatch] |  |
+
+<span id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2-19116"></span>
+
+#### Choice `BatchedMarkersProxy_CreateMarkersV2`
+
+Controllers: `provider`
+
+Returns: `BatchedMarkersProxy_CreateMarkersV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+| batches | [RewardBatchV2] |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index.mdx
@@ -1,13 +1,245 @@
 ---
-title: "splice-util-featured-app-proxies docs"
-description: "Documentation for splice-util-featured-app-proxies docs"
+title: "splice-util-featured-app-proxies"
+description: "Reference documentation for splice-util-featured-app-proxies modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-featured-app-proxies/docs/index.rst" tag="0.6.4" hash="21d081ce" */}
+<div class="x2mdx-ref-hero">
 
-Optional package simplifying the integration of featured apps with the token standard. Not uploaded by default to a validator node.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-- [Splice.Util.FeaturedApp.DelegateProxy](/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy)
-- [Splice.Util.FeaturedApp.WalletUserProxy](/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy)
 
-{/* COPIED_END */}
+  <h1 class="x2mdx-ref-title">splice-util-featured-app-proxies</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-util-featured-app-proxies, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Util.FeaturedApp.DelegateProxy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Utility template for proxying token standard choices so that featured app markers</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Util.FeaturedApp.WalletUserProxy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Utility template for proxying token standard choices so that featured app markers</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 2</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy.mdx
@@ -1,276 +1,264 @@
 ---
 title: "Splice.Util.FeaturedApp.DelegateProxy"
-description: "Documentation for Splice.Util.FeaturedApp.DelegateProxy"
+description: "Reference documentation for Daml module Splice.Util.FeaturedApp.DelegateProxy."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-featured-app-proxies/docs/Splice-Util-FeaturedApp-DelegateProxy.rst" tag="0.6.4" hash="1b1ebdb6" */}
+<span id="module-splice-util-featuredapp-delegateproxy-30718"></span>
 
-Utility template for proxying token standard choices so that featured app markers are created when using extra parties for operating an app.
+# Splice.Util.FeaturedApp.DelegateProxy
 
-You can either use this template directly, or copy the code under a **different package name** and a **different module name**.
+Utility template for proxying token standard choices so that featured app markers
 
-Note: use the `WalletUserProxy` if you are building a wallet app and want your users to create featured app markers for you.
+are created when using extra parties for operating an app.
 
-## Templates
+You can either use this template directly, or copy the code
 
-<div id="type-splice-util-featuredapp-delegateproxy-delegateproxy-71400">
+under a **different package name** and a **different module name**.
 
-**template** DelegateProxy
+Note: use the `WalletUserProxy` if you are building a wallet app and want your users
 
-</div>
+to create featured app markers for you.
 
-> A proxy for a delegate to create featured app markers jointly with using token standard workflows. The delegate is given full control over the creation of the markers.
->
-> This is for example useful when using one or more parties for app operation purposes. Using this proxy allows the operational parties to properly attribute their activity to the featured app, which is represented by the app provider party.
->
-> Signatory: provider
->
-> | Field    | Type                                                                                                                | Description                                               |
-> |----------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
-> | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider whose featured app right should be used  |
-> | delegate | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The delegate interacting with the token standard workflow |
->
-> - **Choice** Archive
->
->   Controller: provider
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationfactoryallocate-41540">
->
->   **Choice** DelegateProxy_AllocationFactory_Allocate
->
->   </div>
->
->   Controller: delegate
->
->   Returns: ProxyResult AllocationInstructionResult
->
->   | Field    | Type                                                                                                                                            | Description |
->   |----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory |             |
->   | proxyArg | ProxyArg AllocationFactory_Allocate                                                                                                             |             |
->
-> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationwithdraw-47558">
->
->   **Choice** DelegateProxy_Allocation_Withdraw
->
->   </div>
->
->   Controller: delegate
->
->   Returns: ProxyResult Allocation_WithdrawResult
->
->   | Field    | Type                                                                                                                                     | Description |
->   |----------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation |             |
->   | proxyArg | ProxyArg Allocation_Withdraw                                                                                                             |             |
->
-> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferfactorytransfer-85873">
->
->   **Choice** DelegateProxy_TransferFactory_Transfer
->
->   </div>
->
->   Controller: delegate
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                          | Description |
->   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
->   | proxyArg | ProxyArg TransferFactory_Transfer                                                                                                             |             |
->
-> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionaccept-5120">
->
->   **Choice** DelegateProxy_TransferInstruction_Accept
->
->   </div>
->
->   Controller: delegate
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                              | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
->   | proxyArg | ProxyArg TransferInstruction_Accept                                                                                                               |             |
->
-> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionreject-73393">
->
->   **Choice** DelegateProxy_TransferInstruction_Reject
->
->   </div>
->
->   Controller: delegate
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                              | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
->   | proxyArg | ProxyArg TransferInstruction_Reject                                                                                                               |             |
->
-> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionwithdraw-896">
->
->   **Choice** DelegateProxy_TransferInstruction_Withdraw
->
->   </div>
->
->   Controller: delegate
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                              | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
->   | proxyArg | ProxyArg TransferInstruction_Withdraw                                                                                                             |             |
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-util-featuredapp-delegateproxy-proxyarg-10352">
+<span id="type-splice-util-featuredapp-delegateproxy-proxyarg-10352"></span>
 
-**data** ProxyArg arg
+### `data ProxyArg arg`
 
-</div>
+Generic argument to the proxy choices.
 
-> Generic argument to the proxy choices.
->
-> <div id="constr-splice-util-featuredapp-delegateproxy-proxyarg-5545">
->
-> ProxyArg
->
-> </div>
->
-> > | Field               | Type                                                                                                                                           | Description                                                 |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
-> > | choiceArg           | arg                                                                                                                                            | The argument to the choice that the delegate is exercising. |
-> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight | The featured app right contract of the provider.            |
-> > | beneficiaries       | \[AppRewardBeneficiary\]                                                                                                                       | The beneficiaries for the activity marker.                  |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) arg =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (ProxyArg arg)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) arg =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (ProxyArg arg)
->
-> **instance** GetField "beneficiaries" (ProxyArg arg) \[AppRewardBeneficiary\]
->
-> **instance** GetField "choiceArg" (ProxyArg arg) arg
->
-> **instance** GetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** GetField "proxyArg" DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
->
-> **instance** GetField "proxyArg" DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
->
-> **instance** GetField "proxyArg" DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
->
-> **instance** GetField "proxyArg" DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
->
-> **instance** GetField "proxyArg" DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
->
-> **instance** GetField "proxyArg" DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
->
-> **instance** SetField "beneficiaries" (ProxyArg arg) \[AppRewardBeneficiary\]
->
-> **instance** SetField "choiceArg" (ProxyArg arg) arg
->
-> **instance** SetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** SetField "proxyArg" DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
->
-> **instance** SetField "proxyArg" DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
->
-> **instance** SetField "proxyArg" DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
->
-> **instance** SetField "proxyArg" DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
->
-> **instance** SetField "proxyArg" DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
->
-> **instance** SetField "proxyArg" DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
+Constructors:
 
-<div id="type-splice-util-featuredapp-delegateproxy-proxyresult-3914">
+<span id="constr-splice-util-featuredapp-delegateproxy-proxyarg-5545"></span>
 
-**data** ProxyResult r
+- `ProxyArg`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| choiceArg | arg | The argument to the choice that the delegate is exercising. |
+| featuredAppRightCid | ContractId FeaturedAppRight | The featured app right contract of the provider. |
+| beneficiaries | [AppRewardBeneficiary] | The beneficiaries for the activity marker. |
 
-> Generic result of the proxy choices.
->
-> <div id="constr-splice-util-featuredapp-delegateproxy-proxyresult-43225">
->
-> ProxyResult
->
-> </div>
->
-> > | Field        | Type                                        | Description |
-> > |--------------|---------------------------------------------|-------------|
-> > | markerResult | FeaturedAppRight_CreateActivityMarkerResult |             |
-> > | choiceResult | r                                           |             |
->
-> **instance** GetField "choiceResult" (ProxyResult r) r
->
-> **instance** GetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** SetField "choiceResult" (ProxyResult r) r
->
-> **instance** SetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+Instances:
+
+- `instance Eq arg => Eq (ProxyArg arg)`
+- `instance Show arg => Show (ProxyArg arg)`
+- `instance GetField beneficiaries (ProxyArg arg) [AppRewardBeneficiary]`
+- `instance GetField choiceArg (ProxyArg arg) arg`
+- `instance GetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance GetField proxyArg DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance GetField proxyArg DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance GetField proxyArg DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance GetField proxyArg DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance GetField proxyArg DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance GetField proxyArg DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+- `instance SetField beneficiaries (ProxyArg arg) [AppRewardBeneficiary]`
+- `instance SetField choiceArg (ProxyArg arg) arg`
+- `instance SetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance SetField proxyArg DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance SetField proxyArg DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance SetField proxyArg DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance SetField proxyArg DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance SetField proxyArg DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance SetField proxyArg DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+
+<span id="type-splice-util-featuredapp-delegateproxy-proxyresult-3914"></span>
+
+### `data ProxyResult r`
+
+Generic result of the proxy choices.
+
+Constructors:
+
+<span id="constr-splice-util-featuredapp-delegateproxy-proxyresult-43225"></span>
+
+- `ProxyResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| markerResult | FeaturedAppRight_CreateActivityMarkerResult |  |
+| choiceResult | r |  |
+
+Instances:
+
+- `instance GetField choiceResult (ProxyResult r) r`
+- `instance GetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance SetField choiceResult (ProxyResult r) r`
+- `instance SetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExercise DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
 
 ## Functions
 
-<div id="function-splice-util-featuredapp-delegateproxy-exerciseproxychoice-9818">
+<span id="function-splice-util-featuredapp-delegateproxy-exerciseproxychoice-9818"></span>
 
-exerciseProxyChoice
-: [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) t ch r =\> DelegateProxy -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> ProxyArg ch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (ProxyResult r)
+### `exerciseProxyChoice`
+
+```daml
+exerciseProxyChoice : HasExercise t ch r => DelegateProxy -> ContractId t -> ProxyArg ch -> Update (ProxyResult r)
+```
 
 Shared code to execute the proxied choice.
 
-</div>
+<span id="function-splice-util-featuredapp-delegateproxy-require-76960"></span>
 
-<div id="function-splice-util-featuredapp-delegateproxy-require-76960">
+### `require`
 
-require
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
 
-Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
 
-</div>
+## Templates
 
-{/* COPIED_END */}
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxy-71400"></span>
+
+### Template `DelegateProxy`
+
+A proxy for a delegate to create featured app markers jointly with using token standard workflows.
+The delegate is given full control over the creation of the markers.
+
+This is for example useful when using one or more parties for app operation purposes.
+Using this proxy allows the operational parties to properly attribute their activity to the featured app,
+which is represented by the app provider party.
+
+Signatories: `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party | The app provider whose featured app right should be used |
+| delegate | Party | The delegate interacting with the token standard workflow |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `provider`
+
+Returns: `()`
+
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationfactoryallocate-41540"></span>
+
+#### Choice `DelegateProxy_AllocationFactory_Allocate`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AllocationFactory |  |
+| proxyArg | ProxyArg AllocationFactory_Allocate |  |
+
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationwithdraw-47558"></span>
+
+#### Choice `DelegateProxy_Allocation_Withdraw`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Allocation |  |
+| proxyArg | ProxyArg Allocation_Withdraw |  |
+
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferfactorytransfer-85873"></span>
+
+#### Choice `DelegateProxy_TransferFactory_Transfer`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferFactory |  |
+| proxyArg | ProxyArg TransferFactory_Transfer |  |
+
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionaccept-5120"></span>
+
+#### Choice `DelegateProxy_TransferInstruction_Accept`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Accept |  |
+
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionreject-73393"></span>
+
+#### Choice `DelegateProxy_TransferInstruction_Reject`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Reject |  |
+
+<span id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionwithdraw-896"></span>
+
+#### Choice `DelegateProxy_TransferInstruction_Withdraw`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Withdraw |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy.mdx
@@ -1,460 +1,440 @@
 ---
 title: "Splice.Util.FeaturedApp.WalletUserProxy"
-description: "Documentation for Splice.Util.FeaturedApp.WalletUserProxy"
+description: "Reference documentation for Daml module Splice.Util.FeaturedApp.WalletUserProxy."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-featured-app-proxies/docs/Splice-Util-FeaturedApp-WalletUserProxy.rst" tag="0.6.4" hash="18b18cc4" */}
+<span id="module-splice-util-featuredapp-walletuserproxy-40223"></span>
 
-Utility template for proxying token standard choices so that featured app markers are created for a wallet app provider by their users when they are using token standard workflows.
+# Splice.Util.FeaturedApp.WalletUserProxy
 
-You can either use this template directly, or copy the code under a **different package name** and a **different module name**.
+Utility template for proxying token standard choices so that featured app markers
 
-Note: use the `DelegateProxy` if you are building an app that uses multiple parties for its own operations.
+are created for a wallet app provider by their users when they are using
 
-## Templates
+token standard workflows.
 
-<div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxy-95528">
+You can either use this template directly, or copy the code
 
-**template** WalletUserProxy
+under a **different package name** and a **different module name**.
 
-</div>
+Note: use the `DelegateProxy` if you are building an app that uses multiple parties
 
-> A proxy to attribute the activity of a wallet user to the wallet app provider.
->
-> The intended usage is for the wallet app provider to
->
-> 1.  create a `WalletUserProxy` contract with the `provider` set to the app provider's party
-> 2.  setup their wallet frontend such that users call the proxy's choices instead of the original token standard choices.
->
-> Note that the weights are specified on the proxy contract, so that they are under the providers control. If they were specified on the choices, then the user could in principle change them, and grant themselves a higher reward than intended.
->
-> Note also that the batch transfer support can be used without having a featured app right.
->
-> Signatory: provider
->
-> | Field              | Type                                                                                                                                                                                                                                                   | Description                                                                    |
-> |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
-> | provider           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                    | The app provider whose featured app right should be triggered                  |
-> | providerWeight     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                     | Reward weight for the provider                                                 |
-> | userWeight         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                     | Reward weight for the user, set to 0.0 if the user should not receive a reward |
-> | extraBeneficiaries | \[AppRewardBeneficiary\]                                                                                                                                                                                                                               | Extra beneficiaries to add                                                     |
-> | optAllowList       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] | An optional allow list of parties that can use the proxy                       |
->
-> - **Choice** Archive
->
->   Controller: provider
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationfactoryallocate-70856">
->
->   **Choice** WalletUserProxy_AllocationFactory_Allocate
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"user" proxyArg)
->
->   Returns: ProxyResult AllocationInstructionResult
->
->   | Field    | Type                                                                                                                                            | Description |
->   |----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory |             |
->   | proxyArg | ProxyArg AllocationFactory_Allocate                                                                                                             |             |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationwithdraw-8358">
->
->   **Choice** WalletUserProxy_Allocation_Withdraw
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"user" proxyArg)
->
->   Returns: ProxyResult Allocation_WithdrawResult
->
->   | Field    | Type                                                                                                                                     | Description |
->   |----------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation |             |
->   | proxyArg | ProxyArg Allocation_Withdraw                                                                                                             |             |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransfer-93002">
->
->   **Choice** WalletUserProxy_BatchTransfer
->
->   </div>
->
->   Controller: getFirstSender transferCalls
->
->   Returns: WalletUserProxy_BatchTransferResult
->
->   | Field                  | Type                                                                                                                                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            |
->   |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | transferCalls          | \[TransferFactoryCall\]                                                                                                                                                                                                                                                         | Transfers to execute via their respective transfer factories. Input holdings are properly threaded through for all instrument-ids. The sender change is always added back as an additional input to follow-up transfers for the same instrument-ids. Note that we accept fully specified calls to factories for maximum flexibility. Some token admins may actually use different factories for different recipients, e.g., to implement preapprovals. |
->   | optFeaturedAppRightCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) | The featured app right contract of the provider to use on every transfer. Optional so the batched choice can be used without a featured app right.                                                                                                                                                                                                                                                                                                     |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxypublicfetch-18804">
->
->   **Choice** WalletUserProxy_PublicFetch
->
->   </div>
->
->   Controller: actor
->
->   Returns: WalletUserProxy
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferfactorytransfer-32457">
->
->   **Choice** WalletUserProxy_TransferFactory_Transfer
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"user" proxyArg)
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                          | Description |
->   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
->   | proxyArg | ProxyArg TransferFactory_Transfer                                                                                                             |             |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionaccept-38416">
->
->   **Choice** WalletUserProxy_TransferInstruction_Accept
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"user" proxyArg)
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                              | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
->   | proxyArg | ProxyArg TransferInstruction_Accept                                                                                                               |             |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionreject-59713">
->
->   **Choice** WalletUserProxy_TransferInstruction_Reject
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"user" proxyArg)
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                              | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
->   | proxyArg | ProxyArg TransferInstruction_Reject                                                                                                               |             |
->
-> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionwithdraw-40772">
->
->   **Choice** WalletUserProxy_TransferInstruction_Withdraw
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"user" proxyArg)
->
->   Returns: ProxyResult TransferInstructionResult
->
->   | Field    | Type                                                                                                                                              | Description |
->   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
->   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
->   | proxyArg | ProxyArg TransferInstruction_Withdraw                                                                                                             |             |
+for its own operations.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-util-featuredapp-walletuserproxy-instrumentholdingmap-68187">
+<span id="type-splice-util-featuredapp-walletuserproxy-instrumentholdingmap-68187"></span>
 
-**type** InstrumentHoldingMap
-= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) InstrumentId \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+### `type InstrumentHoldingMap = Map InstrumentId [ContractId Holding]`
 
-**instance** GetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
+Instances:
 
-**instance** SetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
+- `instance GetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+- `instance SetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
 
-</div>
+<span id="type-splice-util-featuredapp-walletuserproxy-proxyarg-78125"></span>
 
-<div id="type-splice-util-featuredapp-walletuserproxy-proxyarg-78125">
+### `data ProxyArg arg`
 
-**data** ProxyArg arg
+Generic argument to the proxy choices.
 
-</div>
+Constructors:
 
-> Generic argument to the proxy choices.
->
-> <div id="constr-splice-util-featuredapp-walletuserproxy-proxyarg-32408">
->
-> ProxyArg
->
-> </div>
->
-> > | Field               | Type                                                                                                                                           | Description                                                    |
-> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-> > | user                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                            | The wallet user that is using the wallet to exercise a choice. |
-> > | choiceArg           | arg                                                                                                                                            | The argument to the choice that the user is exercising.        |
-> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight | The featured app right contract of the provider.               |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) arg =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (ProxyArg arg)
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) arg =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (ProxyArg arg)
->
-> **instance** GetField "choiceArg" (ProxyArg arg) arg
->
-> **instance** GetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** GetField "proxyArg" WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
->
-> **instance** GetField "proxyArg" WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
->
-> **instance** GetField "proxyArg" WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
->
-> **instance** GetField "proxyArg" WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
->
-> **instance** GetField "proxyArg" WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
->
-> **instance** GetField "proxyArg" WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
->
-> **instance** GetField "user" (ProxyArg arg) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "choiceArg" (ProxyArg arg) arg
->
-> **instance** SetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** SetField "proxyArg" WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
->
-> **instance** SetField "proxyArg" WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
->
-> **instance** SetField "proxyArg" WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
->
-> **instance** SetField "proxyArg" WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
->
-> **instance** SetField "proxyArg" WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
->
-> **instance** SetField "proxyArg" WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
->
-> **instance** SetField "user" (ProxyArg arg) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+<span id="constr-splice-util-featuredapp-walletuserproxy-proxyarg-32408"></span>
 
-<div id="type-splice-util-featuredapp-walletuserproxy-proxyresult-11789">
+- `ProxyArg`
 
-**data** ProxyResult r
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party | The wallet user that is using the wallet to exercise a choice. |
+| choiceArg | arg | The argument to the choice that the user is exercising. |
+| featuredAppRightCid | ContractId FeaturedAppRight | The featured app right contract of the provider. |
 
-</div>
+Instances:
 
-> Generic result of the proxy choices.
->
-> <div id="constr-splice-util-featuredapp-walletuserproxy-proxyresult-146">
->
-> ProxyResult
->
-> </div>
->
-> > | Field        | Type                                        | Description |
-> > |--------------|---------------------------------------------|-------------|
-> > | markerResult | FeaturedAppRight_CreateActivityMarkerResult |             |
-> > | choiceResult | r                                           |             |
->
-> **instance** GetField "choiceResult" (ProxyResult r) r
->
-> **instance** GetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** SetField "choiceResult" (ProxyResult r) r
->
-> **instance** SetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+- `instance Eq arg => Eq (ProxyArg arg)`
+- `instance Show arg => Show (ProxyArg arg)`
+- `instance GetField choiceArg (ProxyArg arg) arg`
+- `instance GetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance GetField proxyArg WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance GetField proxyArg WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance GetField proxyArg WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance GetField proxyArg WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance GetField proxyArg WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance GetField proxyArg WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+- `instance GetField user (ProxyArg arg) Party`
+- `instance SetField choiceArg (ProxyArg arg) arg`
+- `instance SetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance SetField proxyArg WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance SetField proxyArg WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance SetField proxyArg WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance SetField proxyArg WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance SetField proxyArg WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance SetField proxyArg WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+- `instance SetField user (ProxyArg arg) Party`
 
-<div id="type-splice-util-featuredapp-walletuserproxy-transferfactorycall-48419">
+<span id="type-splice-util-featuredapp-walletuserproxy-proxyresult-11789"></span>
 
-**data** TransferFactoryCall
+### `data ProxyResult r`
 
-</div>
+Generic result of the proxy choices.
 
-> A call to the token standard factory to initiate a token standard transfer. Specialized because it is used in the batch transfer choice below.
->
-> <div id="constr-splice-util-featuredapp-walletuserproxy-transferfactorycall-65712">
->
-> TransferFactoryCall
->
-> </div>
->
-> > | Field      | Type                                                                                                                                          | Description |
-> > |------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | factoryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
-> > | choiceArg  | TransferFactory_Transfer                                                                                                                      |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferFactoryCall
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferFactoryCall
->
-> **instance** GetField "choiceArg" TransferFactoryCall TransferFactory_Transfer
->
-> **instance** GetField "factoryCid" TransferFactoryCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
->
-> **instance** GetField "transferCalls" WalletUserProxy_BatchTransfer \[TransferFactoryCall\]
->
-> **instance** SetField "choiceArg" TransferFactoryCall TransferFactory_Transfer
->
-> **instance** SetField "factoryCid" TransferFactoryCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
->
-> **instance** SetField "transferCalls" WalletUserProxy_BatchTransfer \[TransferFactoryCall\]
+Constructors:
 
-<div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-21051">
+<span id="constr-splice-util-featuredapp-walletuserproxy-proxyresult-146"></span>
 
-**data** WalletUserProxy_BatchTransferResult
+- `ProxyResult`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| markerResult | FeaturedAppRight_CreateActivityMarkerResult |  |
+| choiceResult | r |  |
 
-> <div id="constr-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-77048">
->
-> WalletUserProxy_BatchTransferResult
->
-> </div>
->
-> > | Field           | Type                          | Description |
-> > |-----------------|-------------------------------|-------------|
-> > | transferResults | \[TransferInstructionResult\] |             |
-> > | senderChangeMap | InstrumentHoldingMap          |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) WalletUserProxy_BatchTransferResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) WalletUserProxy_BatchTransferResult
->
-> **instance** GetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
->
-> **instance** GetField "transferResults" WalletUserProxy_BatchTransferResult \[TransferInstructionResult\]
->
-> **instance** SetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
->
-> **instance** SetField "transferResults" WalletUserProxy_BatchTransferResult \[TransferInstructionResult\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult
+Instances:
+
+- `instance GetField choiceResult (ProxyResult r) r`
+- `instance GetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance SetField choiceResult (ProxyResult r) r`
+- `instance SetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExercise WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+
+<span id="type-splice-util-featuredapp-walletuserproxy-transferfactorycall-48419"></span>
+
+### `data TransferFactoryCall`
+
+A call to the token standard factory to initiate a token standard transfer.
+Specialized because it is used in the batch transfer choice below.
+
+Constructors:
+
+<span id="constr-splice-util-featuredapp-walletuserproxy-transferfactorycall-65712"></span>
+
+- `TransferFactoryCall`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| factoryCid | ContractId TransferFactory |  |
+| choiceArg | TransferFactory_Transfer |  |
+
+Instances:
+
+- `instance Eq TransferFactoryCall`
+- `instance Show TransferFactoryCall`
+- `instance GetField choiceArg TransferFactoryCall TransferFactory_Transfer`
+- `instance GetField factoryCid TransferFactoryCall (ContractId TransferFactory)`
+- `instance GetField transferCalls WalletUserProxy_BatchTransfer [TransferFactoryCall]`
+- `instance SetField choiceArg TransferFactoryCall TransferFactory_Transfer`
+- `instance SetField factoryCid TransferFactoryCall (ContractId TransferFactory)`
+- `instance SetField transferCalls WalletUserProxy_BatchTransfer [TransferFactoryCall]`
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-21051"></span>
+
+### `data WalletUserProxy_BatchTransferResult`
+
+Constructors:
+
+<span id="constr-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-77048"></span>
+
+- `WalletUserProxy_BatchTransferResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferResults | [TransferInstructionResult] |  |
+| senderChangeMap | InstrumentHoldingMap |  |
+
+Instances:
+
+- `instance Eq WalletUserProxy_BatchTransferResult`
+- `instance Show WalletUserProxy_BatchTransferResult`
+- `instance GetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+- `instance GetField transferResults WalletUserProxy_BatchTransferResult [TransferInstructionResult]`
+- `instance SetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+- `instance SetField transferResults WalletUserProxy_BatchTransferResult [TransferInstructionResult]`
+- `instance HasExercise WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult`
 
 ## Functions
 
-<div id="function-splice-util-featuredapp-walletuserproxy-getfirstsender-96870">
+<span id="function-splice-util-featuredapp-walletuserproxy-getfirstsender-96870"></span>
 
-getFirstSender
-: \[TransferFactoryCall\] -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+### `getFirstSender`
+
+```daml
+getFirstSender : [TransferFactoryCall] -> Party
+```
 
 Determine the sender of the transfer in the first call.
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-runbatch-13560"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-runbatch-13560">
+### `runBatch`
 
-runBatch
-: WalletUserProxy -\> WalletUserProxy_BatchTransfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) WalletUserProxy_BatchTransferResult
+```daml
+runBatch : WalletUserProxy -> WalletUserProxy_BatchTransfer -> Update WalletUserProxy_BatchTransferResult
+```
 
 Validate the batch call and run it
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-executetransfercalls-34186"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-executetransfercalls-34186">
+### `executeTransferCalls`
 
-executeTransferCalls
-: WalletUserProxy -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) -\> \[TransferFactoryCall\] -\> InstrumentHoldingMap -\> \[TransferInstructionResult\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) WalletUserProxy_BatchTransferResult
+```daml
+executeTransferCalls : WalletUserProxy -> Party -> Optional (ContractId FeaturedAppRight) -> [TransferFactoryCall] -> InstrumentHoldingMap -> [TransferInstructionResult] -> Update WalletUserProxy_BatchTransferResult
+```
 
 Run the individual transfer calls in the batch with proper threading of input holdings.
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-exerciseproxychoice-45581"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-exerciseproxychoice-45581">
+### `exerciseProxyChoice`
 
-exerciseProxyChoice
-: [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) t ch r =\> WalletUserProxy -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> ProxyArg ch -\> ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (ProxyResult r)
+```daml
+exerciseProxyChoice : HasExercise t ch r => WalletUserProxy -> ContractId t -> ProxyArg ch -> (ContractId t -> Update Party) -> Update (ProxyResult r)
+```
 
 Shared code to execute the proxied choice.
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-validateappright-75174"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-validateappright-75174">
+### `validateAppRight`
 
-validateAppRight
-: WalletUserProxy -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+validateAppRight : WalletUserProxy -> ContractId FeaturedAppRight -> Update ()
+```
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-checkallowlist-76724"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-checkallowlist-76724">
+### `checkAllowList`
 
-checkAllowList
-: [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+checkAllowList : Optional [Party] -> Party -> Update ()
+```
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-createappmarker-13733"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-createappmarker-13733">
+### `createAppMarker`
 
-createAppMarker
-: WalletUserProxy -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+```daml
+createAppMarker : WalletUserProxy -> Party -> ContractId FeaturedAppRight -> Update FeaturedAppRight_CreateActivityMarkerResult
+```
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-proxybeneficiaries-11168"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-proxybeneficiaries-11168">
+### `proxyBeneficiaries`
 
-proxyBeneficiaries
-: WalletUserProxy -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[AppRewardBeneficiary\]
+```daml
+proxyBeneficiaries : WalletUserProxy -> Party -> [AppRewardBeneficiary]
+```
 
 Get the list of beneficiaries for the featured app marker.
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-validproxy-47629"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-validproxy-47629">
+### `validProxy`
 
-validProxy
-: WalletUserProxy -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+```daml
+validProxy : WalletUserProxy -> Bool
+```
 
-</div>
+<span id="function-splice-util-featuredapp-walletuserproxy-require-57479"></span>
 
-<div id="function-splice-util-featuredapp-walletuserproxy-require-57479">
+### `require`
 
-require
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
 
-Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
 
-</div>
+## Templates
 
-{/* COPIED_END */}
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxy-95528"></span>
+
+### Template `WalletUserProxy`
+
+A proxy to attribute the activity of a wallet user to the wallet app provider.
+
+The intended usage is for the wallet app provider to
+1. create a `WalletUserProxy` contract with the `provider` set to the app provider's party
+2. setup their wallet frontend such that users call the proxy's choices instead of the original token standard choices.
+
+Note that the weights are specified on the proxy contract, so that they are under the providers
+control. If they were specified on the choices, then the user could in principle change them,
+and grant themselves a higher reward than intended.
+
+Note also that the batch transfer support can be used without having a featured app right.
+
+Signatories: `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party | The app provider whose featured app right should be triggered |
+| providerWeight | Decimal | Reward weight for the provider |
+| userWeight | Decimal | Reward weight for the user, set to 0.0 if the user should not receive a reward |
+| extraBeneficiaries | [AppRewardBeneficiary] | Extra beneficiaries to add |
+| optAllowList | Optional [Party] | An optional allow list of parties that can use the proxy |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `provider`
+
+Returns: `()`
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationfactoryallocate-70856"></span>
+
+#### Choice `WalletUserProxy_AllocationFactory_Allocate`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AllocationFactory |  |
+| proxyArg | ProxyArg AllocationFactory_Allocate |  |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationwithdraw-8358"></span>
+
+#### Choice `WalletUserProxy_Allocation_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Allocation |  |
+| proxyArg | ProxyArg Allocation_Withdraw |  |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransfer-93002"></span>
+
+#### Choice `WalletUserProxy_BatchTransfer`
+
+Controllers: `getFirstSender transferCalls`
+
+Returns: `WalletUserProxy_BatchTransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferCalls | [TransferFactoryCall] | Transfers to execute via their respective transfer factories.<br/><br/>Input holdings are properly threaded through for all instrument-ids.<br/><br/>The sender change is always added back as an additional input to follow-up transfers<br/><br/>for the same instrument-ids.<br/><br/>Note that we accept fully specified calls to factories for maximum flexibility.<br/><br/>Some token admins may actually use different factories for different recipients,<br/><br/>e.g., to implement preapprovals. |
+| optFeaturedAppRightCid | Optional (ContractId FeaturedAppRight) | The featured app right contract of the provider to use on every transfer.<br/><br/>Optional so the batched choice can be used without a featured app right. |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxypublicfetch-18804"></span>
+
+#### Choice `WalletUserProxy_PublicFetch`
+
+Controllers: `actor`
+
+Returns: `WalletUserProxy`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferfactorytransfer-32457"></span>
+
+#### Choice `WalletUserProxy_TransferFactory_Transfer`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferFactory |  |
+| proxyArg | ProxyArg TransferFactory_Transfer |  |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionaccept-38416"></span>
+
+#### Choice `WalletUserProxy_TransferInstruction_Accept`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Accept |  |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionreject-59713"></span>
+
+#### Choice `WalletUserProxy_TransferInstruction_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Reject |  |
+
+<span id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionwithdraw-40772"></span>
+
+#### Choice `WalletUserProxy_TransferInstruction_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Withdraw |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index.mdx
@@ -1,14 +1,195 @@
 ---
-title: "splice-util-token-standard-wallet docs"
-description: "Documentation for splice-util-token-standard-wallet docs"
+title: "splice-util-token-standard-wallet"
+description: "Reference documentation for splice-util-token-standard-wallet modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-token-standard-wallet/docs/index.rst" tag="0.6.4" hash="1c1fbd22" */}
+<div class="x2mdx-ref-hero">
 
-Optional package implementing common workflows of wallets using the Token Standard. Not uploaded by default to a validator node.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-- [Splice.Util.Token.Wallet.MergeDelegation](/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation)
 
-See also the `module-splice-util-featuredapp-walletuserproxy-40223` for code that simplifies integrating wallets with featured app rewards.
+  <h1 class="x2mdx-ref-title">splice-util-token-standard-wallet</h1>
 
-{/* COPIED_END */}
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-util-token-standard-wallet, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Util.Token.Wallet.MergeDelegation</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Delegation from users to wallet operators allowing them to merge</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation.mdx
@@ -1,561 +1,503 @@
 ---
 title: "Splice.Util.Token.Wallet.MergeDelegation"
-description: "Documentation for Splice.Util.Token.Wallet.MergeDelegation"
+description: "Reference documentation for Daml module Splice.Util.Token.Wallet.MergeDelegation."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util-token-standard-wallet/docs/Splice-Util-Token-Wallet-MergeDelegation.rst" tag="0.6.4" hash="0129edf8" */}
+<span id="module-splice-util-token-wallet-mergedelegation-69903"></span>
 
-Delegation from users to wallet operators allowing them to merge their token standard holdings; and optionally transfer tokens from the operator to the user as part of the merge operation, e.g., for efficiently implementing extraTransfers.
+# Splice.Util.Token.Wallet.MergeDelegation
+
+Delegation from users to wallet operators allowing them to merge
+
+their token standard holdings; and optionally transfer tokens from
+
+the operator to the user as part of the merge operation, e.g., for
+
+efficiently implementing extraTransfers.
 
 The main reasons for using this merge delegation infrastructure are:
 
-- keeping the number of holdings low to reduce storage and compute cost on the validator node hosting them
-- batching operations to execute them more efficiently both in terms of traffic spend and throughput
+- keeping the number of holdings low to reduce storage and compute cost
 
-## Templates
+on the validator node hosting them
 
-<div id="type-splice-util-token-wallet-mergedelegation-batchmergeutility-64168">
+- batching operations to execute them more efficiently both in terms
 
-**template** BatchMergeUtility
+of traffic spend and throughput
 
-</div>
+## Module Snapshot
 
-> Utility contract for a operator to execute a batch of merge calls with proper threading of the operator's change holdings between the calls that involve extra transfers.
->
-> Signatory: operator
->
-> | Field    | Type                                                                                                                | Description |
-> |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> | operator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - **Choice** Archive
->
->   Controller: operator
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmerge-8070">
->
->   **Choice** BatchMergeUtility_BatchMerge
->
->   </div>
->
->   Controller: operator
->
->   Returns: BatchMergeUtility_BatchMergeResult
->
->   | Field      | Type                    | Description |
->   |------------|-------------------------|-------------|
->   | mergeCalls | \[MergeDelegationCall\] |             |
-
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegation-14952">
-
-**template** MergeDelegation
-
-</div>
-
-> The right for a operator like the wallet app operator to merge token standard holdings on behalf of a token owner.
->
-> Signatory: owner, operator
->
-> | Field    | Type                                                                                                                | Description                                            |
-> |----------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-> | operator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Operator allowed to merge holdings.                    |
-> | owner    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Owner delegating their right.                          |
-> | meta     | Metadata                                                                                                            | Metadata about the delegation, used for extensibility. |
->
-> - **Choice** Archive
->
->   Controller: owner, operator
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationmerge-40083">
->
->   **Choice** MergeDelegation_Merge
->
->   </div>
->
->   Controller: operator
->
->   Returns: MergeDelegation_MergeResult
->
->   | Field               | Type                                                                                                                                                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
->   |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | optMergeTransfer    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall         | The self-transfer to merge holdings for the owner. Optional to allow for an extra transfer to be executed when the owner does not yet have any holdings. At least one of optMergeTransfer or optExtraTransfer must be provided.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
->   | optExtraTransfer    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall         | An optional extra transfer from the operator to the user to execute as part of the merge operation. The amount of the self-transfer will be increased by the amount of the extra transfer, and the new input holdings from the extra transfer will be added to the self-transfer's input holdings. These extra transfers can for example be used to efficiently implement extraTransfers or reward distributions as part of the merge operation. Note that extra transfers only work for users that have preapproved incoming transfers from the operator. Therefore there is no additional restriction on the merge delegation to let users decide whether to allow or disallow those transfers as it is already controlled through the preapproval. |
->   | optFeaturedAppRight | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FeaturedAppRightCall | The featured app right to use to feature the operator's merging activity.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationreject-58487">
->
->   **Choice** MergeDelegation_Reject
->
->   </div>
->
->   Controller: operator
->
->   Returns: MergeDelegation_RejectResult
->
->   (no fields)
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdraw-32286">
->
->   **Choice** MergeDelegation_Withdraw
->
->   </div>
->
->   Controller: owner
->
->   Returns: MergeDelegation_WithdrawResult
->
->   (no fields)
-
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposal-17546">
-
-**template** MergeDelegationProposal
-
-</div>
-
-> Proposal by the user to setup a merge delegation.
->
-> Signatory: (DA.Internal.Record.getField @"owner" delegation)
->
-> | Field      | Type            | Description                               |
-> |------------|-----------------|-------------------------------------------|
-> | delegation | MergeDelegation | The delegation to be created if accepted. |
->
-> - **Choice** Archive
->
->   Controller: (DA.Internal.Record.getField @"owner" delegation)
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalaccept-29492">
->
->   **Choice** MergeDelegationProposal_Accept
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"operator" delegation)
->
->   Returns: MergeDelegationProposal_AcceptResult
->
->   (no fields)
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalreject-90901">
->
->   **Choice** MergeDelegationProposal_Reject
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"operator" delegation)
->
->   Returns: MergeDelegationProposal_RejectResult
->
->   (no fields)
->
-> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdraw-80248">
->
->   **Choice** MergeDelegationProposal_Withdraw
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"owner" delegation)
->
->   Returns: MergeDelegationProposal_WithdrawResult
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-21039">
+<span id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-21039"></span>
 
-**data** BatchMergeUtility_BatchMergeResult
+### `data BatchMergeUtility_BatchMergeResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-14556">
->
-> BatchMergeUtility_BatchMergeResult
->
-> </div>
->
-> > | Field             | Type                            | Description                                                       |
-> > |-------------------|---------------------------------|-------------------------------------------------------------------|
-> > | results           | \[MergeDelegation_MergeResult\] | Results of each individual merge delegation call.                 |
-> > | operatorChangeMap | InstrumentHoldingMap            | Change holdings for the operator after executing extra transfers. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BatchMergeUtility_BatchMergeResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BatchMergeUtility_BatchMergeResult
->
-> **instance** GetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
->
-> **instance** GetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
->
-> **instance** SetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
->
-> **instance** SetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult
+<span id="constr-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-14556"></span>
 
-<div id="type-splice-util-token-wallet-mergedelegation-featuredapprightcall-44578">
+- `BatchMergeUtility_BatchMergeResult`
 
-**data** FeaturedAppRightCall
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [MergeDelegation_MergeResult] | Results of each individual merge delegation call. |
+| operatorChangeMap | InstrumentHoldingMap | Change holdings for the operator after executing extra transfers. |
 
-</div>
+Instances:
 
-> A call to create featured app markers using a featured app right.
->
-> <div id="constr-splice-util-token-wallet-mergedelegation-featuredapprightcall-28365">
->
-> FeaturedAppRightCall
->
-> </div>
->
-> > | Field         | Type                                                                                                                                           | Description |
-> > |---------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | appRightCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
-> > | beneficiaries | \[AppRewardBeneficiary\]                                                                                                                       |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) FeaturedAppRightCall
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) FeaturedAppRightCall
->
-> **instance** GetField "appRightCid" FeaturedAppRightCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** GetField "beneficiaries" FeaturedAppRightCall \[AppRewardBeneficiary\]
->
-> **instance** GetField "optFeaturedAppRight" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FeaturedAppRightCall)
->
-> **instance** SetField "appRightCid" FeaturedAppRightCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
->
-> **instance** SetField "beneficiaries" FeaturedAppRightCall \[AppRewardBeneficiary\]
->
-> **instance** SetField "optFeaturedAppRight" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FeaturedAppRightCall)
+- `instance Eq BatchMergeUtility_BatchMergeResult`
+- `instance Show BatchMergeUtility_BatchMergeResult`
+- `instance GetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+- `instance GetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance SetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+- `instance SetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance HasExercise BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult`
+- `instance HasFromAnyChoice BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult`
+- `instance HasToAnyChoice BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult`
 
-<div id="type-splice-util-token-wallet-mergedelegation-instrumentholdingmap-42719">
+<span id="type-splice-util-token-wallet-mergedelegation-featuredapprightcall-44578"></span>
 
-**type** InstrumentHoldingMap
-= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) InstrumentId \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+### `data FeaturedAppRightCall`
 
-**instance** GetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
+A call to create featured app markers using a featured app right.
 
-**instance** SetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
+Constructors:
 
-</div>
+<span id="constr-splice-util-token-wallet-mergedelegation-featuredapprightcall-28365"></span>
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationcall-90300">
+- `FeaturedAppRightCall`
 
-**data** MergeDelegationCall
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| appRightCid | ContractId FeaturedAppRight |  |
+| beneficiaries | [AppRewardBeneficiary] |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationcall-66961">
->
-> MergeDelegationCall
->
-> </div>
->
-> > | Field         | Type                                                                                                                                          | Description |
-> > |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | delegationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation |             |
-> > | choiceArg     | MergeDelegation_Merge                                                                                                                         |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationCall
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationCall
->
-> **instance** GetField "choiceArg" MergeDelegationCall MergeDelegation_Merge
->
-> **instance** GetField "delegationCid" MergeDelegationCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
->
-> **instance** GetField "mergeCalls" BatchMergeUtility_BatchMerge \[MergeDelegationCall\]
->
-> **instance** SetField "choiceArg" MergeDelegationCall MergeDelegation_Merge
->
-> **instance** SetField "delegationCid" MergeDelegationCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
->
-> **instance** SetField "mergeCalls" BatchMergeUtility_BatchMerge \[MergeDelegationCall\]
+- `instance Eq FeaturedAppRightCall`
+- `instance Show FeaturedAppRightCall`
+- `instance GetField appRightCid FeaturedAppRightCall (ContractId FeaturedAppRight)`
+- `instance GetField beneficiaries FeaturedAppRightCall [AppRewardBeneficiary]`
+- `instance GetField optFeaturedAppRight MergeDelegation_Merge (Optional FeaturedAppRightCall)`
+- `instance SetField appRightCid FeaturedAppRightCall (ContractId FeaturedAppRight)`
+- `instance SetField beneficiaries FeaturedAppRightCall [AppRewardBeneficiary]`
+- `instance SetField optFeaturedAppRight MergeDelegation_Merge (Optional FeaturedAppRightCall)`
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-63821">
+<span id="type-splice-util-token-wallet-mergedelegation-instrumentholdingmap-42719"></span>
 
-**data** MergeDelegationProposal_AcceptResult
+### `type InstrumentHoldingMap = Map InstrumentId [ContractId Holding]`
 
-</div>
+Instances:
 
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-91086">
->
-> MergeDelegationProposal_AcceptResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                          | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | mergeDelegationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationProposal_AcceptResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationProposal_AcceptResult
->
-> **instance** GetField "mergeDelegationCid" MergeDelegationProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
->
-> **instance** SetField "mergeDelegationCid" MergeDelegationProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult
+- `instance GetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+- `instance SetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-81380">
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationcall-90300"></span>
 
-**data** MergeDelegationProposal_RejectResult
+### `data MergeDelegationCall`
 
-</div>
+Constructors:
 
-> Dedicated record type to simplify upgrading
->
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-11455">
->
-> MergeDelegationProposal_RejectResult
->
-> </div>
->
-> > | Field  | Type | Description |
-> > |--------|------|-------------|
-> > | result | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationProposal_RejectResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationProposal_RejectResult
->
-> **instance** GetField "result" MergeDelegationProposal_RejectResult ()
->
-> **instance** SetField "result" MergeDelegationProposal_RejectResult ()
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationcall-66961"></span>
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-14389">
+- `MergeDelegationCall`
 
-**data** MergeDelegationProposal_WithdrawResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| delegationCid | ContractId MergeDelegation |  |
+| choiceArg | MergeDelegation_Merge |  |
 
-</div>
+Instances:
 
-> Dedicated record type to simplify upgrading
->
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-8570">
->
-> MergeDelegationProposal_WithdrawResult
->
-> </div>
->
-> > | Field  | Type | Description |
-> > |--------|------|-------------|
-> > | result | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationProposal_WithdrawResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationProposal_WithdrawResult
->
-> **instance** GetField "result" MergeDelegationProposal_WithdrawResult ()
->
-> **instance** SetField "result" MergeDelegationProposal_WithdrawResult ()
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult
+- `instance Eq MergeDelegationCall`
+- `instance Show MergeDelegationCall`
+- `instance GetField choiceArg MergeDelegationCall MergeDelegation_Merge`
+- `instance GetField delegationCid MergeDelegationCall (ContractId MergeDelegation)`
+- `instance GetField mergeCalls BatchMergeUtility_BatchMerge [MergeDelegationCall]`
+- `instance SetField choiceArg MergeDelegationCall MergeDelegation_Merge`
+- `instance SetField delegationCid MergeDelegationCall (ContractId MergeDelegation)`
+- `instance SetField mergeCalls BatchMergeUtility_BatchMerge [MergeDelegationCall]`
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-93186">
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-63821"></span>
 
-**data** MergeDelegation_MergeResult
+### `data MergeDelegationProposal_AcceptResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-31679">
->
-> MergeDelegation_MergeResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                     | Description |
-> > |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | optMergeTransferResult | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult |             |
-> > | optExtraTransferResult | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegation_MergeResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegation_MergeResult
->
-> **instance** GetField "optExtraTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
->
-> **instance** GetField "optMergeTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
->
-> **instance** GetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
->
-> **instance** SetField "optExtraTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
->
-> **instance** SetField "optMergeTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
->
-> **instance** SetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-91086"></span>
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-25578">
+- `MergeDelegationProposal_AcceptResult`
 
-**data** MergeDelegation_RejectResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mergeDelegationCid | ContractId MergeDelegation |  |
 
-</div>
+Instances:
 
-> Dedicated record type to simplify upgrading
->
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-53673">
->
-> MergeDelegation_RejectResult
->
-> </div>
->
-> > | Field  | Type | Description |
-> > |--------|------|-------------|
-> > | result | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegation_RejectResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegation_RejectResult
->
-> **instance** GetField "result" MergeDelegation_RejectResult ()
->
-> **instance** SetField "result" MergeDelegation_RejectResult ()
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult
+- `instance Eq MergeDelegationProposal_AcceptResult`
+- `instance Show MergeDelegationProposal_AcceptResult`
+- `instance GetField mergeDelegationCid MergeDelegationProposal_AcceptResult (ContractId MergeDelegation)`
+- `instance SetField mergeDelegationCid MergeDelegationProposal_AcceptResult (ContractId MergeDelegation)`
+- `instance HasExercise MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult`
+- `instance HasFromAnyChoice MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult`
+- `instance HasToAnyChoice MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult`
 
-<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-70671">
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-81380"></span>
 
-**data** MergeDelegation_WithdrawResult
+### `data MergeDelegationProposal_RejectResult`
 
-</div>
+Dedicated record type to simplify upgrading
 
-> Dedicated record type to simplify upgrading
->
-> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-6896">
->
-> MergeDelegation_WithdrawResult
->
-> </div>
->
-> > | Field  | Type | Description |
-> > |--------|------|-------------|
-> > | result | ()   |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegation_WithdrawResult
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegation_WithdrawResult
->
-> **instance** GetField "result" MergeDelegation_WithdrawResult ()
->
-> **instance** SetField "result" MergeDelegation_WithdrawResult ()
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult
+Constructors:
 
-<div id="type-splice-util-token-wallet-mergedelegation-transfercall-7536">
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-11455"></span>
 
-**data** TransferCall
+- `MergeDelegationProposal_RejectResult`
 
-</div>
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
 
-> A call to perform a transfer using a transfer factory.
->
-> <div id="constr-splice-util-token-wallet-mergedelegation-transfercall-34031">
->
-> TransferCall
->
-> </div>
->
-> > | Field      | Type                                                                                                                                          | Description |
-> > |------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | factoryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
-> > | choiceArg  | TransferFactory_Transfer                                                                                                                      |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCall
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCall
->
-> **instance** GetField "choiceArg" TransferCall TransferFactory_Transfer
->
-> **instance** GetField "factoryCid" TransferCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
->
-> **instance** GetField "optExtraTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
->
-> **instance** GetField "optMergeTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
->
-> **instance** SetField "choiceArg" TransferCall TransferFactory_Transfer
->
-> **instance** SetField "factoryCid" TransferCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
->
-> **instance** SetField "optExtraTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
->
-> **instance** SetField "optMergeTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
+Instances:
+
+- `instance Eq MergeDelegationProposal_RejectResult`
+- `instance Show MergeDelegationProposal_RejectResult`
+- `instance GetField result MergeDelegationProposal_RejectResult ()`
+- `instance SetField result MergeDelegationProposal_RejectResult ()`
+- `instance HasExercise MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult`
+- `instance HasFromAnyChoice MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult`
+- `instance HasToAnyChoice MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-14389"></span>
+
+### `data MergeDelegationProposal_WithdrawResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-8570"></span>
+
+- `MergeDelegationProposal_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegationProposal_WithdrawResult`
+- `instance Show MergeDelegationProposal_WithdrawResult`
+- `instance GetField result MergeDelegationProposal_WithdrawResult ()`
+- `instance SetField result MergeDelegationProposal_WithdrawResult ()`
+- `instance HasExercise MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult`
+- `instance HasFromAnyChoice MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult`
+- `instance HasToAnyChoice MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-93186"></span>
+
+### `data MergeDelegation_MergeResult`
+
+Constructors:
+
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-31679"></span>
+
+- `MergeDelegation_MergeResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| optMergeTransferResult | Optional TransferInstructionResult |  |
+| optExtraTransferResult | Optional TransferInstructionResult |  |
+
+Instances:
+
+- `instance Eq MergeDelegation_MergeResult`
+- `instance Show MergeDelegation_MergeResult`
+- `instance GetField optExtraTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance GetField optMergeTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance GetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance SetField optExtraTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance SetField optMergeTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance SetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance HasExercise MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult`
+- `instance HasFromAnyChoice MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult`
+- `instance HasToAnyChoice MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-25578"></span>
+
+### `data MergeDelegation_RejectResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-53673"></span>
+
+- `MergeDelegation_RejectResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegation_RejectResult`
+- `instance Show MergeDelegation_RejectResult`
+- `instance GetField result MergeDelegation_RejectResult ()`
+- `instance SetField result MergeDelegation_RejectResult ()`
+- `instance HasExercise MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult`
+- `instance HasFromAnyChoice MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult`
+- `instance HasToAnyChoice MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-70671"></span>
+
+### `data MergeDelegation_WithdrawResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<span id="constr-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-6896"></span>
+
+- `MergeDelegation_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegation_WithdrawResult`
+- `instance Show MergeDelegation_WithdrawResult`
+- `instance GetField result MergeDelegation_WithdrawResult ()`
+- `instance SetField result MergeDelegation_WithdrawResult ()`
+- `instance HasExercise MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult`
+- `instance HasFromAnyChoice MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult`
+- `instance HasToAnyChoice MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-transfercall-7536"></span>
+
+### `data TransferCall`
+
+A call to perform a transfer using a transfer factory.
+
+Constructors:
+
+<span id="constr-splice-util-token-wallet-mergedelegation-transfercall-34031"></span>
+
+- `TransferCall`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| factoryCid | ContractId TransferFactory |  |
+| choiceArg | TransferFactory_Transfer |  |
+
+Instances:
+
+- `instance Eq TransferCall`
+- `instance Show TransferCall`
+- `instance GetField choiceArg TransferCall TransferFactory_Transfer`
+- `instance GetField factoryCid TransferCall (ContractId TransferFactory)`
+- `instance GetField optExtraTransfer MergeDelegation_Merge (Optional TransferCall)`
+- `instance GetField optMergeTransfer MergeDelegation_Merge (Optional TransferCall)`
+- `instance SetField choiceArg TransferCall TransferFactory_Transfer`
+- `instance SetField factoryCid TransferCall (ContractId TransferFactory)`
+- `instance SetField optExtraTransfer MergeDelegation_Merge (Optional TransferCall)`
+- `instance SetField optMergeTransfer MergeDelegation_Merge (Optional TransferCall)`
 
 ## Functions
 
-<div id="function-splice-util-token-wallet-mergedelegation-runbatch-68276">
+<span id="function-splice-util-token-wallet-mergedelegation-runbatch-68276"></span>
 
-runBatch
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[MergeDelegationCall\] -\> InstrumentHoldingMap -\> \[MergeDelegation_MergeResult\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BatchMergeUtility_BatchMergeResult
+### `runBatch`
+
+```daml
+runBatch : Party -> [MergeDelegationCall] -> InstrumentHoldingMap -> [MergeDelegation_MergeResult] -> Update BatchMergeUtility_BatchMergeResult
+```
 
 Run a batch of token standard transfers.
 
-</div>
+<span id="function-splice-util-token-wallet-mergedelegation-createactivitymarkerforprovider-74667"></span>
 
-<div id="function-splice-util-token-wallet-mergedelegation-createactivitymarkerforprovider-74667">
+### `createActivityMarkerForProvider`
 
-createActivityMarkerForProvider
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> FeaturedAppRightCall -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+createActivityMarkerForProvider : Party -> FeaturedAppRightCall -> Update ()
+```
 
-</div>
+<span id="function-splice-util-token-wallet-mergedelegation-checkexpected-33668"></span>
 
-<div id="function-splice-util-token-wallet-mergedelegation-checkexpected-33668">
+### `checkExpected`
 
-checkExpected
-: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a) =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> a -\> a -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+checkExpected : (Eq a, Show a) => Text -> a -> a -> Update ()
+```
 
-</div>
+<span id="function-splice-util-token-wallet-mergedelegation-require-88931"></span>
 
-<div id="function-splice-util-token-wallet-mergedelegation-require-88931">
+### `require`
 
-require
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
 
-Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
 
-</div>
+## Templates
 
-{/* COPIED_END */}
+<span id="type-splice-util-token-wallet-mergedelegation-batchmergeutility-64168"></span>
+
+### Template `BatchMergeUtility`
+
+Utility contract for a operator to execute a batch of merge calls with
+proper threading of the operator's change holdings between the calls that
+involve extra transfers.
+
+Signatories: `operator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| operator | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `operator`
+
+Returns: `()`
+
+<span id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmerge-8070"></span>
+
+#### Choice `BatchMergeUtility_BatchMerge`
+
+Controllers: `operator`
+
+Returns: `BatchMergeUtility_BatchMergeResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mergeCalls | [MergeDelegationCall] |  |
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegation-14952"></span>
+
+### Template `MergeDelegation`
+
+The right for a operator like the wallet app operator to merge token
+standard holdings on behalf of a token owner.
+
+Signatories: `owner`, `operator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| operator | Party | Operator allowed to merge holdings. |
+| owner | Party | Owner delegating their right. |
+| meta | Metadata | Metadata about the delegation, used for extensibility. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `owner`, `operator`
+
+Returns: `()`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationmerge-40083"></span>
+
+#### Choice `MergeDelegation_Merge`
+
+Controllers: `operator`
+
+Returns: `MergeDelegation_MergeResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| optMergeTransfer | Optional TransferCall | The self-transfer to merge holdings for the owner.<br/><br/>Optional to allow for an extra transfer to be executed when the<br/><br/>owner does not yet have any holdings.<br/><br/>At least one of optMergeTransfer or optExtraTransfer must be provided. |
+| optExtraTransfer | Optional TransferCall | An optional extra transfer from the operator to the user to execute<br/><br/>as part of the merge operation. The amount of the self-transfer will be<br/><br/>increased by the amount of the extra transfer, and the new input holdings from the<br/><br/>extra transfer will be added to the self-transfer's input holdings.<br/><br/>These extra transfers can for example be used to efficiently<br/><br/>implement extraTransfers or reward distributions as part of the merge<br/><br/>operation.<br/><br/>Note that extra transfers only work for users that have preapproved<br/><br/>incoming transfers from the operator. Therefore there is no<br/><br/>additional restriction on the merge delegation to let users decide<br/><br/>whether to allow or disallow those transfers as it is already<br/><br/>controlled through the preapproval. |
+| optFeaturedAppRight | Optional FeaturedAppRightCall | The featured app right to use to feature the operator's merging activity. |
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationreject-58487"></span>
+
+#### Choice `MergeDelegation_Reject`
+
+Controllers: `operator`
+
+Returns: `MergeDelegation_RejectResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdraw-32286"></span>
+
+#### Choice `MergeDelegation_Withdraw`
+
+Controllers: `owner`
+
+Returns: `MergeDelegation_WithdrawResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposal-17546"></span>
+
+### Template `MergeDelegationProposal`
+
+Proposal by the user to setup a merge delegation.
+
+Signatories: `(DA.Internal.Record.getField @"owner" delegation)`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| delegation | MergeDelegation | The delegation to be created if accepted. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"owner" delegation)`
+
+Returns: `()`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalaccept-29492"></span>
+
+#### Choice `MergeDelegationProposal_Accept`
+
+Controllers: `(DA.Internal.Record.getField @"operator" delegation)`
+
+Returns: `MergeDelegationProposal_AcceptResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalreject-90901"></span>
+
+#### Choice `MergeDelegationProposal_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"operator" delegation)`
+
+Returns: `MergeDelegationProposal_RejectResult`
+
+<span id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdraw-80248"></span>
+
+#### Choice `MergeDelegationProposal_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"owner" delegation)`
+
+Returns: `MergeDelegationProposal_WithdrawResult`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util/index.mdx
@@ -1,10 +1,195 @@
 ---
-title: "splice-util docs"
-description: "Documentation for splice-util docs"
+title: "splice-util"
+description: "Reference documentation for splice-util modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util/docs/index.rst" tag="0.6.4" hash="169b4e1f" */}
+<div class="x2mdx-ref-hero">
 
-- [Splice.Util](/sdks-tools/api-reference/splice-daml/splice-util/splice-util)
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-{/* COPIED_END */}
+
+  <h1 class="x2mdx-ref-title">splice-util</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-util, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-util/splice-util">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Util</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Utility functions shared across all splice apps.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util/splice-util.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util/splice-util.mdx
@@ -1,222 +1,247 @@
 ---
 title: "Splice.Util"
-description: "Documentation for Splice.Util"
+description: "Reference documentation for Daml module Splice.Util."
 ---
 
-{/* COPIED_START source="splice:daml/splice-util/docs/Splice-Util.rst" tag="0.6.4" hash="ad0bba02" */}
+<span id="module-splice-util-50740"></span>
+
+# Splice.Util
 
 Utility functions shared across all splice apps.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Typeclasses
 
-<div id="class-splice-util-hascheckedfetch-36555">
+<span id="class-splice-util-hascheckedfetch-36555"></span>
 
-**class** ([Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) t, [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) cgid, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) cgid) =\> HasCheckedFetch t cgid **where**
+### `class (Show t, Eq cgid, Show cgid) => HasCheckedFetch t cgid`
 
-</div>
+Contracts typically come in groups. For example, all contracts managed by a specific DSO party.
 
-> Contracts typically come in groups. For example, all contracts managed by a specific DSO party.
->
-> We aim to always fetch with a specific contract group identifier to ensure that we do not mixup contracts from different groups.
->
-> Note that we are not requiring `HasFetch` here, so that we can use this typeclass also for contract groups that are not templates, e.g., interface views.
->
-> <div id="function-splice-util-contractgroupid-63283">
->
-> contractGroupId
-> : t -\> cgid
->
-> </div>
+We aim to always fetch with a specific contract group identifier to ensure that we do not mixup
+contracts from different groups.
 
-<div id="class-splice-util-patchable-41062">
+Note that we are not requiring `HasFetch` here, so that we can use this typeclass also for
+contract groups that are not templates, e.g., interface views.
 
-**class** Patchable a **where**
+Methods:
 
-</div>
+- `contractGroupId : t -> cgid`
 
-> A type class for patching values. Used in particular for changing only a subset of fields in a config value.
->
-> <div id="function-splice-util-patch-72775">
->
-> patch
-> : a -\> a -\> a -\> a
->
-> For records, `patch new base current` should set all fields in `current` to their value in `new` iff their value was changed in `new` compared to `base`. For other kinds of values that have field-like values (e.g. Maps with keys) the implementation should match the one for records by analogy.
->
-> </div>
->
-> **instance** Patchable [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** Patchable [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
->
-> **instance** Patchable [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** ([Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) k, Patchable v) =\> Patchable ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) k v)
->
-> **instance** Patchable [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** Patchable [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
->
-> **instance** Patchable a =\> Patchable ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a)
->
-> **instance** (Patchable a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a) =\> Patchable (Set a)
->
-> **instance** Patchable [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+<span id="class-splice-util-patchable-41062"></span>
+
+### `class Patchable a`
+
+A type class for patching values. Used in particular for changing only a subset of
+fields in a config value.
+
+Methods:
+
+- `patch : a -> a -> a -> a`
+  For records, `patch new base current` should set all fields in `current` to their value in `new` iff their value was changed
+  in `new` compared to `base`. For other kinds of values that have field-like values
+  (e.g. Maps with keys) the implementation should match the one for records
+  by analogy.
+
+Instances:
+
+- `instance Patchable Decimal`
+- `instance Patchable Int`
+- `instance Patchable Text`
+- `instance (Ord k, Patchable v) => Patchable (Map k v)`
+- `instance Patchable Party`
+- `instance Patchable Time`
+- `instance Patchable a => Patchable (Optional a)`
+- `instance (Patchable a, Ord a) => Patchable (Set a)`
+- `instance Patchable RelTime`
 
 ## Functions
 
-<div id="function-splice-util-requirematchingcontract-54053">
+<span id="function-splice-util-requirematchingcontract-54053"></span>
 
-requireMatchingContract
-: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) t, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) t, [HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t) =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+### `requireMatchingContract`
+
+```daml
+requireMatchingContract : (Eq t, Show t, HasFetch t) => ContractId t -> t -> Update ()
+```
 
 Require that a contract-id refers to a specific contract.
 
-</div>
+<span id="function-splice-util-require-11486"></span>
 
-<div id="function-splice-util-require-11486">
+### `require`
 
-require
-: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
 
-Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
 
-</div>
+<span id="function-splice-util-fetchchecked-58913"></span>
 
-<div id="function-splice-util-fetchchecked-58913">
+### `fetchChecked`
 
-fetchChecked
-: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchChecked : (HasFetch t, HasCheckedFetch t cgid) => cgid -> ContractId t -> Update t
+```
 
 Fetch a contract that is part of a specific contract group.
 
 The group is typically chosen by the caller to match its own group, or a more specific group.
 
-</div>
+<span id="function-splice-util-fetchcheckedinterface-8937"></span>
 
-<div id="function-splice-util-fetchcheckedinterface-8937">
+### `fetchCheckedInterface`
 
-fetchCheckedInterface
-: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) i, [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) i v, HasCheckedFetch v cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) i -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) i
+```daml
+fetchCheckedInterface : (HasFetch i, HasInterfaceView i v, HasCheckedFetch v cgid) => cgid -> ContractId i -> Update i
+```
 
 Fetch a contract that is part of a specific contract group defined by its interface view.
 
 The group is typically chosen by the caller to match its own group, or a more specific group.
 
-</div>
+<span id="function-splice-util-fetchandarchive-96960"></span>
 
-<div id="function-splice-util-fetchandarchive-96960">
+### `fetchAndArchive`
 
-fetchAndArchive
-: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid, [HasArchive](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasarchive-7071) t) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchAndArchive : (HasFetch t, HasCheckedFetch t cgid, HasArchive t) => cgid -> ContractId t -> Update t
+```
 
 Fetch and archive a contract in one go.
 
-Use this when implementing choices that mutate another contract by fetching, archiving, and then creating the updated contract.
+Use this when implementing choices that mutate another contract by
+fetching, archiving, and then creating the updated contract.
 
-</div>
+<span id="function-splice-util-fetchreferencedata-72475"></span>
 
-<div id="function-splice-util-fetchreferencedata-72475">
+### `fetchReferenceData`
 
-fetchReferenceData
-: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchReferenceData : (HasFetch t, HasCheckedFetch t cgid) => cgid -> ContractId t -> Update t
+```
 
 Fetch a contract that serves as reference data.
 
 Use this whenever you need to fetch a contract that you do not intend to mutate.
 
-</div>
+<span id="function-splice-util-fetchbutarchivelater-86159"></span>
 
-<div id="function-splice-util-fetchbutarchivelater-86159">
+### `fetchButArchiveLater`
 
-fetchButArchiveLater
-: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchButArchiveLater : (HasFetch t, HasCheckedFetch t cgid) => cgid -> ContractId t -> Update t
+```
 
 Fetch a contract that is not reference data, and should be archived later in some cases.
 
 Prefer `fetchAndArchive` over this function, as it avoids forgetting to archive the contract.
 
-</div>
+<span id="function-splice-util-fetchpublicreferencedata-76996"></span>
 
-<div id="function-splice-util-fetchpublicreferencedata-76996">
+### `fetchPublicReferenceData`
 
-fetchPublicReferenceData
-: (HasCheckedFetch t cgid, [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) t ch t) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> ch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchPublicReferenceData : (HasCheckedFetch t cgid, HasExercise t ch t) => cgid -> ContractId t -> ch -> Update t
+```
 
 Fetch a contract that offers a choice anybody to be read as reference data.
 
-</div>
+<span id="function-splice-util-fetchuncheckedandarchive-65397"></span>
 
-<div id="function-splice-util-fetchuncheckedandarchive-65397">
+### `fetchUncheckedAndArchive`
 
-fetchUncheckedAndArchive
-: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) b, [HasArchive](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasarchive-7071) b) =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) b -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) b
+```daml
+fetchUncheckedAndArchive : (HasFetch b, HasArchive b) => ContractId b -> Update b
+```
 
 Fetch and archive a contract in one go.
 
-Use this when implementing choices that mutate another contract by fetching, archiving, and then creating the updated contract.
+Use this when implementing choices that mutate another contract by
+fetching, archiving, and then creating the updated contract.
 
-</div>
+<span id="function-splice-util-fetchuncheckedreferencedata-5520"></span>
 
-<div id="function-splice-util-fetchuncheckedreferencedata-5520">
+### `fetchUncheckedReferenceData`
 
-fetchUncheckedReferenceData
-: [HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchUncheckedReferenceData : HasFetch t => ContractId t -> Update t
+```
 
 Fetch a contract that serves as reference data.
 
 Use this whenever you need to fetch a contract that you do not intend to mutate.
 
-</div>
+<span id="function-splice-util-fetchuncheckedbutarchivelater-82900"></span>
 
-<div id="function-splice-util-fetchuncheckedbutarchivelater-82900">
+### `fetchUncheckedButArchiveLater`
 
-fetchUncheckedButArchiveLater
-: [HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+```daml
+fetchUncheckedButArchiveLater : HasFetch t => ContractId t -> Update t
+```
 
 Fetch a contract that is not reference data, and should be archived later in some cases.
 
 Prefer `fetchAndArchive` over this function, as it avoids forgetting to archive the contract.
 
-</div>
+<span id="function-splice-util-potentiallyunsafearchive-47027"></span>
 
-<div id="function-splice-util-potentiallyunsafearchive-47027">
+### `potentiallyUnsafeArchive`
 
-potentiallyUnsafeArchive
-: [HasArchive](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasarchive-7071) t =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+```daml
+potentiallyUnsafeArchive : HasArchive t => ContractId t -> Update ()
+```
 
 A more appropriately named version of `archive`.
 
-Please justify all its uses, and where possible prefer `fetchAndArchive` so that the contract group identifier is surely performed.
+Please justify all its uses, and where possible prefer `fetchAndArchive`
+so that the contract group identifier is surely performed.
 
-</div>
+<span id="function-splice-util-patchscalar-11117"></span>
 
-<div id="function-splice-util-patchscalar-11117">
+### `patchScalar`
 
-patchScalar
-: [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a =\> a -\> a -\> a -\> a
+```daml
+patchScalar : Eq a => a -> a -> a -> a
+```
 
-</div>
+<span id="function-splice-util-patchlistasscalar-47719"></span>
 
-<div id="function-splice-util-patchlistasscalar-47719">
+### `patchListAsScalar`
 
-patchListAsScalar
-: [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a =\> \[a\] -\> \[a\] -\> \[a\] -\> \[a\]
+```daml
+patchListAsScalar : Eq a => [a] -> [a] -> [a] -> [a]
+```
 
-</div>
+<span id="function-splice-util-patchlistasset-9274"></span>
 
-<div id="function-splice-util-patchlistasset-9274">
+### `patchListAsSet`
 
-patchListAsSet
-: (Patchable a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a) =\> \[a\] -\> \[a\] -\> \[a\] -\> \[a\]
+```daml
+patchListAsSet : (Patchable a, Ord a) => [a] -> [a] -> [a] -> [a]
+```
 
-</div>
+<span id="function-splice-util-deprecatedchoice-19928"></span>
 
-<div id="function-splice-util-deprecatedchoice-19928">
+### `deprecatedChoice`
 
-deprecatedChoice
-: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) a
-
-</div>
-
-{/* COPIED_END */}
+```daml
+deprecatedChoice : Text -> Text -> Text -> Update a
+```

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index.mdx
@@ -1,10 +1,195 @@
 ---
-title: "splice-validator-life-cycle docs"
-description: "Documentation for splice-validator-life-cycle docs"
+title: "splice-validator-lifecycle"
+description: "Reference documentation for splice-validator-lifecycle modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-validator-lifecycle/docs/index.rst" tag="0.6.4" hash="ac41f15d" */}
+<div class="x2mdx-ref-hero">
 
-- [Splice.ValidatorOnboarding](/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding)
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-{/* COPIED_END */}
+
+  <h1 class="x2mdx-ref-title">splice-validator-lifecycle</h1>
+
+
+  <p class="x2mdx-ref-summary">Generated module overview for splice-validator-lifecycle, built from versioned docs JSON snapshots.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.ValidatorOnboarding</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding.mdx
@@ -1,131 +1,143 @@
 ---
 title: "Splice.ValidatorOnboarding"
-description: "Documentation for Splice.ValidatorOnboarding"
+description: "Reference documentation for Daml module Splice.ValidatorOnboarding."
 ---
 
-{/* COPIED_START source="splice:daml/splice-validator-lifecycle/docs/Splice-ValidatorOnboarding.rst" tag="0.6.4" hash="eec20687" */}
+<span id="module-splice-validatoronboarding-49132"></span>
 
-## Templates
+# Splice.ValidatorOnboarding
 
-<div id="type-splice-validatoronboarding-usedsecret-49603">
+## Module Snapshot
 
-**template** UsedSecret
-
-</div>
-
-> Template used by a sponsoring SV node for enforcing that an onboarding secret is used only once.
->
-> Signatory: sv
->
-> | Field     | Type                                                                                                                | Description                                    |
-> |-----------|---------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
-> | sv        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The SV node that sponsored the onboarding.     |
-> | secret    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | An onboarding secret.                          |
-> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The validator that onboarded using the secret. |
->
-> - **Choice** Archive
->
->   Controller: sv
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-validatoronboarding-validatoronboarding-92198">
-
-**template** ValidatorOnboarding
-
-</div>
-
-> Template used by a sponsoring SV node to keep track of the onboarding of a validator candidate. We use a secret for authenticating the candidate once he has set up his participant. The secret should be unique, contain at least 256-bits of entropy, and be communicated to the candidate via a secure off-ledger channel. Once the candidate has set up his participants, he contacts the SV node via an API call and presents his secret, which triggers the SV node to add him as a validator (as a separate on-ledger action for reducing coupling with the DSO governance contracts).
->
-> Signatory: sv
->
-> | Field           | Type                                                                                                                | Description                                        |
-> |-----------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> | sv              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The SV node sponsoring this onboarding.            |
-> | candidateSecret | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The unique secret given to the candidate.          |
-> | expiresAt       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Can be used by the SV for time-bounding the offer. |
->
-> - **Choice** Archive
->
->   Controller: sv
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-validatoronboarding-validatoronboardingexpire-7877">
->
->   **Choice** ValidatorOnboarding_Expire
->
->   </div>
->
->   Controller: sv
->
->   Returns: ValidatorOnboarding_ExpireResult
->
->   (no fields)
->
-> - <div id="type-splice-validatoronboarding-validatoronboardingmatch-2118">
->
->   **Choice** ValidatorOnboarding_Match
->
->   </div>
->
->   Controller: sv
->
->   Returns: ValidatorOnboarding_MatchResult
->
->   | Field          | Type                                                                                                                | Description |
->   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | providedSecret | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
->   | validator      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-validatoronboarding-validatoronboardingexpireresult-28676">
+<span id="type-splice-validatoronboarding-validatoronboardingexpireresult-28676"></span>
 
-**data** ValidatorOnboarding_ExpireResult
+### `data ValidatorOnboarding_ExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-validatoronboarding-validatoronboardingexpireresult-66123">
->
-> ValidatorOnboarding_ExpireResult
->
-> </div>
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult
+<span id="constr-splice-validatoronboarding-validatoronboardingexpireresult-66123"></span>
 
-<div id="type-splice-validatoronboarding-validatoronboardingmatchresult-68567">
+- `ValidatorOnboarding_ExpireResult`
 
-**data** ValidatorOnboarding_MatchResult
+Instances:
 
-</div>
+- `instance HasExercise ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult`
+- `instance HasFromAnyChoice ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult`
+- `instance HasToAnyChoice ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult`
 
-> <div id="constr-splice-validatoronboarding-validatoronboardingmatchresult-91618">
->
-> ValidatorOnboarding_MatchResult
->
-> </div>
->
-> > | Field      | Type                                                                                                                                     | Description |
-> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | usedSecret | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UsedSecret |             |
->
-> **instance** GetField "usedSecret" ValidatorOnboarding_MatchResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UsedSecret)
->
-> **instance** SetField "usedSecret" ValidatorOnboarding_MatchResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UsedSecret)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult
+<span id="type-splice-validatoronboarding-validatoronboardingmatchresult-68567"></span>
 
-{/* COPIED_END */}
+### `data ValidatorOnboarding_MatchResult`
+
+Constructors:
+
+<span id="constr-splice-validatoronboarding-validatoronboardingmatchresult-91618"></span>
+
+- `ValidatorOnboarding_MatchResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| usedSecret | ContractId UsedSecret |  |
+
+Instances:
+
+- `instance GetField usedSecret ValidatorOnboarding_MatchResult (ContractId UsedSecret)`
+- `instance SetField usedSecret ValidatorOnboarding_MatchResult (ContractId UsedSecret)`
+- `instance HasExercise ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult`
+- `instance HasFromAnyChoice ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult`
+- `instance HasToAnyChoice ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult`
+
+## Templates
+
+<span id="type-splice-validatoronboarding-usedsecret-49603"></span>
+
+### Template `UsedSecret`
+
+Template used by a sponsoring SV node for enforcing that an onboarding secret is used only once.
+
+Signatories: `sv`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party | The SV node that sponsored the onboarding. |
+| secret | Text | An onboarding secret. |
+| validator | Party | The validator that onboarded using the secret. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sv`
+
+Returns: `()`
+
+<span id="type-splice-validatoronboarding-validatoronboarding-92198"></span>
+
+### Template `ValidatorOnboarding`
+
+Template used by a sponsoring SV node to keep track of the onboarding of a validator candidate.
+We use a secret for authenticating the candidate once he has set up his participant.
+The secret should be unique, contain at least 256-bits of entropy,
+and be communicated to the candidate via a secure off-ledger channel.
+Once the candidate has set up his participants, he contacts the SV node via an API call
+and presents his secret, which triggers the SV node to add him as a validator
+(as a separate on-ledger action for reducing coupling with the DSO governance contracts).
+
+Signatories: `sv`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party | The SV node sponsoring this onboarding. |
+| candidateSecret | Text | The unique secret given to the candidate. |
+| expiresAt | Time | Can be used by the SV for time-bounding the offer. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sv`
+
+Returns: `()`
+
+<span id="type-splice-validatoronboarding-validatoronboardingexpire-7877"></span>
+
+#### Choice `ValidatorOnboarding_Expire`
+
+Controllers: `sv`
+
+Returns: `ValidatorOnboarding_ExpireResult`
+
+<span id="type-splice-validatoronboarding-validatoronboardingmatch-2118"></span>
+
+#### Choice `ValidatorOnboarding_Match`
+
+Controllers: `sv`
+
+Returns: `ValidatorOnboarding_MatchResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| providedSecret | Text |  |
+| validator | Party |  |

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/index.mdx
@@ -1,21 +1,245 @@
 ---
-title: "splice-wallet-payments docs"
-description: "Documentation for splice-wallet-payments docs"
+title: "splice-wallet-payments"
+description: "Reference documentation for splice-wallet-payments modules."
 ---
 
-{/* COPIED_START source="splice:daml/splice-wallet-payments/docs/index.rst" tag="0.6.4" hash="cb7aa487" */}
+<div class="x2mdx-ref-hero">
 
-<Note>
-**Deprecated** (since splice-0.4.10): the modules below and their workflows are deprecated and should not be used in new applications.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-To implement a Canton Coin payment, use the Token Standard allocation workflow instead. Note that this immediately makes your application compatible with all Token Standard assets, and allows all of them to be used as payment methods in your application, if desired.
 
-If you need to implement a subscription-like payment, then we recommend doing so via regular renewals on top of token standard allocations in your application. See the `License_Renew` choice and its [tests](https://github.com/digital-asset/cn-quickstart/blob/8b15f38d157d1f88e8da4345f477fffc0cfc4b8f/quickstart/daml/licensing-tests/daml/Licensing/Scripts/TestLicense.daml#L207-L221) in the Canton Network QuickStart repo for an [example of how to do this](https://github.com/digital-asset/cn-quickstart/blob/8b15f38d157d1f88e8da4345f477fffc0cfc4b8f/quickstart/daml/licensing/daml/Licensing/License.daml#L44).
+  <h1 class="x2mdx-ref-title">splice-wallet-payments</h1>
 
-The workflows in the modules below are not compatible with the token standard, and will not be supported in the future.
-</Note>
 
-- [Splice.Wallet.Payment](/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment)
-- [Splice.Wallet.Subscriptions](/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions)
+  <p class="x2mdx-ref-summary">Generated module overview for splice-wallet-payments, built from versioned docs JSON snapshots.</p>
 
-{/* COPIED_END */}
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">0.6.4</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Splice Daml docs JSON generated from release DAR artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>published splice-node release bundles</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Wallet.Payment</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Splice.Wallet.Subscriptions</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.6.4</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>0.6.4</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 2</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>0.6.6</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment.mdx
@@ -1,582 +1,528 @@
 ---
 title: "Splice.Wallet.Payment"
-description: "Documentation for Splice.Wallet.Payment"
+description: "Reference documentation for Daml module Splice.Wallet.Payment."
 ---
 
-{/* COPIED_START source="splice:daml/splice-wallet-payments/docs/Splice-Wallet-Payment.rst" tag="0.6.4" hash="6c338ed0" */}
+<span id="module-splice-wallet-payment-75803"></span>
 
-## Templates
+# Splice.Wallet.Payment
 
-<div id="type-splice-wallet-payment-acceptedapppayment-18193">
+## Module Snapshot
 
-**template** AcceptedAppPayment
-
-</div>
-
-> Signatory: sender, provider, map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts
->
-> | Field                 | Type                                                                                                                                            | Description                                                                                                         |
-> |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-> | sender                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |                                                                                                                     |
-> | amuletReceiverAmounts | \[ReceiverAmuletAmount\]                                                                                                                        |                                                                                                                     |
-> | provider              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |                                                                                                                     |
-> | dso                   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |                                                                                                                     |
-> | lockedAmulet          | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet      |                                                                                                                     |
-> | round                 | Round                                                                                                                                           | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
-> | reference             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest | The contract id of the original payment request to correlate it. Note that the contract will no longer be active.   |
->
-> - <div id="type-splice-wallet-payment-acceptedapppaymentcollect-62282">
->
->   **Choice** AcceptedAppPayment_Collect
->
->   </div>
->
->   Controller: signatory this
->
->   Returns: AcceptedAppPayment_CollectResult
->
->   | Field   | Type               | Description |
->   |---------|--------------------|-------------|
->   | context | AppTransferContext |             |
->
-> - <div id="type-splice-wallet-payment-acceptedapppaymentexpire-51092">
->
->   **Choice** AcceptedAppPayment_Expire
->
->   </div>
->
->   Controller: sender
->
->   Returns: AcceptedAppPayment_ExpireResult
->
->   | Field   | Type               | Description |
->   |---------|--------------------|-------------|
->   | context | AppTransferContext |             |
->
-> - <div id="type-splice-wallet-payment-acceptedapppaymentreject-83760">
->
->   **Choice** AcceptedAppPayment_Reject
->
->   </div>
->
->   Controller: map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts
->
->   Returns: AcceptedAppPayment_RejectResult
->
->   | Field   | Type               | Description |
->   |---------|--------------------|-------------|
->   | context | AppTransferContext |             |
->
-> - **Choice** Archive
->
->   Controller: sender, provider, map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-wallet-payment-apppaymentrequest-31524">
-
-**template** AppPaymentRequest
-
-</div>
-
-> Signatory: sender, appPaymentRequest_receivers this, provider
->
-> | Field           | Type                                                                                                                | Description                                                                         |
-> |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-> | sender          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that should pay.                                                          |
-> | receiverAmounts | \[ReceiverAmount\]                                                                                                  | Pairs of (party, amount) requesting to be paid.                                     |
-> | provider        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider; receives usage rewards.                                           |
-> | dso             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party of the amulet that should be used to make the payment.                |
-> | expiresAt       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When the payment request expires.                                                   |
-> | description     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Human readable description of the reason / good for which the payment is requested. |
->
-> - <div id="type-splice-wallet-payment-apppaymentrequestaccept-83530">
->
->   **Choice** AppPaymentRequest_Accept
->
->   </div>
->
->   Controller: sender, walletProvider
->
->   Returns: AppPaymentRequest_AcceptResult
->
->   | Field          | Type                                                                                                                | Description |
->   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | inputs         | \[TransferInput\]                                                                                                   |             |
->   | context        | PaymentTransferContext                                                                                              |             |
->   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-wallet-payment-apppaymentrequestexpire-10515">
->
->   **Choice** AppPaymentRequest_Expire
->
->   </div>
->
->   Controller: actor
->
->   Returns: AppPaymentRequest_ExpireResult
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-wallet-payment-apppaymentrequestreject-66391">
->
->   **Choice** AppPaymentRequest_Reject
->
->   </div>
->
->   Controller: sender
->
->   Returns: AppPaymentRequest_RejectResult
->
->   (no fields)
->
-> - <div id="type-splice-wallet-payment-apppaymentrequestwithdraw-31618">
->
->   **Choice** AppPaymentRequest_Withdraw
->
->   </div>
->
->   Controller: appPaymentRequest_receivers this
->
->   Returns: AppPaymentRequest_WithdrawResult
->
->   (no fields)
->
-> - **Choice** Archive
->
->   Controller: sender, appPaymentRequest_receivers this, provider
->
->   Returns: ()
->
->   (no fields)
-
-<div id="type-splice-wallet-payment-terminatedapppayment-49143">
-
-**template** TerminatedAppPayment
-
-</div>
-
-> Instead of just archiving payments (e.g. when the request is accepted) we create an TerminatedAppPayment contract. This allows the coordinating workflow to archive its own contracts once the app-payment workflow terminated.
->
-> Signatory: sender, provider, receivers
->
-> | Field     | Type                                                                                                                                            | Description |
-> |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> | sender    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |             |
-> | provider  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |             |
-> | receivers | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                         |             |
-> | reference | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest |             |
->
-> - **Choice** Archive
->
->   Controller: sender, provider, receivers
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-wallet-payment-acceptedapppaymentcollectresult-5751">
+<span id="type-splice-wallet-payment-acceptedapppaymentcollectresult-5751"></span>
 
-**data** AcceptedAppPayment_CollectResult
+### `data AcceptedAppPayment_CollectResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-payment-acceptedapppaymentcollectresult-53822">
->
-> AcceptedAppPayment_CollectResult
->
-> </div>
->
-> > | Field           | Type                                                                                                                                                                                                                                                            | Description |
-> > |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | receiverAmulets | \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)\] |             |
->
-> **instance** GetField "receiverAmulets" AcceptedAppPayment_CollectResult \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)\]
->
-> **instance** SetField "receiverAmulets" AcceptedAppPayment_CollectResult \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)\]
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult
+<span id="constr-splice-wallet-payment-acceptedapppaymentcollectresult-53822"></span>
 
-<div id="type-splice-wallet-payment-acceptedapppaymentexpireresult-93793">
+- `AcceptedAppPayment_CollectResult`
 
-**data** AcceptedAppPayment_ExpireResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiverAmulets | [(Party, ContractId Amulet)] |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-payment-acceptedapppaymentexpireresult-95234">
->
-> AcceptedAppPayment_ExpireResult
->
-> </div>
->
-> > | Field  | Type                                                                                                                                                       | Description |
-> > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amulet | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amulet" AcceptedAppPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amulet" AcceptedAppPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult
+- `instance GetField receiverAmulets AcceptedAppPayment_CollectResult [(Party, ContractId Amulet)]`
+- `instance SetField receiverAmulets AcceptedAppPayment_CollectResult [(Party, ContractId Amulet)]`
+- `instance HasExercise AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult`
+- `instance HasFromAnyChoice AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult`
+- `instance HasToAnyChoice AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult`
 
-<div id="type-splice-wallet-payment-acceptedapppaymentrejectresult-56853">
+<span id="type-splice-wallet-payment-acceptedapppaymentexpireresult-93793"></span>
 
-**data** AcceptedAppPayment_RejectResult
+### `data AcceptedAppPayment_ExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-payment-acceptedapppaymentrejectresult-75142">
->
-> AcceptedAppPayment_RejectResult
->
-> </div>
->
-> > | Field  | Type                                                                                                                                                       | Description |
-> > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amulet | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amulet" AcceptedAppPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amulet" AcceptedAppPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult
+<span id="constr-splice-wallet-payment-acceptedapppaymentexpireresult-95234"></span>
 
-<div id="type-splice-wallet-payment-apppaymentrequestacceptresult-82387">
+- `AcceptedAppPayment_ExpireResult`
 
-**data** AppPaymentRequest_AcceptResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | AmuletCreateSummary (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-payment-apppaymentrequestacceptresult-79598">
->
-> AppPaymentRequest_AcceptResult
->
-> </div>
->
-> > | Field              | Type                                                                                                                                                                                                                                                                  | Description |
-> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | acceptedPayment    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment                                                                                                                      |             |
-> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "acceptedPayment" AppPaymentRequest_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment)
->
-> **instance** GetField "senderChangeAmulet" AppPaymentRequest_AcceptResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "acceptedPayment" AppPaymentRequest_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment)
->
-> **instance** SetField "senderChangeAmulet" AppPaymentRequest_AcceptResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult
+- `instance GetField amulet AcceptedAppPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amulet AcceptedAppPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult`
+- `instance HasFromAnyChoice AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult`
+- `instance HasToAnyChoice AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult`
 
-<div id="type-splice-wallet-payment-apppaymentrequestexpireresult-63922">
+<span id="type-splice-wallet-payment-acceptedapppaymentrejectresult-56853"></span>
 
-**data** AppPaymentRequest_ExpireResult
+### `data AcceptedAppPayment_RejectResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-payment-apppaymentrequestexpireresult-76475">
->
-> AppPaymentRequest_ExpireResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                               | Description |
-> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
->
-> **instance** GetField "terminatedAppPayment" AppPaymentRequest_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
->
-> **instance** SetField "terminatedAppPayment" AppPaymentRequest_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult
+<span id="constr-splice-wallet-payment-acceptedapppaymentrejectresult-75142"></span>
 
-<div id="type-splice-wallet-payment-apppaymentrequestrejectresult-75838">
+- `AcceptedAppPayment_RejectResult`
 
-**data** AppPaymentRequest_RejectResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | AmuletCreateSummary (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-payment-apppaymentrequestrejectresult-65943">
->
-> AppPaymentRequest_RejectResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                               | Description |
-> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
->
-> **instance** GetField "terminatedAppPayment" AppPaymentRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
->
-> **instance** SetField "terminatedAppPayment" AppPaymentRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult
+- `instance GetField amulet AcceptedAppPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amulet AcceptedAppPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult`
+- `instance HasFromAnyChoice AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult`
+- `instance HasToAnyChoice AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult`
 
-<div id="type-splice-wallet-payment-apppaymentrequestwithdrawresult-19567">
+<span id="type-splice-wallet-payment-apppaymentrequestacceptresult-82387"></span>
 
-**data** AppPaymentRequest_WithdrawResult
+### `data AppPaymentRequest_AcceptResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-payment-apppaymentrequestwithdrawresult-24638">
->
-> AppPaymentRequest_WithdrawResult
->
-> </div>
->
-> > | Field                | Type                                                                                                                                               | Description |
-> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
->
-> **instance** GetField "terminatedAppPayment" AppPaymentRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
->
-> **instance** SetField "terminatedAppPayment" AppPaymentRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult
+<span id="constr-splice-wallet-payment-apppaymentrequestacceptresult-79598"></span>
 
-<div id="type-splice-wallet-payment-paymentamount-12698">
+- `AppPaymentRequest_AcceptResult`
 
-**data** PaymentAmount
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| acceptedPayment | ContractId AcceptedAppPayment |  |
+| senderChangeAmulet | Optional (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-payment-paymentamount-44729">
->
-> PaymentAmount
->
-> </div>
->
-> > | Field  | Type                                                                                                               | Description |
-> > |--------|--------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
-> > | unit   | Unit                                                                                                               |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PaymentAmount
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) PaymentAmount
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PaymentAmount
->
-> **instance** GetField "amount" PaymentAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "amount" ReceiverAmount PaymentAmount
->
-> **instance** GetField "paymentAmount" SubscriptionPayData PaymentAmount
->
-> **instance** GetField "unit" PaymentAmount Unit
->
-> **instance** SetField "amount" PaymentAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amount" ReceiverAmount PaymentAmount
->
-> **instance** SetField "paymentAmount" SubscriptionPayData PaymentAmount
->
-> **instance** SetField "unit" PaymentAmount Unit
+- `instance GetField acceptedPayment AppPaymentRequest_AcceptResult (ContractId AcceptedAppPayment)`
+- `instance GetField senderChangeAmulet AppPaymentRequest_AcceptResult (Optional (ContractId Amulet))`
+- `instance SetField acceptedPayment AppPaymentRequest_AcceptResult (ContractId AcceptedAppPayment)`
+- `instance SetField senderChangeAmulet AppPaymentRequest_AcceptResult (Optional (ContractId Amulet))`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult`
 
-<div id="type-splice-wallet-payment-receiveramount-43100">
+<span id="type-splice-wallet-payment-apppaymentrequestexpireresult-63922"></span>
 
-**data** ReceiverAmount
+### `data AppPaymentRequest_ExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-payment-receiveramount-91649">
->
-> ReceiverAmount
->
-> </div>
->
-> > | Field    | Type                                                                                                                | Description |
-> > |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | receiver | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | amount   | PaymentAmount                                                                                                       |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ReceiverAmount
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ReceiverAmount
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ReceiverAmount
->
-> **instance** GetField "amount" ReceiverAmount PaymentAmount
->
-> **instance** GetField "receiver" ReceiverAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "receiverAmounts" AppPaymentRequest \[ReceiverAmount\]
->
-> **instance** SetField "amount" ReceiverAmount PaymentAmount
->
-> **instance** SetField "receiver" ReceiverAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "receiverAmounts" AppPaymentRequest \[ReceiverAmount\]
+<span id="constr-splice-wallet-payment-apppaymentrequestexpireresult-76475"></span>
 
-<div id="type-splice-wallet-payment-receiveramulet-61330">
+- `AppPaymentRequest_ExpireResult`
 
-**data** ReceiverAmulet
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-payment-receiveramulet-72427">
->
-> ReceiverAmulet
->
-> </div>
->
-> > | Field        | Type                                                                                                                                       | Description |
-> > |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | receiver     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                        |             |
-> > | lockedAmulet | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ReceiverAmulet
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ReceiverAmulet
->
-> **instance** GetField "lockedAmulet" ReceiverAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet)
->
-> **instance** GetField "receiver" ReceiverAmulet [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "lockedAmulet" ReceiverAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet)
->
-> **instance** SetField "receiver" ReceiverAmulet [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+- `instance GetField terminatedAppPayment AppPaymentRequest_ExpireResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment AppPaymentRequest_ExpireResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult`
 
-<div id="type-splice-wallet-payment-receiveramuletamount-72096">
+<span id="type-splice-wallet-payment-apppaymentrequestrejectresult-75838"></span>
 
-**data** ReceiverAmuletAmount
+### `data AppPaymentRequest_RejectResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-payment-receiveramuletamount-97653">
->
-> ReceiverAmuletAmount
->
-> </div>
->
-> > | Field        | Type                                                                                                                | Description |
-> > |--------------|---------------------------------------------------------------------------------------------------------------------|-------------|
-> > | receiver     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-> > | amuletAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ReceiverAmuletAmount
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ReceiverAmuletAmount
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ReceiverAmuletAmount
->
-> **instance** GetField "amuletAmount" ReceiverAmuletAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** GetField "amuletReceiverAmounts" AcceptedAppPayment \[ReceiverAmuletAmount\]
->
-> **instance** GetField "receiver" ReceiverAmuletAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "amuletAmount" ReceiverAmuletAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
->
-> **instance** SetField "amuletReceiverAmounts" AcceptedAppPayment \[ReceiverAmuletAmount\]
->
-> **instance** SetField "receiver" ReceiverAmuletAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+<span id="constr-splice-wallet-payment-apppaymentrequestrejectresult-65943"></span>
 
-<div id="type-splice-wallet-payment-unit-67175">
+- `AppPaymentRequest_RejectResult`
 
-**data** Unit
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-payment-usdunit-55511">
->
-> USDUnit
->
-> </div>
->
-> <div id="constr-splice-wallet-payment-amuletunit-84830">
->
-> AmuletUnit
->
-> </div>
->
-> <div id="constr-splice-wallet-payment-extunit-45462">
->
-> ExtUnit
->
-> </div>
->
-> > Extension constructor to work around the current lack of upgrading for variants in Daml 3.0. Will serve as the default value in a containing record in case of an extension.
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Unit
->
-> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) Unit
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Unit
->
-> **instance** GetField "unit" PaymentAmount Unit
->
-> **instance** SetField "unit" PaymentAmount Unit
+- `instance GetField terminatedAppPayment AppPaymentRequest_RejectResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment AppPaymentRequest_RejectResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult`
+
+<span id="type-splice-wallet-payment-apppaymentrequestwithdrawresult-19567"></span>
+
+### `data AppPaymentRequest_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-payment-apppaymentrequestwithdrawresult-24638"></span>
+
+- `AppPaymentRequest_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
+
+Instances:
+
+- `instance GetField terminatedAppPayment AppPaymentRequest_WithdrawResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment AppPaymentRequest_WithdrawResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult`
+
+<span id="type-splice-wallet-payment-paymentamount-12698"></span>
+
+### `data PaymentAmount`
+
+Constructors:
+
+<span id="constr-splice-wallet-payment-paymentamount-44729"></span>
+
+- `PaymentAmount`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amount | Decimal |  |
+| unit | Unit |  |
+
+Instances:
+
+- `instance Eq PaymentAmount`
+- `instance Ord PaymentAmount`
+- `instance Show PaymentAmount`
+- `instance GetField amount PaymentAmount Decimal`
+- `instance GetField amount ReceiverAmount PaymentAmount`
+- `instance GetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance GetField unit PaymentAmount Unit`
+- `instance SetField amount PaymentAmount Decimal`
+- `instance SetField amount ReceiverAmount PaymentAmount`
+- `instance SetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance SetField unit PaymentAmount Unit`
+
+<span id="type-splice-wallet-payment-receiveramount-43100"></span>
+
+### `data ReceiverAmount`
+
+Constructors:
+
+<span id="constr-splice-wallet-payment-receiveramount-91649"></span>
+
+- `ReceiverAmount`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | PaymentAmount |  |
+
+Instances:
+
+- `instance Eq ReceiverAmount`
+- `instance Ord ReceiverAmount`
+- `instance Show ReceiverAmount`
+- `instance GetField amount ReceiverAmount PaymentAmount`
+- `instance GetField receiver ReceiverAmount Party`
+- `instance GetField receiverAmounts AppPaymentRequest [ReceiverAmount]`
+- `instance SetField amount ReceiverAmount PaymentAmount`
+- `instance SetField receiver ReceiverAmount Party`
+- `instance SetField receiverAmounts AppPaymentRequest [ReceiverAmount]`
+
+<span id="type-splice-wallet-payment-receiveramulet-61330"></span>
+
+### `data ReceiverAmulet`
+
+Constructors:
+
+<span id="constr-splice-wallet-payment-receiveramulet-72427"></span>
+
+- `ReceiverAmulet`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| lockedAmulet | ContractId LockedAmulet |  |
+
+Instances:
+
+- `instance Eq ReceiverAmulet`
+- `instance Show ReceiverAmulet`
+- `instance GetField lockedAmulet ReceiverAmulet (ContractId LockedAmulet)`
+- `instance GetField receiver ReceiverAmulet Party`
+- `instance SetField lockedAmulet ReceiverAmulet (ContractId LockedAmulet)`
+- `instance SetField receiver ReceiverAmulet Party`
+
+<span id="type-splice-wallet-payment-receiveramuletamount-72096"></span>
+
+### `data ReceiverAmuletAmount`
+
+Constructors:
+
+<span id="constr-splice-wallet-payment-receiveramuletamount-97653"></span>
+
+- `ReceiverAmuletAmount`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amuletAmount | Decimal |  |
+
+Instances:
+
+- `instance Eq ReceiverAmuletAmount`
+- `instance Ord ReceiverAmuletAmount`
+- `instance Show ReceiverAmuletAmount`
+- `instance GetField amuletAmount ReceiverAmuletAmount Decimal`
+- `instance GetField amuletReceiverAmounts AcceptedAppPayment [ReceiverAmuletAmount]`
+- `instance GetField receiver ReceiverAmuletAmount Party`
+- `instance SetField amuletAmount ReceiverAmuletAmount Decimal`
+- `instance SetField amuletReceiverAmounts AcceptedAppPayment [ReceiverAmuletAmount]`
+- `instance SetField receiver ReceiverAmuletAmount Party`
+
+<span id="type-splice-wallet-payment-unit-67175"></span>
+
+### `data Unit`
+
+Constructors:
+
+<span id="constr-splice-wallet-payment-usdunit-55511"></span>
+
+- `USDUnit`
+
+<span id="constr-splice-wallet-payment-amuletunit-84830"></span>
+
+- `AmuletUnit`
+
+<span id="constr-splice-wallet-payment-extunit-45462"></span>
+
+- `ExtUnit`
+
+Extension constructor to work around the current lack of upgrading for variants in Daml 3.0.
+Will serve as the default value in a containing record in case of an extension.
+
+Instances:
+
+- `instance Eq Unit`
+- `instance Ord Unit`
+- `instance Show Unit`
+- `instance GetField unit PaymentAmount Unit`
+- `instance SetField unit PaymentAmount Unit`
 
 ## Functions
 
-<div id="function-splice-wallet-payment-paymentamounttoamulet-10099">
+<span id="function-splice-wallet-payment-paymentamounttoamulet-10099"></span>
 
-paymentAmountToAmulet
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> OpenMiningRound -\> PaymentAmount -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+### `paymentAmountToAmulet`
 
-</div>
+```daml
+paymentAmountToAmulet : Party -> OpenMiningRound -> PaymentAmount -> Update Decimal
+```
 
-<div id="function-splice-wallet-payment-receiveramounttoamuletreceiveramount-72316">
+<span id="function-splice-wallet-payment-receiveramounttoamuletreceiveramount-72316"></span>
 
-receiverAmountToAmuletReceiverAmount
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> OpenMiningRound -\> ReceiverAmount -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ReceiverAmuletAmount
+### `receiverAmountToAmuletReceiverAmount`
 
-</div>
+```daml
+receiverAmountToAmuletReceiverAmount : Party -> OpenMiningRound -> ReceiverAmount -> Update ReceiverAmuletAmount
+```
 
-<div id="function-splice-wallet-payment-apppaymentrequestreceivers-97989">
+<span id="function-splice-wallet-payment-apppaymentrequestreceivers-97989"></span>
 
-appPaymentRequest_receivers
-: AppPaymentRequest -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
+### `appPaymentRequest_receivers`
 
-</div>
+```daml
+appPaymentRequest_receivers : AppPaymentRequest -> [Party]
+```
 
-<div id="function-splice-wallet-payment-unzipreceiveramulets-38827">
+<span id="function-splice-wallet-payment-unzipreceiveramulets-38827"></span>
 
-unzipReceiverAmulets
-: \[ReceiverAmulet\] -\> (\[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\], \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet\])
+### `unzipReceiverAmulets`
 
-</div>
+```daml
+unzipReceiverAmulets : [ReceiverAmulet] -> ([Party], [ContractId LockedAmulet])
+```
 
-<div id="function-splice-wallet-payment-mkreceiveroutput-26465">
+<span id="function-splice-wallet-payment-mkreceiveroutput-26465"></span>
 
-mkReceiverOutput
-: ReceiverAmuletAmount -\> TransferOutput
+### `mkReceiverOutput`
 
-</div>
+```daml
+mkReceiverOutput : ReceiverAmuletAmount -> TransferOutput
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-wallet-payment-acceptedapppayment-18193"></span>
+
+### Template `AcceptedAppPayment`
+
+Signatories: `sender`, `provider`, `map (\ r -> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| amuletReceiverAmounts | [ReceiverAmuletAmount] |  |
+| provider | Party |  |
+| dso | Party |  |
+| lockedAmulet | ContractId LockedAmulet |  |
+| round | Round | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+| reference | ContractId AppPaymentRequest | The contract id of the original payment request to correlate it. Note that the contract will no longer be active. |
+
+Choices:
+
+<span id="type-splice-wallet-payment-acceptedapppaymentcollect-62282"></span>
+
+#### Choice `AcceptedAppPayment_Collect`
+
+Controllers: `signatory this`
+
+Returns: `AcceptedAppPayment_CollectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | AppTransferContext |  |
+
+<span id="type-splice-wallet-payment-acceptedapppaymentexpire-51092"></span>
+
+#### Choice `AcceptedAppPayment_Expire`
+
+Controllers: `sender`
+
+Returns: `AcceptedAppPayment_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | AppTransferContext |  |
+
+<span id="type-splice-wallet-payment-acceptedapppaymentreject-83760"></span>
+
+#### Choice `AcceptedAppPayment_Reject`
+
+Controllers: `map (\ r -> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts`
+
+Returns: `AcceptedAppPayment_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | AppTransferContext |  |
+
+#### Choice `Archive`
+
+Controllers: `sender`, `provider`, `map (\ r -> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts`
+
+Returns: `()`
+
+<span id="type-splice-wallet-payment-apppaymentrequest-31524"></span>
+
+### Template `AppPaymentRequest`
+
+Signatories: `sender`, `appPaymentRequest_receivers this`, `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The party that should pay. |
+| receiverAmounts | [ReceiverAmount] | Pairs of (party, amount) requesting to be paid. |
+| provider | Party | The app provider; receives usage rewards. |
+| dso | Party | The DSO party of the amulet that should be used to make the payment. |
+| expiresAt | Time | When the payment request expires. |
+| description | Text | Human readable description of the reason / good for which the payment is requested. |
+
+Choices:
+
+<span id="type-splice-wallet-payment-apppaymentrequestaccept-83530"></span>
+
+#### Choice `AppPaymentRequest_Accept`
+
+Controllers: `sender`, `walletProvider`
+
+Returns: `AppPaymentRequest_AcceptResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<span id="type-splice-wallet-payment-apppaymentrequestexpire-10515"></span>
+
+#### Choice `AppPaymentRequest_Expire`
+
+Controllers: `actor`
+
+Returns: `AppPaymentRequest_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<span id="type-splice-wallet-payment-apppaymentrequestreject-66391"></span>
+
+#### Choice `AppPaymentRequest_Reject`
+
+Controllers: `sender`
+
+Returns: `AppPaymentRequest_RejectResult`
+
+<span id="type-splice-wallet-payment-apppaymentrequestwithdraw-31618"></span>
+
+#### Choice `AppPaymentRequest_Withdraw`
+
+Controllers: `appPaymentRequest_receivers this`
+
+Returns: `AppPaymentRequest_WithdrawResult`
+
+#### Choice `Archive`
+
+Controllers: `sender`, `appPaymentRequest_receivers this`, `provider`
+
+Returns: `()`
+
+<span id="type-splice-wallet-payment-terminatedapppayment-49143"></span>
+
+### Template `TerminatedAppPayment`
+
+Instead of just archiving payments (e.g. when the request is accepted) we create an
+TerminatedAppPayment contract. This allows the coordinating workflow to archive its own contracts once the app-payment workflow terminated.
+
+Signatories: `sender`, `provider`, `receivers`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| provider | Party |  |
+| receivers | [Party] |  |
+| reference | ContractId AppPaymentRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sender`, `provider`, `receivers`
+
+Returns: `()`

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions.mdx
@@ -1,873 +1,782 @@
 ---
 title: "Splice.Wallet.Subscriptions"
-description: "Documentation for Splice.Wallet.Subscriptions"
+description: "Reference documentation for Daml module Splice.Wallet.Subscriptions."
 ---
 
-{/* COPIED_START source="splice:daml/splice-wallet-payments/docs/Splice-Wallet-Subscriptions.rst" tag="0.6.4" hash="abf6a5bb" */}
+<span id="module-splice-wallet-subscriptions-81141"></span>
 
-## Templates
+# Splice.Wallet.Subscriptions
 
-<div id="type-splice-wallet-subscriptions-subscription-33404">
+## Module Snapshot
 
-**template** Subscription
-
-</div>
-
-> Main subscription object.
->
-> Signatory: subscriptionSignatories subscriptionData
->
-> | Field            | Type                                                                                                                                              | Description                                                                                                                |
-> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-> | subscriptionData | SubscriptionData                                                                                                                                  |                                                                                                                            |
-> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
->
-> - **Choice** Archive
->
->   Controller: subscriptionSignatories subscriptionData
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionarchive-38051">
->
->   **Choice** Subscription_Archive
->
->   </div>
->
->   Controller: signatory this
->
->   Returns: Subscription_ArchiveResult
->
->   (no fields)
-
-<div id="type-splice-wallet-subscriptions-subscriptionidlestate-59870">
-
-**template** SubscriptionIdleState
-
-</div>
-
-> The base state in our subscription flow. Here, we are typically waiting for the time for the next payment to arrive. If that time has passed, we are waiting for someone to expire the subscription.
->
-> Signatory: subscriptionSignatories subscriptionData
->
-> | Field            | Type                                                                                                                                              | Description                                                       |
-> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
-> | subscription     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription        | The subscription this belongs to.                                 |
-> | subscriptionData | SubscriptionData                                                                                                                                  | Copy of the subscription contract for easier access to its field. |
-> | payData          | SubscriptionPayData                                                                                                                               | Payment-related properties.                                       |
-> | nextPaymentDueAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                 | After which time the next payment can and should be paid.         |
-> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |                                                                   |
->
-> - **Choice** Archive
->
->   Controller: subscriptionSignatories subscriptionData
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscription-25061">
->
->   **Choice** SubscriptionIdleState_CancelSubscription
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"sender" subscriptionData)
->
->   Returns: SubscriptionIdleState_CancelSubscriptionResult
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscription-50078">
->
->   **Choice** SubscriptionIdleState_ExpireSubscription
->
->   </div>
->
->   Controller: actor
->
->   Returns: SubscriptionIdleState_ExpireSubscriptionResult
->
->   | Field | Type                                                                                                                | Description |
->   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionidlestatemakepayment-62467">
->
->   **Choice** SubscriptionIdleState_MakePayment
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"sender" subscriptionData), walletProvider
->
->   Returns: SubscriptionIdleState_MakePaymentResult
->
->   | Field          | Type                                                                                                                | Description |
->   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | inputs         | \[TransferInput\]                                                                                                   |             |
->   | context        | PaymentTransferContext                                                                                              |             |
->   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
-
-<div id="type-splice-wallet-subscriptions-subscriptioninitialpayment-79960">
-
-**template** SubscriptionInitialPayment
-
-</div>
-
-> The initial payment on a subscription. Implicitly, this is also the "accept" of the preceding `SubscriptionRequest`. Collecting this payments creates the subscription and thereby enables all follow-up payments.
->
-> Signatory: subscriptionSignatories subscriptionData
->
-> | Field            | Type                                                                                                                                              | Description                                                                                                                |
-> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-> | subscriptionData | SubscriptionData                                                                                                                                  |                                                                                                                            |
-> | payData          | SubscriptionPayData                                                                                                                               |                                                                                                                            |
-> | targetAmount     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                | Exact amount in Amulet that the receiver will get.                                                                         |
-> | lockedAmulet     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet        |                                                                                                                            |
-> | round            | Round                                                                                                                                             | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets.        |
-> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
->
-> - **Choice** Archive
->
->   Controller: subscriptionSignatories subscriptionData
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollect-92147">
->
->   **Choice** SubscriptionInitialPayment_Collect
->
->   </div>
->
->   Controller: signatory this
->
->   Returns: SubscriptionInitialPayment_CollectResult
->
->   | Field           | Type               | Description |
->   |-----------------|--------------------|-------------|
->   | transferContext | AppTransferContext |             |
->
-> - <div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpire-95363">
->
->   **Choice** SubscriptionInitialPayment_Expire
->
->   </div>
->
->   Controller: actor
->
->   Returns: SubscriptionInitialPayment_ExpireResult
->
->   | Field           | Type                                                                                                                | Description |
->   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | transferContext | AppTransferContext                                                                                                  |             |
->
-> - <div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentreject-61119">
->
->   **Choice** SubscriptionInitialPayment_Reject
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"receiver" subscriptionData)
->
->   Returns: SubscriptionInitialPayment_RejectResult
->
->   | Field           | Type               | Description |
->   |-----------------|--------------------|-------------|
->   | transferContext | AppTransferContext |             |
-
-<div id="type-splice-wallet-subscriptions-subscriptionpayment-4463">
-
-**template** SubscriptionPayment
-
-</div>
-
-> An in-flight (yet to be collected) payment on an existing subscription. Doubles as a "payment in progress" state.
->
-> Signatory: subscriptionSignatories subscriptionData
->
-> | Field            | Type                                                                                                                                              | Description                                                                                                         |
-> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-> | subscription     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription        | The subscription this belongs to.                                                                                   |
-> | subscriptionData | SubscriptionData                                                                                                                                  | Copy of the base subscription properties; for convenience.                                                          |
-> | payData          | SubscriptionPayData                                                                                                                               | Payment-related properties.                                                                                         |
-> | thisPaymentDueAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                 | After which time the next payment can and should be paid.                                                           |
-> | targetAmount     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |                                                                                                                     |
-> | lockedAmulet     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet        |                                                                                                                     |
-> | round            | Round                                                                                                                                             | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
-> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |                                                                                                                     |
->
-> - **Choice** Archive
->
->   Controller: subscriptionSignatories subscriptionData
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionpaymentcollect-45604">
->
->   **Choice** SubscriptionPayment_Collect
->
->   </div>
->
->   Controller: signatory this
->
->   Returns: SubscriptionPayment_CollectResult
->
->   | Field           | Type               | Description |
->   |-----------------|--------------------|-------------|
->   | transferContext | AppTransferContext |             |
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionpaymentexpire-61162">
->
->   **Choice** SubscriptionPayment_Expire
->
->   </div>
->
->   Controller: actor
->
->   Returns: SubscriptionPayment_ExpireResult
->
->   | Field           | Type                                                                                                                | Description |
->   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | actor           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->   | transferContext | AppTransferContext                                                                                                  |             |
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionpaymentreject-72046">
->
->   **Choice** SubscriptionPayment_Reject
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"receiver" subscriptionData)
->
->   Returns: SubscriptionPayment_RejectResult
->
->   | Field           | Type               | Description |
->   |-----------------|--------------------|-------------|
->   | transferContext | AppTransferContext |             |
-
-<div id="type-splice-wallet-subscriptions-subscriptionrequest-40942">
-
-**template** SubscriptionRequest
-
-</div>
-
-> A request for establishing a subscription.
->
-> Signatory: subscriptionSignatories subscriptionData
->
-> | Field            | Type                | Description |
-> |------------------|---------------------|-------------|
-> | subscriptionData | SubscriptionData    |             |
-> | payData          | SubscriptionPayData |             |
->
-> - **Choice** Archive
->
->   Controller: subscriptionSignatories subscriptionData
->
->   Returns: ()
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepayment-96423">
->
->   **Choice** SubscriptionRequest_AcceptAndMakePayment
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"sender" subscriptionData), walletProvider
->
->   Returns: SubscriptionRequest_AcceptAndMakePaymentResult
->
->   | Field          | Type                                                                                                                | Description |
->   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
->   | inputs         | \[TransferInput\]                                                                                                   |             |
->   | context        | PaymentTransferContext                                                                                              |             |
->   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionrequestreject-95001">
->
->   **Choice** SubscriptionRequest_Reject
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"sender" subscriptionData)
->
->   Returns: SubscriptionRequest_RejectResult
->
->   (no fields)
->
-> - <div id="type-splice-wallet-subscriptions-subscriptionrequestwithdraw-88172">
->
->   **Choice** SubscriptionRequest_Withdraw
->
->   </div>
->
->   Controller: (DA.Internal.Record.getField @"receiver" subscriptionData)
->
->   Returns: SubscriptionRequest_WithdrawResult
->
->   (no fields)
-
-<div id="type-splice-wallet-subscriptions-terminatedsubscription-20905">
-
-**template** TerminatedSubscription
-
-</div>
-
-> An aborted subscription. Subscriptions should usually be archived together with the context contract of the app that makes the subscription, e.g., AnsEntryContext. To achieve that, we don't archive subscriptions directly but instead create TerminatedSubscription contracts that are then archived as part of the surrounding workflows.
->
-> Signatory: subscriptionSignatories subscriptionData
->
-> | Field            | Type                                                                                                                                              | Description |
-> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> | subscriptionData | SubscriptionData                                                                                                                                  |             |
-> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
->
-> - **Choice** Archive
->
->   Controller: subscriptionSignatories subscriptionData
->
->   Returns: ()
->
->   (no fields)
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.6.4`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 ## Data Types
 
-<div id="type-splice-wallet-subscriptions-subscriptiondata-61040">
+<span id="type-splice-wallet-subscriptions-subscriptiondata-61040"></span>
 
-**data** SubscriptionData
+### `data SubscriptionData`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptiondata-87477">
->
-> SubscriptionData
->
-> </div>
->
-> > | Field       | Type                                                                                                                | Description                      |
-> > |-------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------|
-> > | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that pays.             |
-> > | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that receives payment. |
-> > | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider.                |
-> > | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                  |
-> > | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                  |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SubscriptionData
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SubscriptionData
->
-> **instance** GetField "description" SubscriptionData [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** GetField "dso" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "provider" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "receiver" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "sender" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** GetField "subscriptionData" Subscription SubscriptionData
->
-> **instance** GetField "subscriptionData" SubscriptionIdleState SubscriptionData
->
-> **instance** GetField "subscriptionData" SubscriptionInitialPayment SubscriptionData
->
-> **instance** GetField "subscriptionData" SubscriptionPayment SubscriptionData
->
-> **instance** GetField "subscriptionData" SubscriptionRequest SubscriptionData
->
-> **instance** GetField "subscriptionData" TerminatedSubscription SubscriptionData
->
-> **instance** SetField "description" SubscriptionData [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
->
-> **instance** SetField "dso" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "provider" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "receiver" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "sender" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
->
-> **instance** SetField "subscriptionData" Subscription SubscriptionData
->
-> **instance** SetField "subscriptionData" SubscriptionIdleState SubscriptionData
->
-> **instance** SetField "subscriptionData" SubscriptionInitialPayment SubscriptionData
->
-> **instance** SetField "subscriptionData" SubscriptionPayment SubscriptionData
->
-> **instance** SetField "subscriptionData" SubscriptionRequest SubscriptionData
->
-> **instance** SetField "subscriptionData" TerminatedSubscription SubscriptionData
+<span id="constr-splice-wallet-subscriptions-subscriptiondata-87477"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-53096">
+- `SubscriptionData`
 
-**data** SubscriptionIdleState_CancelSubscriptionResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The party that pays. |
+| receiver | Party | The party that receives payment. |
+| provider | Party | The app provider. |
+| dso | Party |  |
+| description | Text |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-80217">
->
-> SubscriptionIdleState_CancelSubscriptionResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                 | Description |
-> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
->
-> **instance** GetField "terminatedSubscription" SubscriptionIdleState_CancelSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** SetField "terminatedSubscription" SubscriptionIdleState_CancelSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult
+- `instance Eq SubscriptionData`
+- `instance Show SubscriptionData`
+- `instance GetField description SubscriptionData Text`
+- `instance GetField dso SubscriptionData Party`
+- `instance GetField provider SubscriptionData Party`
+- `instance GetField receiver SubscriptionData Party`
+- `instance GetField sender SubscriptionData Party`
+- `instance GetField subscriptionData Subscription SubscriptionData`
+- `instance GetField subscriptionData SubscriptionIdleState SubscriptionData`
+- `instance GetField subscriptionData SubscriptionInitialPayment SubscriptionData`
+- `instance GetField subscriptionData SubscriptionPayment SubscriptionData`
+- `instance GetField subscriptionData SubscriptionRequest SubscriptionData`
+- `instance GetField subscriptionData TerminatedSubscription SubscriptionData`
+- `instance SetField description SubscriptionData Text`
+- `instance SetField dso SubscriptionData Party`
+- `instance SetField provider SubscriptionData Party`
+- `instance SetField receiver SubscriptionData Party`
+- `instance SetField sender SubscriptionData Party`
+- `instance SetField subscriptionData Subscription SubscriptionData`
+- `instance SetField subscriptionData SubscriptionIdleState SubscriptionData`
+- `instance SetField subscriptionData SubscriptionInitialPayment SubscriptionData`
+- `instance SetField subscriptionData SubscriptionPayment SubscriptionData`
+- `instance SetField subscriptionData SubscriptionRequest SubscriptionData`
+- `instance SetField subscriptionData TerminatedSubscription SubscriptionData`
 
-<div id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-84335">
+<span id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-53096"></span>
 
-**data** SubscriptionIdleState_ExpireSubscriptionResult
+### `data SubscriptionIdleState_CancelSubscriptionResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-85758">
->
-> SubscriptionIdleState_ExpireSubscriptionResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                 | Description |
-> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
->
-> **instance** GetField "terminatedSubscription" SubscriptionIdleState_ExpireSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** SetField "terminatedSubscription" SubscriptionIdleState_ExpireSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult
+<span id="constr-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-80217"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-27466">
+- `SubscriptionIdleState_CancelSubscriptionResult`
 
-**data** SubscriptionIdleState_MakePaymentResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-79353">
->
-> SubscriptionIdleState_MakePaymentResult
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                                                                                                                                  | Description |
-> > |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | subscriptionPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment                                                                                                                     |             |
-> > | senderChange        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "senderChange" SubscriptionIdleState_MakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "subscriptionPayment" SubscriptionIdleState_MakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment)
->
-> **instance** SetField "senderChange" SubscriptionIdleState_MakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "subscriptionPayment" SubscriptionIdleState_MakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult
+- `instance GetField terminatedSubscription SubscriptionIdleState_CancelSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionIdleState_CancelSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult`
+- `instance HasFromAnyChoice SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult`
+- `instance HasToAnyChoice SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult`
 
-<div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-97286">
+<span id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-84335"></span>
 
-**data** SubscriptionInitialPayment_CollectResult
+### `data SubscriptionIdleState_ExpireSubscriptionResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-66575">
->
-> SubscriptionInitialPayment_CollectResult
->
-> </div>
->
-> > | Field             | Type                                                                                                                                                | Description |
-> > |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | subscription      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription          |             |
-> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
-> > | amulet            | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                |             |
->
-> **instance** GetField "amulet" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** GetField "subscription" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription)
->
-> **instance** GetField "subscriptionState" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "amulet" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** SetField "subscription" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription)
->
-> **instance** SetField "subscriptionState" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult
+<span id="constr-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-85758"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-71466">
+- `SubscriptionIdleState_ExpireSubscriptionResult`
 
-**data** SubscriptionInitialPayment_ExpireResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-14633">
->
-> SubscriptionInitialPayment_ExpireResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult
+- `instance GetField terminatedSubscription SubscriptionIdleState_ExpireSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionIdleState_ExpireSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult`
+- `instance HasFromAnyChoice SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult`
+- `instance HasToAnyChoice SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult`
 
-<div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-97550">
+<span id="type-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-27466"></span>
 
-**data** SubscriptionInitialPayment_RejectResult
+### `data SubscriptionIdleState_MakePaymentResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-64365">
->
-> SubscriptionInitialPayment_RejectResult
->
-> </div>
->
-> > | Field     | Type                                                                                                                                                       | Description |
-> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" SubscriptionInitialPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "amuletSum" SubscriptionInitialPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult
+<span id="constr-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-79353"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptionpaydata-96623">
+- `SubscriptionIdleState_MakePaymentResult`
 
-**data** SubscriptionPayData
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionPayment | ContractId SubscriptionPayment |  |
+| senderChange | Optional (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> Payment-related properties. Expected to be mutated rarely.
->
-> <div id="constr-splice-wallet-subscriptions-subscriptionpaydata-90180">
->
-> SubscriptionPayData
->
-> </div>
->
-> > | Field           | Type                                                                                                                   | Description                                                                                                                             |
-> > |-----------------|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-> > | paymentAmount   | PaymentAmount                                                                                                          | What amount of amulet is due on each interval.                                                                                          |
-> > | paymentInterval | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | At which intervals payments should be made.                                                                                             |
-> > | paymentDuration | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | The time available to the sender to initiate a payment; they can initiate the payment this much before the end of the current interval. |
->
-> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SubscriptionPayData
->
-> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SubscriptionPayData
->
-> **instance** GetField "payData" SubscriptionIdleState SubscriptionPayData
->
-> **instance** GetField "payData" SubscriptionInitialPayment SubscriptionPayData
->
-> **instance** GetField "payData" SubscriptionPayment SubscriptionPayData
->
-> **instance** GetField "payData" SubscriptionRequest SubscriptionPayData
->
-> **instance** GetField "paymentAmount" SubscriptionPayData PaymentAmount
->
-> **instance** GetField "paymentDuration" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** GetField "paymentInterval" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "payData" SubscriptionIdleState SubscriptionPayData
->
-> **instance** SetField "payData" SubscriptionInitialPayment SubscriptionPayData
->
-> **instance** SetField "payData" SubscriptionPayment SubscriptionPayData
->
-> **instance** SetField "payData" SubscriptionRequest SubscriptionPayData
->
-> **instance** SetField "paymentAmount" SubscriptionPayData PaymentAmount
->
-> **instance** SetField "paymentDuration" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
->
-> **instance** SetField "paymentInterval" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+- `instance GetField senderChange SubscriptionIdleState_MakePaymentResult (Optional (ContractId Amulet))`
+- `instance GetField subscriptionPayment SubscriptionIdleState_MakePaymentResult (ContractId SubscriptionPayment)`
+- `instance SetField senderChange SubscriptionIdleState_MakePaymentResult (Optional (ContractId Amulet))`
+- `instance SetField subscriptionPayment SubscriptionIdleState_MakePaymentResult (ContractId SubscriptionPayment)`
+- `instance HasExercise SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult`
+- `instance HasFromAnyChoice SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult`
+- `instance HasToAnyChoice SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult`
 
-<div id="type-splice-wallet-subscriptions-subscriptionpaymentcollectresult-94269">
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-97286"></span>
 
-**data** SubscriptionPayment_CollectResult
+### `data SubscriptionInitialPayment_CollectResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionpaymentcollectresult-9234">
->
-> SubscriptionPayment_CollectResult
->
-> </div>
->
-> > | Field             | Type                                                                                                                                                | Description |
-> > |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
-> > | amulet            | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                |             |
->
-> **instance** GetField "amulet" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** GetField "subscriptionState" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "amulet" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
->
-> **instance** SetField "subscriptionState" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult
+<span id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-66575"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptionpaymentexpireresult-84183">
+- `SubscriptionInitialPayment_CollectResult`
 
-**data** SubscriptionPayment_ExpireResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscription | ContractId Subscription |  |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amulet | ContractId Amulet |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionpaymentexpireresult-46758">
->
-> SubscriptionPayment_ExpireResult
->
-> </div>
->
-> > | Field             | Type                                                                                                                                                       | Description |
-> > |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState        |             |
-> > | amuletSum         | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" SubscriptionPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "subscriptionState" SubscriptionPayment_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "amuletSum" SubscriptionPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "subscriptionState" SubscriptionPayment_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult
+- `instance GetField amulet SubscriptionInitialPayment_CollectResult (ContractId Amulet)`
+- `instance GetField subscription SubscriptionInitialPayment_CollectResult (ContractId Subscription)`
+- `instance GetField subscriptionState SubscriptionInitialPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance SetField amulet SubscriptionInitialPayment_CollectResult (ContractId Amulet)`
+- `instance SetField subscription SubscriptionInitialPayment_CollectResult (ContractId Subscription)`
+- `instance SetField subscriptionState SubscriptionInitialPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult`
+- `instance HasFromAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult`
+- `instance HasToAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult`
 
-<div id="type-splice-wallet-subscriptions-subscriptionpaymentrejectresult-80731">
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-71466"></span>
 
-**data** SubscriptionPayment_RejectResult
+### `data SubscriptionInitialPayment_ExpireResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionpaymentrejectresult-20586">
->
-> SubscriptionPayment_RejectResult
->
-> </div>
->
-> > | Field             | Type                                                                                                                                                       | Description |
-> > |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState        |             |
-> > | amuletSum         | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "amuletSum" SubscriptionPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "subscriptionState" SubscriptionPayment_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** SetField "amuletSum" SubscriptionPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "subscriptionState" SubscriptionPayment_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult
+<span id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-14633"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-1166">
+- `SubscriptionInitialPayment_ExpireResult`
 
-**data** SubscriptionRequest_AcceptAndMakePaymentResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-32571">
->
-> SubscriptionRequest_AcceptAndMakePaymentResult
->
-> </div>
->
-> > | Field               | Type                                                                                                                                                                                                                                                                  | Description |
-> > |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | subscriptionPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment                                                                                                              |             |
-> > | senderChange        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
->
-> **instance** GetField "senderChange" SubscriptionRequest_AcceptAndMakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** GetField "subscriptionPayment" SubscriptionRequest_AcceptAndMakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment)
->
-> **instance** SetField "senderChange" SubscriptionRequest_AcceptAndMakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
->
-> **instance** SetField "subscriptionPayment" SubscriptionRequest_AcceptAndMakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult
+- `instance GetField amuletSum SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult`
+- `instance HasFromAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult`
+- `instance HasToAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult`
 
-<div id="type-splice-wallet-subscriptions-subscriptionrequestrejectresult-11624">
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-97550"></span>
 
-**data** SubscriptionRequest_RejectResult
+### `data SubscriptionInitialPayment_RejectResult`
 
-</div>
+Constructors:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionrequestrejectresult-75381">
->
-> SubscriptionRequest_RejectResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                 | Description |
-> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
->
-> **instance** GetField "terminatedSubscription" SubscriptionRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** SetField "terminatedSubscription" SubscriptionRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult
+<span id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-64365"></span>
 
-<div id="type-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-7225">
+- `SubscriptionInitialPayment_RejectResult`
 
-**data** SubscriptionRequest_WithdrawResult
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
 
-</div>
+Instances:
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-40204">
->
-> SubscriptionRequest_WithdrawResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                 | Description |
-> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
->
-> **instance** GetField "terminatedSubscription" SubscriptionRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** SetField "terminatedSubscription" SubscriptionRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult
+- `instance GetField amuletSum SubscriptionInitialPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum SubscriptionInitialPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult`
+- `instance HasFromAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult`
+- `instance HasToAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult`
 
-<div id="type-splice-wallet-subscriptions-subscriptionarchiveresult-60922">
+<span id="type-splice-wallet-subscriptions-subscriptionpaydata-96623"></span>
 
-**data** Subscription_ArchiveResult
+### `data SubscriptionPayData`
 
-</div>
+Payment-related properties. Expected to be mutated rarely.
 
-> <div id="constr-splice-wallet-subscriptions-subscriptionarchiveresult-91207">
->
-> Subscription_ArchiveResult
->
-> </div>
->
-> > | Field                  | Type                                                                                                                                                 | Description |
-> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
->
-> **instance** GetField "terminatedSubscription" Subscription_ArchiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** SetField "terminatedSubscription" Subscription_ArchiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
->
-> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Subscription Subscription_Archive Subscription_ArchiveResult
->
-> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Subscription Subscription_Archive Subscription_ArchiveResult
->
-> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Subscription Subscription_Archive Subscription_ArchiveResult
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionpaydata-90180"></span>
+
+- `SubscriptionPayData`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentAmount | PaymentAmount | What amount of amulet is due on each interval. |
+| paymentInterval | RelTime | At which intervals payments should be made. |
+| paymentDuration | RelTime | The time available to the sender to initiate a payment; they can initiate the payment this much before the end of the current interval. |
+
+Instances:
+
+- `instance Eq SubscriptionPayData`
+- `instance Show SubscriptionPayData`
+- `instance GetField payData SubscriptionIdleState SubscriptionPayData`
+- `instance GetField payData SubscriptionInitialPayment SubscriptionPayData`
+- `instance GetField payData SubscriptionPayment SubscriptionPayData`
+- `instance GetField payData SubscriptionRequest SubscriptionPayData`
+- `instance GetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance GetField paymentDuration SubscriptionPayData RelTime`
+- `instance GetField paymentInterval SubscriptionPayData RelTime`
+- `instance SetField payData SubscriptionIdleState SubscriptionPayData`
+- `instance SetField payData SubscriptionInitialPayment SubscriptionPayData`
+- `instance SetField payData SubscriptionPayment SubscriptionPayData`
+- `instance SetField payData SubscriptionRequest SubscriptionPayData`
+- `instance SetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance SetField paymentDuration SubscriptionPayData RelTime`
+- `instance SetField paymentInterval SubscriptionPayData RelTime`
+
+<span id="type-splice-wallet-subscriptions-subscriptionpaymentcollectresult-94269"></span>
+
+### `data SubscriptionPayment_CollectResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionpaymentcollectresult-9234"></span>
+
+- `SubscriptionPayment_CollectResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amulet | ContractId Amulet |  |
+
+Instances:
+
+- `instance GetField amulet SubscriptionPayment_CollectResult (ContractId Amulet)`
+- `instance GetField subscriptionState SubscriptionPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance SetField amulet SubscriptionPayment_CollectResult (ContractId Amulet)`
+- `instance SetField subscriptionState SubscriptionPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult`
+- `instance HasFromAnyChoice SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult`
+- `instance HasToAnyChoice SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionpaymentexpireresult-84183"></span>
+
+### `data SubscriptionPayment_ExpireResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionpaymentexpireresult-46758"></span>
+
+- `SubscriptionPayment_ExpireResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum SubscriptionPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField subscriptionState SubscriptionPayment_ExpireResult (ContractId SubscriptionIdleState)`
+- `instance SetField amuletSum SubscriptionPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField subscriptionState SubscriptionPayment_ExpireResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult`
+- `instance HasFromAnyChoice SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult`
+- `instance HasToAnyChoice SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionpaymentrejectresult-80731"></span>
+
+### `data SubscriptionPayment_RejectResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionpaymentrejectresult-20586"></span>
+
+- `SubscriptionPayment_RejectResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum SubscriptionPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField subscriptionState SubscriptionPayment_RejectResult (ContractId SubscriptionIdleState)`
+- `instance SetField amuletSum SubscriptionPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField subscriptionState SubscriptionPayment_RejectResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult`
+- `instance HasFromAnyChoice SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult`
+- `instance HasToAnyChoice SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-1166"></span>
+
+### `data SubscriptionRequest_AcceptAndMakePaymentResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-32571"></span>
+
+- `SubscriptionRequest_AcceptAndMakePaymentResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionPayment | ContractId SubscriptionInitialPayment |  |
+| senderChange | Optional (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField senderChange SubscriptionRequest_AcceptAndMakePaymentResult (Optional (ContractId Amulet))`
+- `instance GetField subscriptionPayment SubscriptionRequest_AcceptAndMakePaymentResult (ContractId SubscriptionInitialPayment)`
+- `instance SetField senderChange SubscriptionRequest_AcceptAndMakePaymentResult (Optional (ContractId Amulet))`
+- `instance SetField subscriptionPayment SubscriptionRequest_AcceptAndMakePaymentResult (ContractId SubscriptionInitialPayment)`
+- `instance HasExercise SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult`
+- `instance HasFromAnyChoice SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult`
+- `instance HasToAnyChoice SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequestrejectresult-11624"></span>
+
+### `data SubscriptionRequest_RejectResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionrequestrejectresult-75381"></span>
+
+- `SubscriptionRequest_RejectResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription SubscriptionRequest_RejectResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionRequest_RejectResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult`
+- `instance HasFromAnyChoice SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult`
+- `instance HasToAnyChoice SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-7225"></span>
+
+### `data SubscriptionRequest_WithdrawResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-40204"></span>
+
+- `SubscriptionRequest_WithdrawResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription SubscriptionRequest_WithdrawResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionRequest_WithdrawResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult`
+- `instance HasFromAnyChoice SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult`
+- `instance HasToAnyChoice SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionarchiveresult-60922"></span>
+
+### `data Subscription_ArchiveResult`
+
+Constructors:
+
+<span id="constr-splice-wallet-subscriptions-subscriptionarchiveresult-91207"></span>
+
+- `Subscription_ArchiveResult`
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription Subscription_ArchiveResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription Subscription_ArchiveResult (ContractId TerminatedSubscription)`
+- `instance HasExercise Subscription Subscription_Archive Subscription_ArchiveResult`
+- `instance HasFromAnyChoice Subscription Subscription_Archive Subscription_ArchiveResult`
+- `instance HasToAnyChoice Subscription Subscription_Archive Subscription_ArchiveResult`
 
 ## Functions
 
-<div id="function-splice-wallet-subscriptions-subscriptionsignatories-98765">
+<span id="function-splice-wallet-subscriptions-subscriptionsignatories-98765"></span>
 
-subscriptionSignatories
-: SubscriptionData -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
+### `subscriptionSignatories`
 
-</div>
+```daml
+subscriptionSignatories : SubscriptionData -> [Party]
+```
 
-<div id="function-splice-wallet-subscriptions-paydataisvalid-4217">
+<span id="function-splice-wallet-subscriptions-paydataisvalid-4217"></span>
 
-payDataIsValid
-: SubscriptionPayData -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+### `payDataIsValid`
 
-</div>
+```daml
+payDataIsValid : SubscriptionPayData -> Bool
+```
 
-<div id="function-splice-wallet-subscriptions-lockandmakechange-61624">
+<span id="function-splice-wallet-subscriptions-lockandmakechange-61624"></span>
 
-lockAndMakeChange
-: PaymentTransferContext -\> SubscriptionData -\> SubscriptionPayData -\> \[TransferInput\] -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet, [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), Round)
+### `lockAndMakeChange`
 
-</div>
+```daml
+lockAndMakeChange : PaymentTransferContext -> SubscriptionData -> SubscriptionPayData -> [TransferInput] -> Time -> Party -> Update (ContractId LockedAmulet, Optional (ContractId Amulet), Decimal, Round)
+```
 
-<div id="function-splice-wallet-subscriptions-unlockandtransfer-4476">
+<span id="function-splice-wallet-subscriptions-unlockandtransfer-4476"></span>
 
-unlockAndTransfer
-: AppTransferContext -\> SubscriptionData -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+### `unlockAndTransfer`
 
-</div>
+```daml
+unlockAndTransfer : AppTransferContext -> SubscriptionData -> Decimal -> ContractId LockedAmulet -> Update (ContractId Amulet)
+```
 
-<div id="function-splice-wallet-subscriptions-mktransferoutput-31673">
+<span id="function-splice-wallet-subscriptions-mktransferoutput-31673"></span>
 
-mkTransferOutput
-: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferOutput
+### `mkTransferOutput`
 
-</div>
+```daml
+mkTransferOutput : Party -> Decimal -> TransferOutput
+```
 
-{/* COPIED_END */}
+## Templates
+
+<span id="type-splice-wallet-subscriptions-subscription-33404"></span>
+
+### Template `Subscription`
+
+Main subscription object.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| reference | ContractId SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<span id="type-splice-wallet-subscriptions-subscriptionarchive-38051"></span>
+
+#### Choice `Subscription_Archive`
+
+Controllers: `signatory this`
+
+Returns: `Subscription_ArchiveResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionidlestate-59870"></span>
+
+### Template `SubscriptionIdleState`
+
+The base state in our subscription flow.
+Here, we are typically waiting for the time for the next payment to arrive.
+If that time has passed, we are waiting for someone to expire the subscription.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscription | ContractId Subscription | The subscription this belongs to. |
+| subscriptionData | SubscriptionData | Copy of the subscription contract for easier access to its field. |
+| payData | SubscriptionPayData | Payment-related properties. |
+| nextPaymentDueAt | Time | After which time the next payment can and should be paid. |
+| reference | ContractId SubscriptionRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<span id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscription-25061"></span>
+
+#### Choice `SubscriptionIdleState_CancelSubscription`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`
+
+Returns: `SubscriptionIdleState_CancelSubscriptionResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscription-50078"></span>
+
+#### Choice `SubscriptionIdleState_ExpireSubscription`
+
+Controllers: `actor`
+
+Returns: `SubscriptionIdleState_ExpireSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptionidlestatemakepayment-62467"></span>
+
+#### Choice `SubscriptionIdleState_MakePayment`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`, `walletProvider`
+
+Returns: `SubscriptionIdleState_MakePaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpayment-79960"></span>
+
+### Template `SubscriptionInitialPayment`
+
+The initial payment on a subscription.
+Implicitly, this is also the "accept" of the preceding `SubscriptionRequest`.
+Collecting this payments creates the subscription and thereby enables all follow-up payments.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| payData | SubscriptionPayData |  |
+| targetAmount | Decimal | Exact amount in Amulet that the receiver will get. |
+| lockedAmulet | ContractId LockedAmulet |  |
+| round | Round | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+| reference | ContractId SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollect-92147"></span>
+
+#### Choice `SubscriptionInitialPayment_Collect`
+
+Controllers: `signatory this`
+
+Returns: `SubscriptionInitialPayment_CollectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpire-95363"></span>
+
+#### Choice `SubscriptionInitialPayment_Expire`
+
+Controllers: `actor`
+
+Returns: `SubscriptionInitialPayment_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptioninitialpaymentreject-61119"></span>
+
+#### Choice `SubscriptionInitialPayment_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"receiver" subscriptionData)`
+
+Returns: `SubscriptionInitialPayment_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptionpayment-4463"></span>
+
+### Template `SubscriptionPayment`
+
+An in-flight (yet to be collected) payment on an existing subscription.
+Doubles as a "payment in progress" state.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscription | ContractId Subscription | The subscription this belongs to. |
+| subscriptionData | SubscriptionData | Copy of the base subscription properties; for convenience. |
+| payData | SubscriptionPayData | Payment-related properties. |
+| thisPaymentDueAt | Time | After which time the next payment can and should be paid. |
+| targetAmount | Decimal |  |
+| lockedAmulet | ContractId LockedAmulet |  |
+| round | Round | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+| reference | ContractId SubscriptionRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<span id="type-splice-wallet-subscriptions-subscriptionpaymentcollect-45604"></span>
+
+#### Choice `SubscriptionPayment_Collect`
+
+Controllers: `signatory this`
+
+Returns: `SubscriptionPayment_CollectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptionpaymentexpire-61162"></span>
+
+#### Choice `SubscriptionPayment_Expire`
+
+Controllers: `actor`
+
+Returns: `SubscriptionPayment_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptionpaymentreject-72046"></span>
+
+#### Choice `SubscriptionPayment_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"receiver" subscriptionData)`
+
+Returns: `SubscriptionPayment_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequest-40942"></span>
+
+### Template `SubscriptionRequest`
+
+A request for establishing a subscription.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| payData | SubscriptionPayData |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepayment-96423"></span>
+
+#### Choice `SubscriptionRequest_AcceptAndMakePayment`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`, `walletProvider`
+
+Returns: `SubscriptionRequest_AcceptAndMakePaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequestreject-95001"></span>
+
+#### Choice `SubscriptionRequest_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`
+
+Returns: `SubscriptionRequest_RejectResult`
+
+<span id="type-splice-wallet-subscriptions-subscriptionrequestwithdraw-88172"></span>
+
+#### Choice `SubscriptionRequest_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"receiver" subscriptionData)`
+
+Returns: `SubscriptionRequest_WithdrawResult`
+
+<span id="type-splice-wallet-subscriptions-terminatedsubscription-20905"></span>
+
+### Template `TerminatedSubscription`
+
+An aborted subscription. Subscriptions should usually be archived together with
+the context contract of the app that makes the subscription, e.g., AnsEntryContext.
+To achieve that, we don't archive subscriptions directly but instead create TerminatedSubscription contracts
+that are then archived as part of the surrounding workflows.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| reference | ContractId SubscriptionRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "generate:canton-protobuf-history": "python3 scripts/generate_canton_protobuf_history.py",
     "generate:wallet-gateway-openrpc-reference": "python3 scripts/generate_wallet_gateway_openrpc_reference.py",
     "generate:splice-mintlify-openapi": "python3 scripts/generate_splice_mintlify_openapi.py",
+    "generate:splice-daml-reference": "python3 scripts/generate_splice_daml_reference.py",
     "generate:canton-metrics-reference": "python3 scripts/generate_canton_metrics_reference.py",
     "generate:external-snippets": "python3 scripts/generate_external_snippets.py",
     "validate:splice-mintlify-openapi-nav": "python3 scripts/validate_splice_mintlify_openapi_nav.py",

--- a/scripts/generate_all_reference_docs.py
+++ b/scripts/generate_all_reference_docs.py
@@ -32,7 +32,7 @@ LEGACY_PAGE_REFS = {
 
 @dataclass(frozen=True)
 class NavSlice:
-    kind: Literal["ledger_child", "top_group", "top_groups", "nested_group"]
+    kind: Literal["ledger_child", "top_group", "top_groups", "nested_group", "product_nested_group"]
     labels: tuple[str, ...]
 
 
@@ -86,6 +86,12 @@ SCRIPT_JOBS = [
     ScriptJob(
         script_path=REPO_ROOT / "scripts" / "generate_splice_mintlify_openapi.py",
         nav_slices=(NavSlice("top_group", ("Splice APIs",)),),
+    ),
+    ScriptJob(
+        script_path=REPO_ROOT / "scripts" / "generate_splice_daml_reference.py",
+        nav_slices=(
+            NavSlice("product_nested_group", ("API Reference", "Splice APIs", "Splice Daml Packages")),
+        ),
     ),
     ScriptJob(
         script_path=REPO_ROOT / "scripts" / "generate_typescript_bindings_reference.py",
@@ -168,6 +174,25 @@ def dropdown_pages(docs: dict[str, Any], *, dropdown_label: str) -> list[Any]:
         return pages
 
     raise ValueError(f"docs.json navigation must define dropdowns or products: {DOCS_JSON_PATH}")
+
+
+def product_navigation_items(docs: dict[str, Any], *, product_label: str, source_path: Path) -> list[Any]:
+    navigation = docs.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json missing navigation object: {source_path}")
+    products = navigation.get("products")
+    if not isinstance(products, list):
+        raise ValueError(f"docs.json navigation.products must be a list: {source_path}")
+    product = next((item for item in products if isinstance(item, dict) and item.get("product") == product_label), None)
+    if product is None:
+        raise ValueError(f"Product not found in docs.json: {product_label}")
+    pages = product.get("pages")
+    if isinstance(pages, list):
+        return pages
+    groups = product.get("groups")
+    if isinstance(groups, list):
+        return groups
+    raise ValueError(f"Product does not expose a pages or groups list: {product_label}")
 
 
 def with_legacy_dropdown_scratch(docs: dict[str, Any]) -> dict[str, Any]:
@@ -308,6 +333,32 @@ def prune_page_refs(node: object, page_refs: set[str]) -> object | None:
 
 
 def merge_nav_slice(*, final_docs: dict[str, Any], scratch_docs: dict[str, Any], nav_slice: NavSlice, scratch_path: Path) -> None:
+    if nav_slice.kind == "product_nested_group":
+        product_label, *path_labels = nav_slice.labels
+        if len(path_labels) < 2:
+            raise ValueError(f"Product nested nav slice needs at least one parent and one child group: {nav_slice}")
+
+        scratch_items = product_navigation_items(
+            scratch_docs,
+            product_label=product_label,
+            source_path=scratch_path,
+        )
+        for parent_label in path_labels[:-1]:
+            scratch_parent = require_group(scratch_items, parent_label, source_path=scratch_path)
+            scratch_items = group_pages(scratch_parent, source_path=scratch_path)
+        child_group = require_group(scratch_items, path_labels[-1], source_path=scratch_path)
+
+        final_items = product_navigation_items(
+            final_docs,
+            product_label=product_label,
+            source_path=DOCS_JSON_PATH,
+        )
+        for parent_label in path_labels[:-1]:
+            final_parent = ensure_group(final_items, parent_label)
+            final_items = group_pages(final_parent, source_path=DOCS_JSON_PATH)
+        replace_group(final_items, child_group)
+        return
+
     final_pages = dropdown_pages(final_docs, dropdown_label=API_REFERENCE_DROPDOWN)
     scratch_pages = dropdown_pages(scratch_docs, dropdown_label=API_REFERENCE_DROPDOWN)
 

--- a/scripts/generate_splice_daml_reference.py
+++ b/scripts/generate_splice_daml_reference.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from docs_env import ensure_repo_direnv, repo_direnv_command
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import splice_openapi_release_bundles
+
+
+DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "x2mdx" / "splice-daml-reference" / "source-artifacts.json"
+DEFAULT_CACHE_DIR = REPO_ROOT / ".internal" / "cache" / "x2mdx" / "splice-daml-reference"
+DEFAULT_MANIFEST_ROOT = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "splice-daml-reference"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "docs-main" / "sdks-tools" / "api-reference" / "splice-daml"
+DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+
+
+@dataclass(frozen=True)
+class PackageInfo:
+    family: str
+    package_name: str
+    package_id: str
+    package_root: Path
+    exposed_modules: list[str]
+    depends: list[str]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Splice Daml package reference pages through the x2mdx daml-json renderer."
+    )
+    parser.add_argument("--source-config", default=str(DEFAULT_SOURCE_CONFIG))
+    parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR))
+    parser.add_argument("--manifest-root", default=str(DEFAULT_MANIFEST_ROOT))
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
+    parser.add_argument("--nav-product", help="docs.json navigation product to update. Defaults to manifest nav_product.")
+    parser.add_argument("--family", action="append", help="Package family to generate. Repeat to limit generation.")
+    parser.add_argument("--version", action="append", help="Release version to include. Repeat to limit generation.")
+    parser.add_argument("--publish-version", help="Release version whose pages should be published.")
+    parser.add_argument("--force-refresh", action="store_true", help="Re-download and re-extract release bundles.")
+    parser.add_argument("--force-regenerate", action="store_true", help="Regenerate Daml docs JSON and MDX output.")
+    parser.add_argument(
+        "--source-name",
+        default="Published Splice Daml docs JSON generated from release DAR artifacts",
+        help="Source label embedded in generated content.",
+    )
+    parser.add_argument(
+        "--version-filter",
+        default="published splice-node release bundles",
+        help="Version-filter label embedded in generated content.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def require_string(payload: dict[str, Any], key: str, *, source_path: Path) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{source_path} must define non-empty string field '{key}'")
+    return value
+
+
+def require_string_list(payload: dict[str, Any], key: str, *, source_path: Path) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{source_path} must define string list field '{key}'")
+    return list(value)
+
+
+def configured_families(source_config: dict[str, Any], *, source_path: Path) -> list[str]:
+    families = require_string_list(source_config, "families", source_path=source_path)
+    blocked = [entry["name"] for entry in blocked_live_families(source_config).values()]
+    duplicates = {family for family in families if families.count(family) > 1}
+    if duplicates:
+        raise ValueError(f"Duplicate configured Splice Daml families: {sorted(duplicates)}")
+    if set(families).intersection(blocked):
+        raise ValueError("Blocked Splice Daml families must not also be generated families")
+    return families
+
+
+def blocked_live_families(source_config: dict[str, Any]) -> dict[str, dict[str, str]]:
+    payload = source_config.get("blocked_live_families") or []
+    if not isinstance(payload, list):
+        raise ValueError("blocked_live_families must be a list when present")
+    blocked: dict[str, dict[str, str]] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ValueError("Each blocked_live_families entry must be an object")
+        name = item.get("name")
+        reason = item.get("reason")
+        if not isinstance(name, str) or not name:
+            raise ValueError("Each blocked_live_families entry needs a non-empty `name`")
+        if not isinstance(reason, str) or not reason:
+            raise ValueError(f"Blocked family {name!r} needs a non-empty `reason`")
+        blocked[name] = {"name": name, "reason": reason}
+    return blocked
+
+
+def docs_json_page_ref(path: Path, docs_json_path: Path) -> str:
+    relative = path.resolve().relative_to(docs_json_path.resolve().parent)
+    if relative.suffix != ".mdx":
+        raise ValueError(f"Expected MDX file under docs root, got: {path}")
+    return relative.with_suffix("").as_posix()
+
+
+def docs_route(path: Path, docs_json_path: Path) -> str:
+    page_ref = docs_json_page_ref(path, docs_json_path)
+    if page_ref.endswith("/index"):
+        page_ref = page_ref[: -len("/index")]
+    return f"/{page_ref}"
+
+
+def read_mdx_title(path: Path) -> str:
+    in_frontmatter = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line == "---":
+            if in_frontmatter:
+                break
+            in_frontmatter = True
+            continue
+        if not in_frontmatter:
+            continue
+        if line.startswith("title: "):
+            return line.split(":", 1)[1].strip().strip('"')
+    raise ValueError(f"Missing title frontmatter in {path}")
+
+
+def live_families_from_archive(archive_path: Path) -> set[str]:
+    pattern = re.compile(r".*/docs/html/app_dev/api/([^/]+)/index\.html$")
+    families: set[str] = set()
+    with tarfile.open(archive_path, "r:gz") as handle:
+        for member in handle.getmembers():
+            if not member.isfile():
+                continue
+            match = pattern.fullmatch(member.name)
+            if match:
+                families.add(match.group(1))
+    if not families:
+        raise ValueError(f"No app_dev/api families found in {archive_path}")
+    return families
+
+
+def dar_members_from_archive(archive_path: Path) -> dict[str, str]:
+    current_pattern = re.compile(r".*/dars/([^/]+)-current\.dar$")
+    fallback_pattern = re.compile(r".*/dars/([^/]+?)-[0-9].*\.dar$")
+    members: dict[str, tuple[int, str]] = {}
+    with tarfile.open(archive_path, "r:gz") as handle:
+        for member in handle.getmembers():
+            if not member.isfile() or not member.name.endswith(".dar") or "/dars/" not in member.name:
+                continue
+            current_match = current_pattern.fullmatch(member.name)
+            if current_match:
+                family = current_match.group(1)
+                priority = 1
+            else:
+                fallback_match = fallback_pattern.fullmatch(member.name)
+                if fallback_match is None:
+                    continue
+                family = fallback_match.group(1)
+                priority = 0
+            previous = members.get(family)
+            if previous is None or priority > previous[0]:
+                members[family] = (priority, member.name)
+    return {family: member_name for family, (_priority, member_name) in members.items()}
+
+
+def extract_dar(
+    *,
+    archive_path: Path,
+    dar_member_name: str,
+    output_dir: Path,
+    force_refresh: bool,
+) -> Path:
+    if output_dir.exists() and not force_refresh and any(output_dir.rglob("*.daml")):
+        return output_dir
+
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="splice-dar-") as temp_dir:
+        temp_dar = Path(temp_dir) / "bundle.dar"
+        with tarfile.open(archive_path, "r:gz") as handle:
+            member = handle.getmember(dar_member_name)
+            extracted = handle.extractfile(member)
+            if extracted is None:
+                raise FileNotFoundError(f"Failed to extract {dar_member_name} from {archive_path}")
+            temp_dar.write_bytes(extracted.read())
+        with zipfile.ZipFile(temp_dar) as dar_zip:
+            dar_zip.extractall(output_dir)
+    return output_dir
+
+
+def package_info(*, family: str, extract_dir: Path) -> PackageInfo:
+    package_root = next(
+        (path for path in sorted(extract_dir.iterdir()) if path.is_dir() and path.name != "META-INF"),
+        None,
+    )
+    if package_root is None:
+        raise FileNotFoundError(f"Could not find extracted package root in {extract_dir}")
+
+    conf_path = next((package_root / "data").glob("*.conf"), None)
+    if conf_path is None:
+        raise FileNotFoundError(f"Missing package conf in {package_root / 'data'}")
+
+    fields: dict[str, str] = {}
+    for line in conf_path.read_text(encoding="utf-8").splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+
+    package_id = fields.get("id")
+    if not package_id:
+        raise ValueError(f"Missing package id in {conf_path}")
+    package_name = fields.get("name")
+    if not package_name:
+        raise ValueError(f"Missing package name in {conf_path}")
+    exposed_modules = [item for item in fields.get("exposed-modules", "").split() if item]
+    if not exposed_modules:
+        raise ValueError(f"Missing exposed modules in {conf_path}")
+    depends = [item for item in fields.get("depends", "").split() if item]
+    return PackageInfo(
+        family=family,
+        package_name=package_name,
+        package_id=package_id,
+        package_root=package_root,
+        exposed_modules=exposed_modules,
+        depends=depends,
+    )
+
+
+def module_source_paths(info: PackageInfo) -> list[str]:
+    source_paths: list[str] = []
+    for module_name in info.exposed_modules:
+        relative_path = Path(*module_name.split(".")).with_suffix(".daml")
+        source_path = info.package_root / relative_path
+        if not source_path.exists():
+            raise FileNotFoundError(f"Missing source file for module {module_name}: {source_path}")
+        source_paths.append(str(relative_path))
+    return source_paths
+
+
+def dependency_include_dirs(
+    *,
+    info: PackageInfo,
+    package_index: dict[str, PackageInfo],
+) -> list[Path]:
+    include_dirs: list[Path] = []
+    seen_ids: set[str] = set()
+    package_name_index = {package.package_name: package for package in package_index.values()}
+
+    def resolve_dependency(package_id: str) -> PackageInfo | None:
+        exact = package_index.get(package_id)
+        if exact is not None:
+            return exact
+        candidates = [
+            package
+            for package_name, package in package_name_index.items()
+            if package_id == package_name or package_id.startswith(f"{package_name}-")
+        ]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda package: len(package.package_name), reverse=True)
+        return candidates[0]
+
+    def visit(package_id: str) -> None:
+        if package_id in seen_ids:
+            return
+        seen_ids.add(package_id)
+        dependency = resolve_dependency(package_id)
+        if dependency is None:
+            return
+        include_dirs.append(dependency.package_root)
+        for nested in dependency.depends:
+            visit(nested)
+
+    for dependency_id in info.depends:
+        visit(dependency_id)
+    return include_dirs
+
+
+def generate_daml_json(
+    *,
+    info: PackageInfo,
+    include_dirs: list[Path],
+    output_json: Path,
+    force_regenerate: bool,
+) -> Path:
+    if output_json.exists() and not force_regenerate:
+        print(f"Using cached Daml docs JSON: {output_json}")
+        return output_json
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    command = repo_direnv_command(
+        REPO_ROOT,
+        "daml",
+        "damlc",
+        "docs",
+        "--ignore-data-deps-visibility",
+        "yes",
+    )
+    for include_dir in include_dirs:
+        command.extend(["--include", str(include_dir)])
+    command.extend(
+        [
+            "--include-modules",
+            ",".join(info.exposed_modules),
+            "--format",
+            "json",
+            "--output",
+            str(output_json),
+            *module_source_paths(info),
+        ]
+    )
+    print("Running:", " ".join(command))
+    subprocess.run(command, cwd=str(info.package_root), check=True)
+    return output_json
+
+
+def write_manifest(
+    *,
+    manifest_path: Path,
+    source_name: str,
+    publish_version: str,
+    versions: list[dict[str, str]],
+) -> Path:
+    manifest = {
+        "source": source_name,
+        "publish_version": publish_version,
+        "versions": versions,
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote manifest: {manifest_path}")
+    return manifest_path
+
+
+def run_x2mdx(
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    publish_version: str,
+    overview_title: str,
+    source_name: str,
+    version_filter: str,
+    docs_json_path: Path,
+) -> None:
+    route_prefix = docs_route(output_dir / "index.mdx", docs_json_path)
+    command = repo_direnv_command(
+        REPO_ROOT,
+        "x2mdx",
+        "daml-json",
+        "build-api-pages-from-manifest",
+        "--manifest",
+        str(manifest_path),
+        "--output-dir",
+        str(output_dir),
+        "--publish-version",
+        publish_version,
+        "--overview-title",
+        overview_title,
+        "--source-name",
+        source_name,
+        "--version-filter",
+        version_filter,
+        "--link-prefix",
+        route_prefix,
+    )
+    print("Running:", " ".join(command))
+    subprocess.run(command, cwd=str(REPO_ROOT), check=True)
+
+
+def family_group(*, family_dir: Path, docs_json_path: Path) -> dict[str, Any]:
+    index_path = family_dir / "index.mdx"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Missing generated family index: {index_path}")
+    page_entries = []
+    for page in sorted(family_dir.glob("*.mdx")):
+        title = read_mdx_title(page)
+        page_entries.append((0 if page.name == "index.mdx" else 1, title.lower(), docs_json_page_ref(page, docs_json_path)))
+    page_entries.sort()
+    return {
+        "group": family_dir.name,
+        "pages": [page_ref for _sort, _title, page_ref in page_entries],
+    }
+
+
+def navigation_product_pages(docs: dict[str, Any], *, product_label: str, docs_json_path: Path) -> list[Any]:
+    navigation = docs.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json navigation must be an object: {docs_json_path}")
+    products = navigation.get("products")
+    if not isinstance(products, list):
+        raise ValueError(f"docs.json navigation.products must be a list: {docs_json_path}")
+    product = next((item for item in products if isinstance(item, dict) and item.get("product") == product_label), None)
+    if product is None:
+        raise ValueError(f"Product not found in docs.json: {product_label}")
+    pages = product.get("pages")
+    if isinstance(pages, list):
+        return pages
+    groups = product.get("groups")
+    if isinstance(groups, list):
+        return groups
+    raise ValueError(f"Product does not expose a pages or groups list: {product_label}")
+
+
+def ensure_group_path(items: list[Any], group_path: list[str]) -> list[Any]:
+    current_pages = items
+    for label in group_path:
+        group = next((item for item in current_pages if isinstance(item, dict) and item.get("group") == label), None)
+        if group is None:
+            group = {"group": label, "pages": []}
+            current_pages.append(group)
+        pages = group.get("pages")
+        if not isinstance(pages, list):
+            pages = []
+            group["pages"] = pages
+        current_pages = pages
+    return current_pages
+
+
+def replace_group(items: list[Any], group: dict[str, Any]) -> None:
+    label = group.get("group")
+    if not isinstance(label, str) or not label:
+        raise ValueError(f"Expected navigation group label: {group}")
+    replacement_index: int | None = None
+    filtered: list[Any] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("group") == label:
+            if replacement_index is None:
+                replacement_index = len(filtered)
+            continue
+        filtered.append(item)
+    if replacement_index is None:
+        filtered.append(group)
+    else:
+        filtered.insert(replacement_index, group)
+    items[:] = filtered
+
+
+def remove_group_label(node: Any, label: str) -> None:
+    if isinstance(node, list):
+        kept: list[Any] = []
+        for item in node:
+            if isinstance(item, dict) and item.get("group") == label:
+                continue
+            remove_group_label(item, label)
+            kept.append(item)
+        node[:] = kept
+        return
+    if isinstance(node, dict):
+        for value in node.values():
+            remove_group_label(value, label)
+
+
+def update_docs_navigation(
+    *,
+    docs_json_path: Path,
+    product_label: str,
+    parent_groups: list[str],
+    nav_group_label: str,
+    output_root: Path,
+    family_order: list[str],
+) -> None:
+    docs = load_json(docs_json_path)
+    remove_group_label(docs.get("navigation"), nav_group_label)
+    pages = navigation_product_pages(docs, product_label=product_label, docs_json_path=docs_json_path)
+    target_pages = ensure_group_path(pages, parent_groups)
+    groups = [
+        family_group(family_dir=output_root / family, docs_json_path=docs_json_path)
+        for family in family_order
+        if (output_root / family / "index.mdx").exists()
+    ]
+    if not groups:
+        raise FileNotFoundError(f"No Splice Daml package output directories found under {output_root}")
+    replace_group(target_pages, {"group": nav_group_label, "pages": groups})
+    docs_json_path.write_text(json.dumps(docs, indent=2) + "\n", encoding="utf-8")
+    print(f"Updated docs navigation: {docs_json_path}")
+
+
+def render_reference(
+    *,
+    source_config_path: Path,
+    cache_dir: Path,
+    manifest_root: Path,
+    output_root: Path,
+    docs_json_path: Path,
+    nav_product: str | None,
+    include_families: set[str] | None,
+    include_versions: set[str] | None,
+    publish_version_override: str | None,
+    source_name: str,
+    version_filter: str,
+    force_refresh: bool,
+    force_regenerate: bool,
+) -> None:
+    source_config = load_json(source_config_path)
+    families = configured_families(source_config, source_path=source_config_path)
+    blocked = blocked_live_families(source_config)
+    selected_families = [family for family in families if include_families is None or family in include_families]
+    unknown_families = (include_families or set()).difference(families).difference(blocked)
+    if unknown_families:
+        raise ValueError(f"Unknown family selection: {sorted(unknown_families)}")
+    if not selected_families:
+        raise ValueError("No Splice Daml families selected for generation")
+
+    releases = splice_openapi_release_bundles.selected_releases(
+        source_config=source_config,
+        include_versions=include_versions,
+    )
+    publish_version = publish_version_override or str(source_config.get("publish_version") or releases[-1]["version"])
+    release_by_version = {release["version"]: release for release in releases}
+    if publish_version not in release_by_version:
+        raise ValueError(f"Publish version {publish_version!r} was not selected")
+    publish_release = release_by_version[publish_version]
+
+    publish_archive = splice_openapi_release_bundles.ensure_archive(
+        cache_dir=cache_dir,
+        release=publish_release,
+        force_refresh=force_refresh,
+    )
+    live_families = live_families_from_archive(publish_archive)
+    covered_families = set(families).union(blocked)
+    missing_live = sorted(live_families.difference(covered_families))
+    extra_covered = sorted(covered_families.difference(live_families))
+    if missing_live or extra_covered:
+        problems = []
+        if missing_live:
+            problems.append(f"uncovered live families: {missing_live}")
+        if extra_covered:
+            problems.append(f"configured families not present on live docs surface: {extra_covered}")
+        raise ValueError("; ".join(problems))
+
+    publish_dars = dar_members_from_archive(publish_archive)
+    for family in families:
+        if family not in publish_dars:
+            raise ValueError(f"Configured family {family!r} has no DAR in publish release {publish_version}")
+
+    package_info_by_version: dict[str, dict[str, PackageInfo]] = {}
+    package_info_by_id: dict[str, dict[str, PackageInfo]] = {}
+    for release in releases:
+        archive = splice_openapi_release_bundles.ensure_archive(
+            cache_dir=cache_dir,
+            release=release,
+            force_refresh=force_refresh,
+        )
+        dar_members = dar_members_from_archive(archive)
+        family_infos: dict[str, PackageInfo] = {}
+        id_index: dict[str, PackageInfo] = {}
+        for family in families:
+            member_name = dar_members.get(family)
+            if member_name is None:
+                continue
+            extract_dir = extract_dar(
+                archive_path=archive,
+                dar_member_name=member_name,
+                output_dir=cache_dir / "extracted" / release["version"] / family,
+                force_refresh=force_refresh,
+            )
+            info = package_info(family=family, extract_dir=extract_dir)
+            family_infos[family] = info
+            id_index[info.package_id] = info
+        package_info_by_version[release["version"]] = family_infos
+        package_info_by_id[release["version"]] = id_index
+
+    for family in selected_families:
+        manifest_versions: list[dict[str, str]] = []
+        for release in releases:
+            info = package_info_by_version[release["version"]].get(family)
+            if info is None:
+                continue
+            output_json = generate_daml_json(
+                info=info,
+                include_dirs=dependency_include_dirs(
+                    info=info,
+                    package_index=package_info_by_id[release["version"]],
+                ),
+                output_json=cache_dir / "json" / release["version"] / f"{family}.json",
+                force_regenerate=force_regenerate,
+            )
+            manifest_versions.append(
+                {
+                    "version": release["version"],
+                    "json_path": str(output_json.resolve()),
+                }
+            )
+
+        if not manifest_versions:
+            raise ValueError(f"No generated JSON versions available for {family}")
+
+        manifest_path = write_manifest(
+            manifest_path=manifest_root / family / "manifest.json",
+            source_name=source_name,
+            publish_version=publish_version,
+            versions=manifest_versions,
+        )
+        run_x2mdx(
+            manifest_path=manifest_path,
+            output_dir=output_root / family,
+            publish_version=publish_version,
+            overview_title=family,
+            source_name=source_name,
+            version_filter=version_filter,
+            docs_json_path=docs_json_path,
+        )
+
+    family_order = [*families, *blocked.keys()]
+    update_docs_navigation(
+        docs_json_path=docs_json_path,
+        product_label=nav_product or require_string(source_config, "nav_product", source_path=source_config_path),
+        parent_groups=require_string_list(source_config, "nav_parent_groups", source_path=source_config_path),
+        nav_group_label=require_string(source_config, "nav_group_label", source_path=source_config_path),
+        output_root=output_root,
+        family_order=family_order,
+    )
+
+
+def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
+    args = parse_args()
+    render_reference(
+        source_config_path=Path(args.source_config).resolve(),
+        cache_dir=Path(args.cache_dir).resolve(),
+        manifest_root=Path(args.manifest_root).resolve(),
+        output_root=Path(args.output_root).resolve(),
+        docs_json_path=Path(args.docs_json).resolve(),
+        nav_product=args.nav_product,
+        include_families=set(args.family) if args.family else None,
+        include_versions=set(args.version) if args.version else None,
+        publish_version_override=args.publish_version,
+        source_name=args.source_name,
+        version_filter=args.version_filter,
+        force_refresh=args.force_refresh,
+        force_regenerate=args.force_regenerate,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/x2mdx/daml_json/render.py
+++ b/src/x2mdx/daml_json/render.py
@@ -34,6 +34,7 @@ ACRONYM_PARTS = {
     "lf": "LF",
 }
 REPLACED_BY_RE = re.compile(r"^Replaced by: (?P<target>[A-Za-z][A-Za-z0-9_.]*[A-Za-z0-9])\.$")
+MARKDOWN_AUTOLINK_RE = re.compile(r"<(https?://[^>\s]+)>")
 
 
 def slugify(text: str) -> str:
@@ -44,11 +45,15 @@ def escape_md_cell(text: str) -> str:
     return text.replace("|", r"\|").replace("\n", "<br/>")
 
 
+def normalize_markdown_autolinks(text: str) -> str:
+    return MARKDOWN_AUTOLINK_RE.sub(lambda match: f"[{match.group(1)}]({match.group(1)})", text)
+
+
 def render_doc_blocks(descr: Any) -> str:
     if not descr:
         return ""
     if isinstance(descr, str):
-        return descr.strip()
+        return normalize_markdown_autolinks(descr.strip())
 
     paragraphs = descr if isinstance(descr, list) else [descr]
     blocks: list[str] = []
@@ -68,7 +73,7 @@ def render_doc_blocks(descr: Any) -> str:
         else:
             raw = str(paragraph).strip()
         if raw:
-            blocks.append(raw)
+            blocks.append(normalize_markdown_autolinks(raw))
     return "\n\n".join(blocks)
 
 
@@ -425,7 +430,7 @@ def render_constructor(constructor: dict[str, Any]) -> str:
     desc = render_doc_blocks(payload.get("ac_descr"))
     if desc:
         parts.append(desc)
-    return "\n".join(parts)
+    return "\n\n".join(parts)
 
 
 def render_adt(adt_union: dict[str, Any]) -> str:
@@ -448,7 +453,7 @@ def render_adt(adt_union: dict[str, Any]) -> str:
         constrs = adt.get("ad_constrs", [])
         if constrs:
             parts.append("Constructors:")
-            parts.append("\n".join(render_constructor(constructor) for constructor in constrs))
+            parts.append("\n\n".join(render_constructor(constructor) for constructor in constrs))
         instances = adt.get("ad_instances", [])
         if instances:
             parts.append("Instances:")
@@ -492,7 +497,7 @@ def render_adt(adt_union: dict[str, Any]) -> str:
         constrs = adt.get("ad_constrs", [])
         if constrs:
             parts.append("Constructors:")
-            parts.append("\n".join(render_constructor(constructor) for constructor in constrs))
+            parts.append("\n\n".join(render_constructor(constructor) for constructor in constrs))
     elif tag == "Synonym":
         rhs = render_type(adt["ad_rhs"])
         parts.append(f"### `type {name} = {rhs}`")
@@ -761,7 +766,7 @@ def build_pages(
                     title=overview_title,
                     description=f"Reference documentation for {overview_title} modules.",
                     eyebrow="Daml Reference",
-                    summary="Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.",
+                    summary=f"Generated module overview for {overview_title}, built from versioned docs JSON snapshots.",
                     badges=[ReferenceBadge("Daml", tone="protocol"), ReferenceBadge(report.publish_version, tone="neutral")],
                     meta_items=[
                         ReferenceMetaItem("Publish version", report.publish_version),

--- a/tests/test_daml_json.py
+++ b/tests/test_daml_json.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from x2mdx.cli import main as cli_main
 from x2mdx.daml_json.lifecycle import build_daml_doc_report_from_sources
+from x2mdx.daml_json.render import render_doc_blocks
 from x2mdx.daml_json.snapshots import load_daml_doc_sources
 
 
@@ -237,6 +238,7 @@ class DamlJsonTests(unittest.TestCase):
         self.assertEqual(result, 0)
         module_text = (output_dir / "utility-credential-v0-credential.mdx").read_text(encoding="utf-8")
         self.assertIn("### `data Claim`", module_text)
+        self.assertIn("- `Claim`\n\n| Field | Type | Description |", module_text)
         self.assertIn("### Template `Credential`", module_text)
         self.assertIn("#### Choice `Get`", module_text)
         self.assertNotIn('"ADTDoc"', module_text)
@@ -267,3 +269,9 @@ class DamlJsonTests(unittest.TestCase):
         self.assertEqual(result, 0)
         index_text = (output_dir / "index.mdx").read_text(encoding="utf-8")
         self.assertIn('<a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list">', index_text)
+
+    def test_doc_blocks_normalize_markdown_autolinks_for_mdx(self) -> None:
+        self.assertEqual(
+            render_doc_blocks("See <https://example.com/docs/path/> for details."),
+            "See [https://example.com/docs/path/](https://example.com/docs/path/) for details.",
+        )

--- a/tests/test_splice_daml_reference.py
+++ b/tests/test_splice_daml_reference.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import scripts.generate_splice_daml_reference as splice_daml_reference
+
+
+def write_mdx(path: Path, title: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntitle: \"{title}\"\n---\n", encoding="utf-8")
+
+
+def add_tar_file(handle: tarfile.TarFile, name: str, data: bytes = b"content") -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    handle.addfile(info, io.BytesIO(data))
+
+
+def test_dar_members_from_archive_prefers_current_dar(tmp_path: Path) -> None:
+    archive = tmp_path / "splice-node.tar.gz"
+    with tarfile.open(archive, "w:gz") as handle:
+        add_tar_file(handle, "bundle/dars/splice-util-0.6.4.dar")
+        add_tar_file(handle, "bundle/dars/splice-util-current.dar")
+        add_tar_file(handle, "bundle/dars/splice-wallet-0.6.4.dar")
+
+    assert splice_daml_reference.dar_members_from_archive(archive) == {
+        "splice-util": "bundle/dars/splice-util-current.dar",
+        "splice-wallet": "bundle/dars/splice-wallet-0.6.4.dar",
+    }
+
+
+def test_dependency_include_dirs_resolves_nested_package_ids(tmp_path: Path) -> None:
+    base = tmp_path / "packages"
+    dependency = splice_daml_reference.PackageInfo(
+        family="dependency",
+        package_name="dependency",
+        package_id="dependency-1.0.0",
+        package_root=base / "dependency",
+        exposed_modules=["Dependency"],
+        depends=[],
+    )
+    parent = splice_daml_reference.PackageInfo(
+        family="parent",
+        package_name="parent",
+        package_id="parent-1.0.0",
+        package_root=base / "parent",
+        exposed_modules=["Parent"],
+        depends=["dependency-1.0.0"],
+    )
+
+    assert splice_daml_reference.dependency_include_dirs(
+        info=parent,
+        package_index={dependency.package_id: dependency, parent.package_id: parent},
+    ) == [dependency.package_root]
+
+
+def test_update_docs_navigation_replaces_product_nested_splice_group(tmp_path: Path) -> None:
+    docs_json = tmp_path / "docs-main" / "docs.json"
+    output_root = tmp_path / "docs-main" / "sdks-tools" / "api-reference" / "splice-daml"
+    write_mdx(output_root / "splice-util" / "index.mdx", "splice-util")
+    write_mdx(output_root / "splice-util" / "splice-util.mdx", "Splice.Util")
+    write_mdx(output_root / "splice-token-standard-test" / "index.mdx", "splice-token-standard-test")
+    docs_json.parent.mkdir(parents=True, exist_ok=True)
+    docs_json.write_text(
+        """
+{
+  "navigation": {
+    "products": [
+      {
+        "product": "SDKs and Tools",
+        "pages": [
+          {
+            "group": "API Overview",
+            "pages": [
+              {
+                "group": "Splice APIs",
+                "pages": [
+                  "sdks-tools/api-reference/splice-daml-apis",
+                  {
+                    "group": "Splice Daml Packages",
+                    "pages": ["old/ref"]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "product": "API Reference",
+        "pages": [
+          {
+            "group": "Splice APIs",
+            "pages": [
+              "sdks-tools/api-reference/splice-daml-apis"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    splice_daml_reference.update_docs_navigation(
+        docs_json_path=docs_json,
+        product_label="API Reference",
+        parent_groups=["Splice APIs"],
+        nav_group_label="Splice Daml Packages",
+        output_root=output_root,
+        family_order=["splice-util", "splice-token-standard-test"],
+    )
+
+    payload = splice_daml_reference.load_json(docs_json)
+    sdk_pages = payload["navigation"]["products"][0]["pages"][0]["pages"][0]["pages"]
+    assert all(not isinstance(item, dict) or item.get("group") != "Splice Daml Packages" for item in sdk_pages)
+    splice_pages = payload["navigation"]["products"][1]["pages"][0]["pages"]
+    package_group = next(item for item in splice_pages if isinstance(item, dict) and item["group"] == "Splice Daml Packages")
+    assert package_group == {
+        "group": "Splice Daml Packages",
+        "pages": [
+            {
+                "group": "splice-util",
+                "pages": [
+                    "sdks-tools/api-reference/splice-daml/splice-util/index",
+                    "sdks-tools/api-reference/splice-daml/splice-util/splice-util",
+                ],
+            },
+            {
+                "group": "splice-token-standard-test",
+                "pages": [
+                    "sdks-tools/api-reference/splice-daml/splice-token-standard-test/index",
+                ],
+            },
+        ],
+    }

--- a/tests/test_wallet_kernel_nav.py
+++ b/tests/test_wallet_kernel_nav.py
@@ -208,3 +208,64 @@ def test_aggregate_generation_replaces_legacy_wallet_kernel_group() -> None:
         {"group": "Wallet Gateway", "pages": ["new"]},
         {"group": "Splice APIs", "pages": []},
     ]
+
+
+def test_aggregate_generation_merges_product_nested_group(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    generate_all_reference_docs = load_script("generate_all_reference_docs")
+    docs_json = tmp_path / "docs-main" / "docs.json"
+    scratch_json = tmp_path / "docs-main" / ".generate_splice_daml_reference.docs.json"
+    monkeypatch.setattr(generate_all_reference_docs, "DOCS_JSON_PATH", docs_json)
+
+    final_docs = {
+        "navigation": {
+            "products": [
+                {
+                    "product": "API Reference",
+                    "pages": [
+                        {
+                            "group": "Splice APIs",
+                            "pages": [
+                                {
+                                    "group": "Splice Daml Packages",
+                                    "pages": ["old"],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    scratch_docs = {
+        "navigation": {
+            "products": [
+                {
+                    "product": "API Reference",
+                    "pages": [
+                        {
+                            "group": "Splice APIs",
+                            "pages": [
+                                {
+                                    "group": "Splice Daml Packages",
+                                    "pages": ["new"],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+    generate_all_reference_docs.merge_nav_slice(
+        final_docs=final_docs,
+        scratch_docs=scratch_docs,
+        nav_slice=generate_all_reference_docs.NavSlice(
+            "product_nested_group",
+            ("API Reference", "Splice APIs", "Splice Daml Packages"),
+        ),
+        scratch_path=scratch_json,
+    )
+
+    pages = final_docs["navigation"]["products"][0]["pages"][0]["pages"][0]["pages"]
+    assert pages == ["new"]


### PR DESCRIPTION
## Summary

- add `npm run generate:splice-daml-reference` for Splice Daml packages using release-bundle DARs, `daml damlc docs --format json`, and the existing `x2mdx daml-json` renderer
- wire the Splice Daml generator into aggregate reference generation and API Reference navigation consolidation
- regenerate the checked-in Splice Daml package pages
- preserve static pages for `splice-token-standard-test` and `splice-wallet` until their release artifacts can be generated through the DAML JSON path
- fix Daml record-constructor table block spacing so generated constructor field tables render as tables in Mintlify

Addresses #539. Preserves the #600 navigation move: `Splice Daml Packages` remains under `API Reference > Splice APIs`, not `SDKs and Tools`.

## Validation

- `npm run generate:splice-daml-reference`
- `python3 -m py_compile scripts/generate_splice_daml_reference.py src/x2mdx/daml_json/render.py tests/test_splice_daml_reference.py scripts/generate_all_reference_docs.py tests/test_wallet_kernel_nav.py`
- `jq empty config/x2mdx/splice-daml-reference/source-artifacts.json package.json docs-main/docs.json`
- `git diff --check`
- `direnv exec . python3 -m pytest tests/test_splice_daml_reference.py tests/test_daml_json.py tests/test_wallet_kernel_nav.py`
- local Mintlify preview on `http://localhost:3019` returned `200` for representative Splice Daml routes; Chromium DOM check confirmed `RewardBatch` fields render as an HTML `<table>` under the active `API Reference` product

`npx mintlify validate` still fails on current-main issues outside this branch: `integrations/wallet/proof-of-transfer` parse/navigation and a missing external snippet import from `global-synchronizer/release-notes/splice.mdx`. It no longer reports generated Splice Daml page parse errors.

## Preview routes

Expected Mintlify preview root once deployment is available:

- https://cantonfoundation-issue-539-splice-daml-reference-automation.mintlify.app

Useful routes to inspect:

- https://cantonfoundation-issue-539-splice-daml-reference-automation.mintlify.app/sdks-tools/api-reference/splice-daml/splice-amulet
- https://cantonfoundation-issue-539-splice-daml-reference-automation.mintlify.app/sdks-tools/api-reference/splice-daml/splice-util
- https://cantonfoundation-issue-539-splice-daml-reference-automation.mintlify.app/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1
- https://cantonfoundation-issue-539-splice-daml-reference-automation.mintlify.app/sdks-tools/api-reference/splice-daml/splice-wallet-payments
- https://cantonfoundation-issue-539-splice-daml-reference-automation.mintlify.app/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy
