### PR TITLE
Use tag-based Splice snippet extraction

### DIFF
--- a/config/snippet-config/splice-snippet-list-remote.json
+++ b/config/snippet-config/splice-snippet-list-remote.json
@@ -180,14 +180,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/overview/version_information.rst",
       "location": {
-        "type": "lines",
-        "start": 42,
-        "end": 42
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_001_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_001_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "transform": "rstjson",
+        "normalizeIndent": false,
+        "preserveIndent": true
       }
     },
     {
@@ -195,14 +197,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 162,
-        "end": 168
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_002_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_002_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -210,14 +214,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 175,
-        "end": 181
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_003_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_003_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -225,14 +231,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 190,
-        "end": 197
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_004_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_004_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -240,14 +248,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 206,
-        "end": 213
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_005_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_005_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -255,14 +265,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 228,
-        "end": 232
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_006_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_006_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -270,14 +282,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 126,
-        "end": 127
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_007_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_007_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -285,14 +299,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/app_dev/testing/localnet.rst",
       "location": {
-        "type": "lines",
-        "start": 147,
-        "end": 147
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_008_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_008_END"
       },
       "description": "",
       "options": {
         "language": "none",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -300,14 +316,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/configuration.rst",
       "location": {
-        "type": "lines",
-        "start": 51,
-        "end": 53
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_009_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_009_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -315,14 +333,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/configuration.rst",
       "location": {
-        "type": "lines",
-        "start": 70,
-        "end": 72
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_010_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_010_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -330,14 +350,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 166,
-        "end": 166
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_011_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_011_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -345,14 +367,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 174,
-        "end": 177
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_012_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_012_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -360,14 +384,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 104,
-        "end": 120
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_013_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_013_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -375,14 +401,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 136,
-        "end": 148
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_014_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_014_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -390,14 +418,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 40,
-        "end": 57
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_015_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_015_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -405,14 +435,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 71,
-        "end": 88
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_016_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_016_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -420,14 +452,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 126,
-        "end": 126
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_017_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_017_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -435,14 +469,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 154,
-        "end": 154
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_018_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_018_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -450,14 +486,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 63,
-        "end": 63
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_019_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_019_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -465,14 +503,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/console_access.rst",
       "location": {
-        "type": "lines",
-        "start": 94,
-        "end": 94
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_020_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_020_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -480,14 +520,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/traffic.rst",
       "location": {
-        "type": "lines",
-        "start": 94,
-        "end": 104
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_021_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_021_END"
       },
       "description": "",
       "options": {
         "language": "json",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -495,14 +537,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/traffic.rst",
       "location": {
-        "type": "lines",
-        "start": 129,
-        "end": 129
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_022_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_022_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -510,14 +554,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/traffic.rst",
       "location": {
-        "type": "lines",
-        "start": 88,
-        "end": 88
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_023_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_023_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -525,14 +571,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/troubleshooting.rst",
       "location": {
-        "type": "lines",
-        "start": 109,
-        "end": 110
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_024_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_024_END"
       },
       "description": "",
       "options": {
         "language": "text",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -540,14 +588,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/troubleshooting.rst",
       "location": {
-        "type": "lines",
-        "start": 123,
-        "end": 124
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_025_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_025_END"
       },
       "description": "",
       "options": {
         "language": "text",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -555,14 +605,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/troubleshooting.rst",
       "location": {
-        "type": "lines",
-        "start": 135,
-        "end": 136
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_026_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_026_END"
       },
       "description": "",
       "options": {
         "language": "text",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -570,14 +622,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/troubleshooting.rst",
       "location": {
-        "type": "lines",
-        "start": 161,
-        "end": 162
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_027_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_027_END"
       },
       "description": "",
       "options": {
         "language": "text",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -585,14 +639,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/troubleshooting.rst",
       "location": {
-        "type": "lines",
-        "start": 174,
-        "end": 177
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_028_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_028_END"
       },
       "description": "",
       "options": {
         "language": "text",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -600,14 +656,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/deployment/troubleshooting.rst",
       "location": {
-        "type": "lines",
-        "start": 89,
-        "end": 90
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_029_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_029_END"
       },
       "description": "",
       "options": {
         "language": "text",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -615,14 +673,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/scalability/scalability.rst",
       "location": {
-        "type": "lines",
-        "start": 117,
-        "end": 119
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_030_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_030_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -630,14 +690,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_backup.rst",
       "location": {
-        "type": "lines",
-        "start": 23,
-        "end": 23
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_031_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_031_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -645,14 +707,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 1033,
-        "end": 1033
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_032_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_032_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -660,14 +724,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 302,
-        "end": 308
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_033_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_033_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -675,14 +741,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 314,
-        "end": 320
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_034_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_034_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -690,14 +758,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 326,
-        "end": 336
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_035_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_035_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -705,14 +775,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 381,
-        "end": 383
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_036_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_036_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -720,14 +792,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 39,
-        "end": 40
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_037_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_037_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -735,14 +809,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 507,
-        "end": 518
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_038_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_038_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -750,14 +826,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 55,
-        "end": 67
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_039_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_039_END"
       },
       "description": "SV keygen shell commands (RST verbatim block)",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -765,14 +843,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 627,
-        "end": 629
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_040_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_040_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -780,14 +860,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 725,
-        "end": 742
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_041_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_041_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -795,14 +877,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 835,
-        "end": 835
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_042_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_042_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -810,14 +894,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 844,
-        "end": 846
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_043_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_043_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -825,14 +911,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 861,
-        "end": 864
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_044_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_044_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -840,14 +928,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 873,
-        "end": 873
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_045_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_045_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -855,14 +945,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 914,
-        "end": 914
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_046_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_046_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -870,14 +962,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 93,
-        "end": 93
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_047_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_047_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -885,14 +979,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 990,
-        "end": 990
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_048_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_048_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -900,14 +996,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 1135,
-        "end": 1143
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_049_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_049_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -915,14 +1013,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 1005,
-        "end": 1005
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_050_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_050_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -930,14 +1030,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 354,
-        "end": 360
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_051_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_051_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -945,15 +1047,17 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 468,
-        "end": 480
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_052_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_052_END"
       },
       "description": "Canton console sample; unescape RST quotes, haskell fence",
       "options": {
         "language": "haskell",
         "normalizeIndent": "baseline",
-        "unescapeRstQuotes": true
+        "unescapeRstQuotes": true,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -961,14 +1065,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 528,
-        "end": 531
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_053_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_053_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -976,14 +1082,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 691,
-        "end": 692
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_054_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_054_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -991,14 +1099,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 701,
-        "end": 701
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_055_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_055_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1006,14 +1116,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 707,
-        "end": 709
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_056_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_056_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1021,14 +1133,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 715,
-        "end": 715
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_057_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_057_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1036,14 +1150,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 366,
-        "end": 367
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_058_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_058_END"
       },
       "description": "CometBFT config files to retain (RST verbatim block)",
       "options": {
         "language": "text",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1051,14 +1167,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 74,
-        "end": 75
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_059_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_059_END"
       },
       "description": "Sample SV keygen output (RST verbatim block)",
       "options": {
         "language": "text",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1066,14 +1184,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 440,
-        "end": 442
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_060_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_060_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1081,14 +1201,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 448,
-        "end": 450
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_061_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_061_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1096,14 +1218,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 456,
-        "end": 458
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_062_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_062_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1111,14 +1235,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 882,
-        "end": 892
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_063_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_063_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1126,14 +1252,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 900,
-        "end": 906
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_064_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_064_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1141,14 +1269,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 926,
-        "end": 984
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_065_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_065_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1156,14 +1286,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst",
       "location": {
-        "type": "lines",
-        "start": 118,
-        "end": 124
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_066_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_066_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1171,14 +1303,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst",
       "location": {
-        "type": "lines",
-        "start": 142,
-        "end": 144
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_067_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_067_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1186,14 +1320,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst",
       "location": {
-        "type": "lines",
-        "start": 87,
-        "end": 89
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_068_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_068_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1201,14 +1337,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_network_resets.rst",
       "location": {
-        "type": "lines",
-        "start": 75,
-        "end": 75
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_069_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_069_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1216,14 +1354,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_network_resets.rst",
       "location": {
-        "type": "lines",
-        "start": 81,
-        "end": 83
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_070_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_070_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1231,14 +1371,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_network_resets.rst",
       "location": {
-        "type": "lines",
-        "start": 90,
-        "end": 92
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_071_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_071_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1246,14 +1388,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 482,
-        "end": 501
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_072_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_072_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1261,14 +1405,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 507,
-        "end": 532
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_073_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_073_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1276,14 +1422,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 538,
-        "end": 558
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_074_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_074_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1291,14 +1439,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 564,
-        "end": 585
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_075_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_075_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1306,14 +1456,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 683,
-        "end": 684
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_076_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_076_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1321,14 +1473,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 171,
-        "end": 178
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_077_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_077_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1336,14 +1490,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 193,
-        "end": 193
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_078_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_078_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1351,14 +1507,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 204,
-        "end": 206
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_079_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_079_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1366,14 +1524,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 222,
-        "end": 224
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_080_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_080_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1381,14 +1541,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 344,
-        "end": 344
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_081_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_081_END"
       },
       "description": "",
       "options": {
         "language": "sql",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1396,14 +1558,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 359,
-        "end": 365
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_082_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_082_END"
       },
       "description": "",
       "options": {
         "language": "sql",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1411,14 +1575,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 296,
-        "end": 299
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_083_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_083_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1426,14 +1592,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 309,
-        "end": 314
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_084_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_084_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1441,14 +1609,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 821,
-        "end": 823
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_085_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_085_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1456,14 +1626,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 829,
-        "end": 831
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_086_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_086_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1471,14 +1643,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 838,
-        "end": 840
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_087_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_087_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1486,14 +1660,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 846,
-        "end": 848
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_088_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_088_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1501,14 +1677,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 865,
-        "end": 868
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_089_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_089_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1516,14 +1694,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_operations.rst",
       "location": {
-        "type": "lines",
-        "start": 889,
-        "end": 893
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_090_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_090_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1531,14 +1711,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_pruning.rst",
       "location": {
-        "type": "lines",
-        "start": 62,
-        "end": 65
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_091_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_091_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1546,14 +1728,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_restore.rst",
       "location": {
-        "type": "lines",
-        "start": 102,
-        "end": 102
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_092_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_092_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1561,14 +1745,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_restore.rst",
       "location": {
-        "type": "lines",
-        "start": 57,
-        "end": 64
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_093_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_093_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1576,14 +1762,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_restore.rst",
       "location": {
-        "type": "lines",
-        "start": 74,
-        "end": 81
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_094_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_094_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1591,14 +1779,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_security.rst",
       "location": {
-        "type": "lines",
-        "start": 110,
-        "end": 112
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_095_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_095_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1606,14 +1796,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_security.rst",
       "location": {
-        "type": "lines",
-        "start": 73,
-        "end": 87
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_096_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_096_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1621,14 +1813,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/sv_operator/sv_security.rst",
       "location": {
-        "type": "lines",
-        "start": 94,
-        "end": 97
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_097_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_097_END"
       },
       "description": "",
       "options": {
         "language": "json",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1636,14 +1830,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_backups.rst",
       "location": {
-        "type": "lines",
-        "start": 36,
-        "end": 36
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_098_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_098_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1651,14 +1847,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_backups.rst",
       "location": {
-        "type": "lines",
-        "start": 67,
-        "end": 69
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_099_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_099_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1666,14 +1864,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 167,
-        "end": 168
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_100_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_100_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1681,14 +1881,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 175,
-        "end": 176
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_101_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_101_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1696,14 +1898,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 281,
-        "end": 282
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_102_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_102_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1711,14 +1915,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 306,
-        "end": 308
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_103_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_103_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1726,14 +1932,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 58,
-        "end": 67
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_104_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_104_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1741,14 +1949,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 105,
-        "end": 111
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_105_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_105_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1756,14 +1966,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 152,
-        "end": 159
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_106_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_106_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1771,14 +1983,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 347,
-        "end": 357
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_107_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_107_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1786,14 +2000,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_compose.rst",
       "location": {
-        "type": "lines",
-        "start": 96,
-        "end": 102
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_108_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_108_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1801,14 +2017,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_delegations.rst",
       "location": {
-        "type": "lines",
-        "start": 201,
-        "end": 209
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_109_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_109_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1816,14 +2034,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_delegations.rst",
       "location": {
-        "type": "lines",
-        "start": 215,
-        "end": 234
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_110_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_110_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1831,14 +2051,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_delegations.rst",
       "location": {
-        "type": "lines",
-        "start": 251,
-        "end": 269
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_111_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_111_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1846,14 +2068,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_delegations.rst",
       "location": {
-        "type": "lines",
-        "start": 276,
-        "end": 294
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_112_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_112_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1861,14 +2085,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_delegations.rst",
       "location": {
-        "type": "lines",
-        "start": 309,
-        "end": 324
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_113_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_113_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1876,14 +2102,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 240,
-        "end": 241
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_114_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_114_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1891,14 +2119,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 248,
-        "end": 249
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_115_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_115_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1906,14 +2136,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 260,
-        "end": 260
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_116_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_116_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1921,14 +2153,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 299,
-        "end": 300
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_117_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_117_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1936,14 +2170,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 314,
-        "end": 319
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_118_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_118_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1951,14 +2187,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 485,
-        "end": 491
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_119_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_119_END"
       },
       "description": "",
       "options": {
         "language": "",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1966,14 +2204,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 268,
-        "end": 268
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_120_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_120_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1981,14 +2221,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 443,
-        "end": 444
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_121_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_121_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -1996,14 +2238,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_disaster_recovery.rst",
       "location": {
-        "type": "lines",
-        "start": 185,
-        "end": 187
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_122_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_122_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2011,14 +2255,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 65,
-        "end": 65
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_123_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_123_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2026,14 +2272,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 472,
-        "end": 474
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_124_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_124_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2041,14 +2289,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 657,
-        "end": 657
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_125_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_125_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2056,14 +2306,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 127,
-        "end": 130
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_126_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_126_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2071,14 +2323,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_helm.rst",
       "location": {
-        "type": "lines",
-        "start": 82,
-        "end": 84
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_127_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_127_END"
       },
       "description": "",
       "options": {
         "language": "yaml",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2086,14 +2340,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_onboarding.rst",
       "location": {
-        "type": "lines",
-        "start": 107,
-        "end": 116
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_128_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_128_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2101,14 +2357,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_onboarding.rst",
       "location": {
-        "type": "lines",
-        "start": 136,
-        "end": 165
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_129_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_129_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2116,14 +2374,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_onboarding.rst",
       "location": {
-        "type": "lines",
-        "start": 126,
-        "end": 130
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_130_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_130_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2131,14 +2391,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_onboarding.rst",
       "location": {
-        "type": "lines",
-        "start": 86,
-        "end": 86
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_131_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_131_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2146,14 +2408,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_onboarding.rst",
       "location": {
-        "type": "lines",
-        "start": 95,
-        "end": 100
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_132_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_132_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": "baseline"
+        "normalizeIndent": "baseline",
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2161,14 +2425,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_users.rst",
       "location": {
-        "type": "lines",
-        "start": 48,
-        "end": 51
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_133_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_133_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2176,14 +2442,16 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/validator_users.rst",
       "location": {
-        "type": "lines",
-        "start": 66,
-        "end": 69
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_134_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_134_END"
       },
       "description": "",
       "options": {
         "language": "bash",
-        "normalizeIndent": false
+        "normalizeIndent": false,
+        "transform": "rstjson",
+        "preserveIndent": true
       }
     },
     {
@@ -2256,9 +2524,9 @@
       "sourceRepo": "splice",
       "sourceFilepath": "docs/src/validator_operator/required_network_parameters.rst",
       "location": {
-        "type": "lines",
-        "start": 9,
-        "end": 35
+        "type": "stringMarker",
+        "start": "CF_DOCS_SPLICE_SNIPPET_135_START",
+        "end": "CF_DOCS_SPLICE_SNIPPET_135_END"
       },
       "description": "",
       "options": {

--- a/scripts/generateOutputDocs.js
+++ b/scripts/generateOutputDocs.js
@@ -52,13 +52,34 @@ function extractByStringMarker(fileContent, startMarker, endMarker) {
         throw new Error(`Start marker not found: "${startMarker}"`)
     }
 
-    const contentStart = startIndex + startMarker.length
+    let contentStart = startIndex + startMarker.length
+    const startLineEnd = fileContent.indexOf('\n', startIndex)
+    if (startLineEnd !== -1) {
+        const startLine = fileContent.substring(
+            fileContent.lastIndexOf('\n', startIndex) + 1,
+            startLineEnd
+        )
+        if (startLine.includes(startMarker)) {
+            contentStart = startLineEnd + 1
+        }
+    }
     const endIndex = fileContent.indexOf(endMarker, contentStart)
     if (endIndex === -1) {
         throw new Error(`End marker not found: "${endMarker}"`)
     }
 
-    return fileContent.substring(contentStart, endIndex).trim()
+    let contentEnd = endIndex
+    const endLineStart = fileContent.lastIndexOf('\n', endIndex) + 1
+    const endLineEnd = fileContent.indexOf('\n', endIndex)
+    const endLine = fileContent.substring(
+        endLineStart,
+        endLineEnd === -1 ? fileContent.length : endLineEnd
+    )
+    if (endLine.includes(endMarker)) {
+        contentEnd = endLineStart
+    }
+
+    return fileContent.substring(contentStart, contentEnd).trim()
 }
 
 function extractByRegexWrap(fileContent, startRegex, endRegex) {
@@ -179,20 +200,21 @@ function trimBlankEdges(content) {
     return content.replace(/^\s*\n+/, '').replace(/\n+\s*$/, '')
 }
 
-function convertRstBlocksToMarkdown(content, fallbackLanguage = '') {
+function convertRstBlocksToMarkdown(content, fallbackLanguage = '', preserveIndent = false) {
     const input = trimBlankEdges(content)
     const lines = input.split('\n')
     const out = []
     let i = 0
 
     while (i < lines.length) {
-        const m = lines[i].match(/^\s*\.\.\s+code-block::\s*(\S*)\s*$/)
+        const m = lines[i].match(/^(\s*)\.\.\s+(code-block|code|parsed-literal)::\s*(\S*)\s*$/)
         if (!m) {
             i++
             continue
         }
 
-        let language = (m[1] || '').trim()
+        const directiveIndent = m[1].length
+        let language = (m[3] || '').trim()
         if (!language || language.toLowerCase() === 'none') {
             language = fallbackLanguage || ''
         }
@@ -209,8 +231,9 @@ function convertRstBlocksToMarkdown(content, fallbackLanguage = '') {
                 continue
             }
 
-            if (/^( {4}|\t)/.test(line)) {
-                block.push(line.replace(/^( {4}|\t)/, ''))
+            const indent = line.match(/^\s*/)[0].length
+            if (indent > directiveIndent) {
+                block.push(preserveIndent ? line : line.replace(/^( {4}|\t)/, ''))
                 i++
                 continue
             }
@@ -252,7 +275,7 @@ function convertRstBlocksToMarkdown(content, fallbackLanguage = '') {
 function formatSnippetContent(content, options) {
     if (options && options.transform === 'rstjson') {
         const language = options && options.language ? options.language : ''
-        return convertRstBlocksToMarkdown(content, language)
+        return convertRstBlocksToMarkdown(content, language, options.preserveIndent === true)
     }
     const displayStyle = (options && options.displayStyle) || 'wrapCode'
     const rawLanguage = options && options.language ? options.language : ''


### PR DESCRIPTION
## Summary

Switches the Splice external snippet config from line-number ranges to stable string-marker tags. This removes the brittle dependency on exact source line numbers in `config/snippet-config/splice-snippet-list-remote.json`.

The helper now strips marker lines cleanly when markers appear on source-comment lines, and the RST snippet transform handles `code`, `code-block`, and `parsed-literal` directives while preserving legacy snippet indentation.

## Dependency

Depends on the upstream source tags from canton-network/splice#5732. Keep this PR draft until that PR lands or the source ref used for generation includes those tags.

## Validation

- First converted and tested one snippet.
- Bulk converted the remaining Splice line-number snippets.
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-splice-snippet-tags npm run generate:external-snippets -- splice --source-dir /Users/danielporter/control/.worktrees/splice-snippet-tags-source --skip-prepare --copy-output --version main --replace-output --min-free-gb 1`
  - `152 succeeded, 0 failed`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-splice-snippet-tags bash -lc 'jq empty config/snippet-config/splice-snippet-list-remote.json && node --check scripts/generateOutputDocs.js'`\n- `git diff --check`\n\nNo checked-in generated snippet files changed.