### PR TITLE
update contract key docs

### DIFF
--- a/docs-main/appdev/modules/m3-contract-keys.mdx
+++ b/docs-main/appdev/modules/m3-contract-keys.mdx
@@ -1,26 +1,20 @@
 ---
 title: "Contract Keys"
-description: "Use contract keys for stable references to contracts, lookups, and uniqueness constraints"
+description: "Use contract keys for stable references to contracts and key-based lookups"
 ---
 
-import DamlAppdevModulesM3ContractKeysL107 from "/snippets/daml-docs/appdev_modules_m3-contract-keys_L107.mdx";
-import DamlAppdevModulesM3ContractKeysL132 from "/snippets/daml-docs/appdev_modules_m3-contract-keys_L132.mdx";
 import DamlAppdevModulesM3ContractKeysL24 from "/snippets/daml-docs/appdev_modules_m3-contract-keys_L24.mdx";
-
-
-{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/contract-keys.rst" hash="85971992" */}
+import DamlAppdevModulesM3ContractKeysL132 from "/snippets/daml-docs/appdev_modules_m3-contract-keys_L132.mdx";
 
 # Reference: Contract Keys
 
-<Warning>
-Contract keys coming in the Canton 3.5 release. This documentation will be updated at that time.
-</Warning>
+Contract keys are an optional addition to templates. They let you specify a way of identifying contracts using the parameters to the template — similar to a key in a database.
 
-## Unsupported feature
+Contract keys do not change and can be used to refer to a contract even when the contract ID changes. As a contract is updated via archive and create operations, the currently active contract(s) can easily be referenced via the contract key.
 
-Contract keys are an optional addition to templates. They let you specify a way of uniquely identifying contracts, using the parameters to the template - similar to a primary key for a database.
-
-Contract keys do not change and can be used to refer to a contract even when the contract id changes.
+<Note>
+Unlike in Daml 2.x, contract keys are **not** guaranteed to be unique in Canton 3.x. Multiple active contracts of the same template can share the same key. However, most applications are expected to enforce key uniqueness externally — for example, in the Daml business logic or at the application level. The primary key-based API (`lookupByKey`, `fetchByKey`, `exerciseByKey`) is optimized for the common case where at most one contract exists per key.
+</Note>
 
 Here's an example of setting up a contract key for a bank account, to act as a bank account ID:
 
@@ -34,81 +28,81 @@ It's best to use simple types for your keys like `Text` or `Int`, rather than a 
 
 ## Specify Maintainers
 
-If you specify a contract key for a template, you must also specify a `maintainer` or maintainers, in a similar way to specifying signatories or observers. The maintainers "own" the key in the same way the signatories "own" a contract. Just like signatories of contracts prevent double spends or use of false contract data, maintainers of keys prevent double allocation or incorrect lookups. Since the key is part of the contract, the maintainers **must** be signatories of the contract. However, maintainers are computed from the `key` instead of the template arguments. In the example above, the `bank` is ultimately the maintainer of the key.
+If you specify a contract key for a template, you must also specify a `maintainer` or maintainers, in a similar way to specifying signatories or observers. The maintainers "own" the key in the same way the signatories "own" a contract. Just like signatories of contracts prevent double spends or use of false contract data, maintainers of keys ensure consistent key lookups. Since the key is part of the contract, the maintainers **must** be signatories of the contract. However, maintainers are computed from the `key` instead of the template arguments. In the example above, the `bank` is ultimately the maintainer of the key.
 
-Uniqueness of keys is guaranteed per template. Since multiple templates may use the same key type, some key-related functions must be annotated using the `@ContractType` as shown in the examples below.
+Since multiple templates may use the same key type, some key-related functions must be annotated using the `@ContractType` as shown in the examples below.
 
-When you are writing Daml models, the maintainers matter since they affect authorization -- much like signatories and observers. You don't need to do anything to "maintain" the keys. In the above example, it is guaranteed that there can only be one `Account` with a given `number` at a given `bank`.
-
-Checking of the keys is done automatically at execution time, by the Daml execution engine: if someone tries to create a new contract that duplicates an existing contract key, the execution engine will cause that creation to fail.
+When you are writing Daml models, the maintainers matter since they affect authorization -- much like signatories and observers. You don't need to do anything to "maintain" the keys. Validators hosting the maintainers of a key involved in a transaction verify that contracts are retrieved in a consistent order for that key within the transaction.
 
 ## Contract Lookups
 
-The primary purpose of contract keys is to provide a stable, and possibly meaningful, identifier that can be used in Daml to fetch contracts. There are two functions to perform such lookups: `fetchbykey` and `lookupbykey`. Both types of lookup are performed at interpretation time on the submitting Participant Node, on a best-effort basis. Currently, that best-effort means lookups only return contracts if the submitting Party is a stakeholder of that contract.
+The primary purpose of contract keys is to provide a stable, and possibly meaningful, identifier that can be used in Daml to fetch contracts. The main functions for key-based lookups are `fetchByKey`, `lookupByKey`, and `exerciseByKey`, all available in the Prelude.
 
-In particular, the above means that if multiple commands are submitted simultaneously, all using contract lookups to find and consume a given contract, there will be contention between these commands, and at most one will succeed. For more information, see the section on avoiding contention in the [Canton documentation](/appdev/deep-dives/performance-optimization).
+When multiple contracts share the same key, these functions return the **first** contract according to the following lookup order:
 
-Limiting key usage to stakeholders also means that keys cannot be used to access a divulged contract, i.e. there can be cases where `fetch` succeeds and `fetchByKey` does not. See the example at the end of this section for details.
+1. Contracts created within the current transaction, starting with the most recent.
+2. Explicitly disclosed contracts, in the order provided in the command.
+3. Contracts known to the participant, in any order. (The current implementation returns them in recency order, but this is not guaranteed and should not be relied on.)
+
+For use cases where multiple contracts per key are expected, the `DA.ContractKeys` module provides `lookupNByKey` and `lookupAllByKey` (see [Multi-Contract Key Lookups](#multi-contract-key-lookups) below).
+
+Because disclosed contracts are prioritized over known contracts, you can use disclosures to ensure a specific retrieval order during command submission.
 
 ### fetchByKey
 
 `(fetchedContractId, fetchedContract) <- fetchByKey @ContractType contractKey`
 
-Use `fetchByKey` to fetch the ID and data of the contract with the specified key. It is an alternative to `fetch` and behaves the same in most ways.
+Use `fetchByKey` to fetch the ID and data of the first contract with the specified key (according to the lookup order above). It is an alternative to `fetch` and behaves the same in most ways.
 
 It returns a tuple of the ID and the contract object (containing all its data).
 
 Like `fetch`, `fetchByKey` needs to be authorized by at least one stakeholder.
 
-`fetchByKey` fails and aborts the transaction if:
-
-- The submitting Party is not a stakeholder on a contract with the given key, or
-- A contract was found, but the `fetchByKey` violates the authorization rule, meaning no stakeholder authorized the `fetch`.
-
-This means that if it fails, it doesn't guarantee that a contract with that key doesn't exist, just that the submitting Party doesn't know about it, or there are issues with authorization.
-
-### visibleByKey
-
-`boolean <- visibleByKey @ContractType contractKey`
-
-Use `visibleByKey` to check whether you can see an active contract for the given key with the current authorizations. If the contract exists and you have permission to see it, returns `True`, otherwise returns `False`.
-
-To clarify, ignoring contention:
-
-1.  `visibleByKey` will return `True` if all of these are true: there exists a contract for the given key, the submitter is a stakeholder on that contract, and at the point of call we have the authorization of **all** of the maintainers of the key.
-2.  `visibleByKey` will return `False` if all of those are true: there is no contract for the given key, and at the point of call we have authorization from **all** the maintainers of the key.
-3.  `visibleByKey` will abort the transaction at interpretation time if, at the point of call, we are missing the authorization from any one maintainer of the key.
-4.  `visibleByKey` will fail at validation time (after returning `False` at interpretation time) if all of these are true: at the point of call, we have the authorization of **all** the maintainers, and a valid contract exists for the given key, but the submitter is not a stakeholder on that contract.
-
-While it may at first seem too restrictive to require **all** maintainers to authorize the call, this is actually required in order to validate negative lookups. In the positive case, when you can see the contract, it's easy for the transaction to mention which contract it found, and therefore for validators to check that this contract does indeed exist, and is active as of the time of executing the transaction.
-
-For the negative case, however, the transaction submitted for execution cannot say *which* contract it has not found (as, by definition, it has not found it, and it may not even exist). Still, validators have to be able to reproduce the result of not finding the contract, and therefore they need to be able to look for it, which means having the authorization to ask the maintainers about it.
+`fetchByKey` fails and aborts the transaction if no contract with the given key is visible to the submitting party.
 
 ### lookupByKey
 
 `optionalContractId <- lookupByKey @ContractType contractKey`
 
-Use `lookupByKey` to check whether a contract with the specified key exists. If it does exist, `lookupByKey` returns the `Some contractId`, where `contractId` is the ID of the contract; otherwise, it returns `None`.
+Use `lookupByKey` to check whether a contract with the specified key exists. If it does exist, `lookupByKey` returns `Some contractId`, where `contractId` is the ID of the first contract matching the key (according to the lookup order above); otherwise, it returns `None`.
 
-`lookupByKey` is conceptually equivalent to
+`lookupByKey` requires authorization from **all** maintainers of the key. This is necessary so that confirming participants hosting the maintainers can verify that contracts are retrieved in a consistent order for the given key within the transaction.
 
-<DamlAppdevModulesM3ContractKeysL107 />
+More precisely:
 
-Therefore, `lookupByKey` needs all the same authorizations as `visibleByKey`, for the same reasons, and fails in the same cases.
-
-To get the data from the contract once you've confirmed it exists, you'll still need to use `fetch`.
+- `lookupByKey` returns `Some contractId` if a contract with the given key exists and the submitter is a stakeholder on that contract, and authorization from all maintainers is present.
+- `lookupByKey` returns `None` if no contract with the given key exists (or none is visible to the submitter), and authorization from all maintainers is present.
+- `lookupByKey` aborts the transaction if authorization from any maintainer is missing.
 
 ## exerciseByKey
 
 `exerciseByKey @ContractType contractKey`
 
-Use `exerciseByKey` to exercise a choice on a contract identified by its `key` (compared to `exercise`, which lets you exercise a contract identified by its `ContractId`). Just like `exercise`, running `exerciseByKey` requires visibility of the contract (either through divulgence, `readAs` or being a stakeholder) and authorization from the controllers of the choice.
+Use `exerciseByKey` to exercise a choice on the first contract with the given key (according to the lookup order above). Just like `exercise`, running `exerciseByKey` requires visibility of the contract and authorization from the controllers of the choice.
+
+## Multi-Contract Key Lookups
+
+For use cases where multiple contracts may share the same key, the `DA.ContractKeys` module provides:
+
+- **`lookupNByKey @ContractType n key`** — looks up up to `n` contracts with the given key, returned in the lookup order described above.
+- **`lookupAllByKey @ContractType key`** — looks up all contracts with the given key.
+
+These functions are not imported by default. To use them, add `import DA.ContractKeys` to your module.
+
+<Note>
+Performance is optimized for the common case of zero or one contract per key. The multi-contract functions (`lookupNByKey`, `lookupAllByKey`) may be less performant when many contracts share a key.
+</Note>
+
+## Daml Script Functions
+
+In addition to the Daml language primitives above (which run inside transactions), there are Daml Script functions for querying keys outside of transactions:
+
+- **`queryByKey @ContractType party key`** — looks up a contract by key and returns its ID and data. Runs as a top-level `Script` action.
+- **`queryNByKey @ContractType party n key`** — looks up up to `n` contracts by key and returns their IDs and data. Runs as a top-level `Script` action.
+- **`exerciseByKeyCmd @ContractType key choiceArg`** — exercises a choice on the first contract with the given key. This is a `Commands` action and must be used inside a `submit` block, where it can be combined with other commands.
 
 ## Example
 
-A complete example of possible success and failure scenarios of `fetchByKey` and `lookupByKey` is shown below.
+An example demonstrating key-based lookups and exercises:
 
 <DamlAppdevModulesM3ContractKeysL132 />
-
-
-{/* COPIED_END */}

--- a/docs-main/appdev/modules/m3-contract-keys.mdx
+++ b/docs-main/appdev/modules/m3-contract-keys.mdx
@@ -13,7 +13,9 @@ Contract keys are an optional addition to templates. They let you specify a way 
 Contract keys do not change and can be used to refer to a contract even when the contract ID changes. As a contract is updated via archive and create operations, the currently active contract(s) can easily be referenced via the contract key.
 
 <Note>
-Unlike in Daml 2.x, contract keys are **not** guaranteed to be unique in Canton 3.x. Multiple active contracts of the same template can share the same key. However, most applications are expected to enforce key uniqueness externally — for example, in the Daml business logic or at the application level. The primary key-based API (`lookupByKey`, `fetchByKey`, `exerciseByKey`) is optimized for the common case where at most one contract exists per key.
+In Canton 3.x, it is possible for multiple active contracts of the same template to share the same key. 
+
+The general usage is that key uniqueness is guaranteed outside of the Daml engine — for example, in the Daml business logic or at the backend client level (e.g., a unique account number or invoice number). Because of this, the primary key-based API (`lookupByKey`, `fetchByKey`, `exerciseByKey`) are optimized for the common case where there is at most a key references one contract.
 </Note>
 
 Here's an example of setting up a contract key for a bank account, to act as a bank account ID:

--- a/docs-main/appdev/modules/m3-contract-keys.mdx
+++ b/docs-main/appdev/modules/m3-contract-keys.mdx
@@ -38,7 +38,7 @@ When you are writing Daml models, the maintainers matter since they affect autho
 
 ## Contract Lookups
 
-The primary purpose of contract keys is to provide a stable, and possibly meaningful, identifier that can be used in Daml to fetch contracts. The main functions for key-based lookups are `fetchByKey`, `lookupByKey`, and `exerciseByKey`, all available in the Prelude.
+The primary purpose of contract keys is to provide a stable, and possibly meaningful, identifier that can be used in Daml to fetch contracts. The main functions for key-based lookups are `fetchByKey`, `lookupByKey`, and `exerciseByKey`, all available by default.
 
 When multiple contracts share the same key, these functions return the **first** contract according to the following lookup order:
 
@@ -60,7 +60,7 @@ It returns a tuple of the ID and the contract object (containing all its data).
 
 Like `fetch`, `fetchByKey` needs to be authorized by at least one stakeholder.
 
-`fetchByKey` fails and aborts the transaction if no contract with the given key is visible to the submitting party.
+`fetchByKey` fails and aborts the transaction with a [`CONTRACT_KEY_NOT_FOUND`](/appdev/reference/error-codes#contracts-and-transactions) error if no contract with the given key is visible to the submitting party.
 
 ### lookupByKey
 

--- a/docs-main/snippets/daml-docs/appdev_modules_m3-contract-keys_L132.mdx
+++ b/docs-main/snippets/daml-docs/appdev_modules_m3-contract-keys_L132.mdx
@@ -1,101 +1,27 @@
 ```haskell
--- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Keys where
+module Test where
 
 import Daml.Script
 import DA.Assert
+import DA.ContractKeys
 import DA.Optional
 
-template Keyed
+template WithKey
   with
-    sig : Party
-    obs : Party
+    p : Party
+    payload : Text
   where
-    signatory sig
-    observer obs
-
-    key sig : Party
+    signatory p
+    key p : Party
     maintainer key
-
-template Divulger
-  with
-    divulgee : Party
-    sig : Party
-  where
-    signatory divulgee
-    observer sig
-
-    nonconsuming choice DivulgeKeyed
-      : Keyed
+    nonconsuming choice GetText : Text
       with
-        keyedCid : ContractId Keyed
-      controller sig
-      do
-        fetch keyedCid
-
-template Delegation
-  with
-    sig : Party
-    delegees : [Party]
-  where
-    signatory sig
-    observer delegees
-
-    nonconsuming choice CreateKeyed
-      : ContractId Keyed
-      with
-        delegee : Party
-        obs : Party
-      controller delegee
-      do
-        create Keyed with sig; obs
-
-    nonconsuming choice ArchiveKeyed
-      : ()
-      with
-        delegee : Party
-        keyedCid : ContractId Keyed
-      controller delegee
-      do
-        archive keyedCid
-
-    nonconsuming choice UnkeyedFetch
-      : Keyed
-      with
-        cid : ContractId Keyed
-        delegee : Party
-      controller delegee
-      do
-        fetch cid
-
-    nonconsuming choice VisibleKeyed
-      : Bool
-      with
-        key : Party
-        delegee : Party
-      controller delegee
-      do
-        visibleByKey @Keyed key
-
-    nonconsuming choice LookupKeyed
-      : Optional (ContractId Keyed)
-      with
-        lookupKey : Party
-        delegee : Party
-      controller delegee
-      do
-        lookupByKey @Keyed lookupKey
-
-    nonconsuming choice FetchKeyed
-      : (ContractId Keyed, Keyed)
-      with
-        lookupKey : Party
-        delegee : Party
-      controller delegee
-      do
-        fetchByKey @Keyed lookupKey
+        party : Party
+      controller party
+      do pure payload
 
 template Helper
   with
@@ -103,251 +29,111 @@ template Helper
   where
     signatory p
 
-    choice FetchByKey : (ContractId Keyed, Keyed)
-      with
-        keyedKey : Party
+    choice PerformLookupByKey : Optional (ContractId WithKey)
       controller p
-      do fetchByKey @Keyed keyedKey
-
-    choice VisibleByKey : Bool
-      with
-        keyedKey : Party
+      do lookupByKey @WithKey p
+    
+    choice PerformFetchByKey : (ContractId WithKey, WithKey)
       controller p
-      do visibleByKey @Keyed keyedKey
-
-    choice LookupByKey : (Optional (ContractId Keyed))
-      with
-        keyedKey : Party
+      do fetchByKey @WithKey p
+    
+    choice PerformExerciseByKey : Text
       controller p
-      do lookupByKey @Keyed keyedKey
-
-    choice AssertNotVisibleKeyed : ()
-      with
-        delegationCid : ContractId Delegation
-        delegee : Party
-        key : Party
+      do exerciseByKey @WithKey p GetText with party = p
+    
+    choice PerformLookupNByKey : [(ContractId WithKey, WithKey)]
+      with n : Int
       controller p
-      do
-        b <- exercise delegationCid VisibleKeyed with
-          delegee
-          key
-        assert $ not b
-
-    choice AssertLookupKeyedIsNone : ()
-      with
-        delegationCid : ContractId Delegation
-        delegee : Party
-        lookupKey : Party
+      do lookupNByKey @WithKey n p
+    
+    choice CreateThenPerformLookupNByKey : [(ContractId WithKey, WithKey)]
+      with 
+        payload : Text
+        n : Int
       controller p
-      do
-        b <- exercise delegationCid LookupKeyed with
-          delegee
-          lookupKey
-        assert $ isNone b
+      do create (WithKey p payload)
+         lookupNByKey @WithKey n p
 
-    choice AssertFetchKeyedEqExpected : ()
-      with
-        delegationCid : ContractId Delegation
-        delegee : Party
-        lookupKey : Party
-        expectedCid : ContractId Keyed
-      controller p
-      do
-        (cid, keyed) <- exercise delegationCid FetchKeyed with
-          delegee
-          lookupKey
-        cid === expectedCid
+-- Demonstrates basic key operations: lookupByKey, fetchByKey, exerciseByKey
+useKeyOperations : Script ()
+useKeyOperations = script do
+  alice <- allocateParty "alice"
 
+  -- Create a contract with a key
+  cid <- alice `submit` createCmd (WithKey alice "hello")
 
-lookupTest = script do
+  -- lookupByKey returns Some if a contract with the key exists
+  mcid <- alice `submit`
+    createAndExerciseCmd (Helper alice) PerformLookupByKey
+  assert (isSome mcid)
 
-  -- Put four parties in the four possible relationships with a `Keyed`
-  sig <- allocateParty "s" -- Signatory
-  obs <- allocateParty "o" -- Observer
-  divulgee <- allocateParty "d" -- Divulgee
-  blind <- allocateParty "b" -- Blind
+  -- fetchByKey returns the contract ID and data
+  (kcid, contract) <- alice `submit`
+    createAndExerciseCmd (Helper alice) PerformFetchByKey
+  kcid === cid
+  contract.payload === "hello"
 
-  keyedCid <- submit sig do createCmd Keyed with ..
-  divulgercid <- submit divulgee do createCmd Divulger with ..
-  submit sig do exerciseCmd divulgercid DivulgeKeyed with ..
+  -- exerciseByKey exercises a choice on the contract with the key
+  result <- alice `submit`
+    createAndExerciseCmd (Helper alice) PerformExerciseByKey
+  result === "hello"
 
-  -- Now the signatory and observer delegate their choices
-  sigDelegationCid <- submit sig do
-    createCmd Delegation with
-      sig
-      delegees = [obs, divulgee, blind]
-  obsDelegationCid <- submit obs do
-    createCmd Delegation with
-      sig = obs
-      delegees = [divulgee, blind]
+-- Demonstrates non-unique keys: multiple contracts can share a key.
+-- lookupByKey and fetchByKey return the first contract per lookup order;
+-- lookupNByKey (from DA.ContractKeys) returns up to n contracts.
+multipleContractsPerKey : Script ()
+multipleContractsPerKey = script do
+  alice <- allocateParty "alice"
 
-  -- TESTING LOOKUPS AND FETCHES
+  -- Create multiple contracts with the same key
+  cid1 <- alice `submit` createCmd (WithKey alice "first")
+  cid2 <- alice `submit` createCmd (WithKey alice "second")
+  cid3 <- alice `submit` createCmd (WithKey alice "third")
 
-  -- Maintainer can fetch
-  (cid, keyed) <- submit sig do
-    Helper sig `createAndExerciseCmd` FetchByKey sig
-  cid === keyedCid
-  -- Maintainer can see
-  b <- submit sig do
-    Helper sig `createAndExerciseCmd` VisibleByKey sig
-  assert b
-  -- Maintainer can lookup
-  mcid <- submit sig do
-    Helper sig `createAndExerciseCmd` LookupByKey sig
-  mcid === Some keyedCid
+  let contracts = [(cid1, "first"), (cid2, "second"), (cid3, "third")]
 
+  -- fetchByKey returns one of the created contracts
+  (kcid, contract) <- alice `submit`
+    createAndExerciseCmd (Helper alice) PerformFetchByKey
+  assert ((kcid, contract.payload) `elem` contracts)
 
-  -- Stakeholder can fetch
-  (cid, l) <- submit obs do
-    Helper obs `createAndExerciseCmd` FetchByKey sig
-  keyedCid === cid
-  -- Stakeholder can't see without authorization
-  submitMustFail obs do
-    Helper obs `createAndExerciseCmd` VisibleByKey sig
+  -- lookupNByKey returns up to n contracts (any 2 of 3, in any order)
+  result <- alice `submit`
+    createAndExerciseCmd (Helper alice) PerformLookupNByKey with n = 2
+  let results = [(cid, c.payload) | (cid, c) <- result]
+  length results === 2
+  let [r1, r2] = results
+  assert (r1 `elem` contracts)
+  assert (r2 `elem` contracts)
+  r1 =/= r2
 
-  -- Stakeholder can see with authorization
-  b <- submit obs do
-    exerciseCmd sigDelegationCid VisibleKeyed with
-      delegee = obs
-      key = sig
-  assert b
-  -- Stakeholder can't lookup without authorization
-  submitMustFail obs do
-    Helper obs `createAndExerciseCmd` LookupByKey sig
-  -- Stakeholder can lookup with authorization
-  mcid <- submit obs do
-    exerciseCmd sigDelegationCid LookupKeyed with
-      delegee = obs
-      lookupKey = sig
-  mcid === Some keyedCid
+  -- lookupNByKey returns:
+  --   - local contracts in recency order
+  --   - then disclosures in command-specified order
+  --   - then contracts known to the participant in any order
+  Some disclosure <- alice `queryDisclosure` cid1
+  result <- submit (actAs alice <> disclose disclosure) do
+    createAndExerciseCmd (Helper alice) CreateThenPerformLookupNByKey with
+      payload = "fourth"
+      n = 3
+  let results = [(cid, c.payload) | (cid, c) <- result]
+  length results === 3
+  let [r1, r2, r3] = results
+  r1._2 === "fourth"
+  r2 === (cid1, "first")
+  r3._1 =/= cid1
+  r3._2 =/= "fourth"
+  assert (r3 `elem` contracts)
 
-  -- Divulgee can't fetch the contract directly
-  submitMustFail divulgee do
-    exerciseCmd obsDelegationCid UnkeyedFetch with
-        delegee = divulgee
-        cid = keyedCid
-  -- Divulgee can't fetch through the key
-  submitMustFail divulgee do
-    Helper divulgee `createAndExerciseCmd` FetchByKey sig
-  -- Divulgee can't see
-  submitMustFail divulgee do
-    Helper divulgee `createAndExerciseCmd` VisibleByKey sig
-  -- Divulgee can't see with stakeholder authority
-  submitMustFail divulgee do
-    exerciseCmd obsDelegationCid VisibleKeyed with
-        delegee = divulgee
-        key = sig
-  -- Divulgee can't lookup
-  submitMustFail divulgee do
-    Helper divulgee `createAndExerciseCmd` LookupByKey sig
-  -- Divulgee can't lookup with stakeholder authority
-  submitMustFail divulgee do
-    exerciseCmd obsDelegationCid LookupKeyed with
-        delegee = divulgee
-        lookupKey = sig
-  -- Divulgee can't do positive lookup with maintainer authority.
-  submitMustFail divulgee do
-    Helper divulgee `createAndExerciseCmd` AssertNotVisibleKeyed with
-      delegationCid = sigDelegationCid
-      delegee = divulgee
-      key = sig
-  -- Divulgee can't do positive lookup with maintainer authority.
-  -- Note that the lookup returns `None` so the assertion passes.
-  -- If the assertion is changed to `isSome`, the assertion fails,
-  -- which means the error message changes. The reason is that the
-  -- assertion is checked at interpretation time, before the lookup
-  -- is checked at validation time.
-  submitMustFail divulgee do
-    Helper divulgee `createAndExerciseCmd` AssertLookupKeyedIsNone with
-      delegationCid = sigDelegationCid
-      delegee = divulgee
-      lookupKey = sig
-  -- Divulgee can't fetch with stakeholder authority
-  submitMustFail divulgee do
-    Helper divulgee `createAndExerciseCmd` AssertFetchKeyedEqExpected with
-      delegationCid = obsDelegationCid
-      delegee = divulgee
-      lookupKey = sig
-      expectedCid = keyedCid
+-- Demonstrates exerciseByKeyCmd in a submit block
+exerciseByKeyCmdExample : Script ()
+exerciseByKeyCmdExample = script do
+  alice <- allocateParty "alice"
 
-  -- Blind party can't fetch
-  submitMustFail blind do
-    Helper blind `createAndExerciseCmd` FetchByKey sig
-  -- Blind party can't see
-  submitMustFail blind do
-    Helper blind `createAndExerciseCmd` VisibleByKey sig
-  -- Blind party can't see with stakeholder authority
-  submitMustFail blind do
-    exerciseCmd obsDelegationCid VisibleKeyed with
-      delegee = blind
-      key = sig
-  -- Blind party can't see with maintainer authority
-  submitMustFail blind do
-    Helper blind `createAndExerciseCmd` AssertNotVisibleKeyed with
-      delegationCid = sigDelegationCid
-      delegee = blind
-      key = sig
-  -- Blind party can't lookup
-  submitMustFail blind do
-    Helper blind `createAndExerciseCmd` LookupByKey sig
-  -- Blind party can't lookup with stakeholder authority
-  submitMustFail blind do
-    exerciseCmd obsDelegationCid LookupKeyed with
-      delegee = blind
-      lookupKey = sig
-  -- Blind party can't lookup with maintainer authority.
-  -- The lookup initially returns `None`, but is rejected at
-  -- validation time
-  submitMustFail blind do
-    Helper blind `createAndExerciseCmd` AssertLookupKeyedIsNone with
-      delegationCid = sigDelegationCid
-      delegee = blind
-      lookupKey = sig
-  -- Blind party can't fetch with stakeholder authority as lookup is negative
-  submitMustFail blind do
-    exerciseCmd obsDelegationCid FetchKeyed with
-      delegee = blind
-      lookupKey = sig
-  -- Blind party can see nonexistence of a contract
-  submit blind do
-    Helper blind `createAndExerciseCmd` AssertNotVisibleKeyed with
-      delegationCid = obsDelegationCid
-      delegee = blind
-      key = obs
-  -- Blind can do a negative lookup on a truly nonexistant contract
-  submit blind do
-    Helper blind `createAndExerciseCmd` AssertLookupKeyedIsNone with
-      delegationCid = obsDelegationCid
-      delegee = blind
-      lookupKey = obs
+  alice `submit` createCmd (WithKey alice "payload")
 
-  -- TESTING CREATES AND ARCHIVES
-
-  -- Divulgee can't archive
-  submitMustFail divulgee do
-    exerciseCmd sigDelegationCid ArchiveKeyed with
-      delegee = divulgee
-      keyedCid
-
-  submit sig do
-     exerciseCmd keyedCid Archive
-
-  -- Divulgee can create
-  keyedCid2 <- submit divulgee do
-    exerciseCmd sigDelegationCid CreateKeyed with
-      delegee = divulgee
-      obs
-
-  -- Stakeholder can archive
-  submit obs do
-    exerciseCmd sigDelegationCid ArchiveKeyed with
-      delegee = obs
-      keyedCid = keyedCid2
-  -- Stakeholder can create
-  keyedCid3 <- submit obs do
-    exerciseCmd sigDelegationCid CreateKeyed with
-      delegee = obs
-      obs
-
-  return ()
+  -- exerciseByKeyCmd is a Commands action used inside submit
+  result <- alice `submit` do
+    exerciseByKeyCmd @WithKey alice GetText with party = alice
+  result === "payload"
 ```


### PR DESCRIPTION
Update the contract key documentation copied over from 2.x to match the semantics of contract keys in canton 3.5.

Preview of the modified page: https://cantonfoundation-pb-update-key-documentation.mintlify.app/appdev/modules/m3-contract-keys