### PR TITLE
Probe network variable tabs CI failure

### DIFF
--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/onboarding-process-1.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/onboarding-process-1.mdx
@@ -31,3 +31,5 @@ Sequencers that are functional and have whitelisted your IP correctly will retur
 <ExternalSpliceMainSpliceRstCodeDocsSrcValidatorOperatorValidatorOnboardingBash136 />
 
 The default configuration for both of these requires access to at least 2/3 of the SVs for each of scans and sequencers. You may, at your option and own risk, configure connection to a single trusted scan and sequencer as described under validator helm chart configuration, at the cost of losing BFT integrity guarantees.
+
+CI failure probe: |gsf_scan_url|


### PR DESCRIPTION
## Summary

Intentional failure probe for the `Validate network variable tabs` GitHub Actions check added in #663.

This branch changes one source snippet under `docs-main/snippets/networkvars` without committing the corresponding generated rendered MDX. The expected result is that the `Validate network variable tabs` check fails with `docs-main/global-synchronizer/deployment/onboarding-process.mdx` reported as stale.

## Expected CI result

- `Validate network variable tabs` should fail.
- The failure should demonstrate that `npm run validate:network-variable-tabs` catches source snippet updates that are not rendered into the docs page.

## Local probe

Ran `npm run validate:network-variable-tabs`; it exited `1` and reported:

```text
Network variable tabs are stale. Run `npm run generate:network-variable-tabs` and commit the rendered MDX changes.
 M docs-main/global-synchronizer/deployment/onboarding-process.mdx
Updated 1 page(s).
```

This PR should not be merged.
