### PR TITLE
Update external-signing-onboarding.mdx

### DIFF
--- a/docs-main/appdev/deep-dives/external-signing-onboarding.mdx
+++ b/docs-main/appdev/deep-dives/external-signing-onboarding.mdx
@@ -794,10 +794,10 @@ def build_signed_topology_transaction(
                 transaction_hashes=hashes,
                 signatures=[
                     crypto_pb2.Signature(
-                        format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_DER,
+                        format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_CONCAT,
                         signature=signature,
                         signed_by=signed_by,
-                        signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256,
+                        signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_ED25519,
                     )
                 ],
             )
@@ -1255,10 +1255,10 @@ def update_external_party_hosting(
         transaction=updated_party_to_participant_transaction,
         signatures=[
             crypto_pb2.Signature(
-                format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_DER,
+                format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_CONCAT,
                 signature=signature,
                 signed_by=fingerprint,
-                signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256,
+                signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_ED25519,
             )
         ],
         multi_transaction_signatures=[],
@@ -1561,10 +1561,10 @@ def update_external_party_hosting(
         transaction=updated_party_to_participant_transaction,
         signatures=[
             crypto_pb2.Signature(
-                format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_DER,
+                format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_CONCAT,
                 signature=signature,
                 signed_by=fingerprint,
-                signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256,
+                signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_ED25519,
             )
         ],
         multi_transaction_signatures=[],

--- a/docs-main/appdev/deep-dives/external-signing-transactions.mdx
+++ b/docs-main/appdev/deep-dives/external-signing-transactions.mdx
@@ -1216,9 +1216,9 @@ grpcurl -emit-defaults -plaintext -d @ localhost:4001 com.daml.ledger.api.v2.int
             "party": "alice::1220d466a5d96a3509736c821e25fe81fc8a73f226d92e57e94a65170e58b07fc08e",
             "signatures": [
               {
-                "format": "SIGNATURE_FORMAT_DER",
+                "format": "SIGNATURE_FORMAT_CONCAT",
                 "signature": "$SIGNATURE",
-                "signing_algorithm_spec": "SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256",
+                "signing_algorithm_spec": "SIGNING_ALGORITHM_SPEC_ED25519",
                 "signed_by": "1220d466a5d96a3509736c821e25fe81fc8a73f226d92e57e94a65170e58b07fc08e"
               }
             ]
@@ -1242,10 +1242,10 @@ execute_request = interactive_submission_service_pb2.ExecuteSubmissionRequest(
                 party=party,
                 signatures=[
                     crypto_pb2.Signature(
-                        format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_DER,
+                        format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_CONCAT,
                         signature=signature,
                         signed_by=pub_fingerprint,
-                        signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256,
+                        signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_ED25519,
                     )
                 ],
             )
@@ -1596,10 +1596,10 @@ def execute_and_get_contract_id(
                     party=party,
                     signatures=[
                         crypto_pb2.Signature(
-                            format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_DER,
+                            format=crypto_pb2.SignatureFormat.SIGNATURE_FORMAT_CONCAT,
                             signature=signature,
                             signed_by=pub_fingerprint,
-                            signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256,
+                            signing_algorithm_spec=crypto_pb2.SigningAlgorithmSpec.SIGNING_ALGORITHM_SPEC_ED25519,
                         )
                     ],
                 )


### PR DESCRIPTION
External signing example uses an elliptic curve signing key, so the signature needs to use CONCAT

As per
<img width="835" height="187" alt="image" src="https://github.com/user-attachments/assets/9f9882f7-f025-4018-8e3c-7384ae5470a8" />
