### PR TITLE
remove two hidden toctrees and fix three broken toctrees

### DIFF
--- a/docs-main/integrations/exchanges/guidance.mdx
+++ b/docs-main/integrations/exchanges/guidance.mdx
@@ -15,11 +15,15 @@ The pages below guide you how to integrate an exchange with Canton for the purpo
 
 The core of such an integration is automating the deposits and withdrawals of tokens to and from the exchange. The guide can thus also be used for services other than exchanges that want to support deposits and withdrawals of Canton Network tokens.
 
-<div className="toctree" maxdepth="3">
-
-overview architecture workflows txingestion non-functionals node-operations disaster-recovery testing extensions
-
-</div>
+- [Overview](#overview)
+- [Integration Architecture](#integration-architecture)
+- [Integration Workflows](#integration-workflows)
+- [Transaction History Ingestion Details](#transaction-history-ingestion-details)
+- [Fault Tolerance](#fault-tolerance)
+- [Validator Node Operations](#validator-node-operations)
+- [Backup and Restore](#backup-and-restore)
+- [Integration Testing](#integration-testing)
+- [Integration Extensions](#integration-extensions)
 
 
 {/* COPIED_END */}

--- a/docs-main/integrations/wallet/exchange-integration.mdx
+++ b/docs-main/integrations/wallet/exchange-integration.mdx
@@ -11,11 +11,15 @@ The pages below guide you how to integrate an exchange with Canton for the purpo
 
 The core of such an integration is automating the deposits and withdrawals of tokens to and from the exchange. The guide can thus also be used for services other than exchanges that want to support deposits and withdrawals of Canton Network tokens.
 
-<div className="toctree" maxdepth="3">
-
-overview architecture workflows txingestion non-functionals node-operations disaster-recovery testing extensions
-
-</div>
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Workflows](#workflows)
+- [Transaction Ingestion](#transaction-ingestion)
+- [Non-Functional Requirements](#non-functional-requirements)
+- [Node Operations](#node-operations)
+- [Disaster Recovery](#disaster-recovery)
+- [Testing](#testing)
+- [Extensions](#extensions)
 
 {/* COPIED_END */}
 

--- a/docs-main/integrations/wallet/wallet-sdk-v1-migration.mdx
+++ b/docs-main/integrations/wallet/wallet-sdk-v1-migration.mdx
@@ -117,11 +117,12 @@ const sdk = await SDK.create(config, provider)
 
 We have removed the controllers and replaced them with namespaces to appropriately segregate the service layer in terms of business context. When the sdk is initialized, it has access to the users, keys, ledger, and party namespaces. The amulet, token, asset, and events namespace can initialized with a separate config via `.extend()` method.
 
-<div className="toctree" maxdepth="2" caption="Detailed namespace guides:">
-
-party token user amulet ledger asset
-
-</div>
+- [Party Namespace](#party-namespace)
+- [Token Namespace](#token-namespace)
+- [User Namespace](#user-namespace)
+- [Amulet Namespace](#amulet-namespace)
+- [Ledger Namespace](#ledger-namespace)
+- [Asset Namespace](#asset-namespace)
 
 ## Removed functionality
 

--- a/docs-main/sdks-tools/api-reference/splice-http-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-http-apis.mdx
@@ -23,12 +23,6 @@ The Ledger API is not part of Splice, and thus not documented here. See `app_dev
 
 Some of the Splice apps also define additional HTTP APIs that are considered internal and are subject to change without notice. If you do need some of them for your app, please create an issue on [https://github.com/canton-network/splice](https://github.com/canton-network/splice), so that you can align with the Splice team on the API, your needs, and the required stability guarantees.
 
-<div className="toctree" hidden="">
-
-../scan_api/index ../validator_api/index
-
-</div>
-
 ## OpenAPI Conventions
 
 <NetworkVariables networkData={networkData}>

--- a/docs-main/sdks-tools/api-reference/splice-scan-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-api.mdx
@@ -18,7 +18,7 @@ Please see the `scan_openapi` for the full API reference; and see `app_dev_opena
 
 **Scan App Overview**
 
-The Scan App serving the Scan APIs is part of a `CN Supervalidator` (SV) node. The Scan App is shown in the context of an SV node in the following diagram:
+The Scan App serving the Scan APIs is part of a `CN SuperValidator` (SV) node. The Scan App is shown in the context of an SV node in the following diagram:
 
 ![image](/images/splice/sv_scan_app_topology.png)
 
@@ -33,12 +33,5 @@ The Scan App subscribes to the SV participant as the DSO (Decentralized Synchron
 You can directly connect to a Scan API hosted by a single SV, or you can read from multiple Scan APIs and compare the results.
 
 The validator node contains a `validator-api-scan-proxy` that provides `BFT` reads to Scan APIs hosted by Super Validators.
-
-<div className="toctree" hidden="">
-
-scan_bulk_data_api scan_global_synchronizer_connectivity_api scan_global_synchronizer_operations_api scan_cc_reference_data_api scan_current_state_api scan_aggregates_api scan_openapi
-
-</div>
-
 
 {/* COPIED_END */}


### PR DESCRIPTION
tested with `mintlify dev`
Removes two toctrees that were set to hidden and fixes three broken toctrees in large reference files. screenshots below.

<img width="765" height="596" alt="Screenshot 2026-05-29 at 12 41 08 AM" src="https://github.com/user-attachments/assets/ce6a1801-10d0-4c77-9536-4f2db771b5e3" />
<img width="769" height="433" alt="Screenshot 2026-05-29 at 12 41 38 AM" src="https://github.com/user-attachments/assets/4e6ca647-68fa-48e7-a18e-538517146a56" />
<img width="751" height="587" alt="Screenshot 2026-05-29 at 12 42 03 AM" src="https://github.com/user-attachments/assets/9f3f3699-3474-4943-960a-9e9c1f451147" />
