### PR TITLE
ci: add mypy and ruff

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ let
   python = pythonBase.withPackages (ps: [
     ps.grpcio-tools
     ps.jinja2
+    ps.mypy
     ps.protobuf
     ps.pytest
     ps.pyyaml
@@ -15,12 +16,12 @@ pkgs.mkShell {
     pkgs.gh
     pkgs.jdk17_headless
     pkgs.nodejs_22
+    pkgs.ruff
     python
   ];
 
   shellHook = ''
-    export JAVA_HOME="${pkgs.jdk17_headless}"
-    export PATH="$PWD/node_modules/.bin:$JAVA_HOME/bin:${pkgs.nodejs_22}/bin:${python}/bin:${pkgs.gh}/bin:$HOME/.dpm/bin:$HOME/.daml/bin:$PATH"
+    export PATH="$PWD/node_modules/.bin:$JAVA_HOME/bin:$HOME/.dpm/bin:$HOME/.daml/bin:$PATH"
     export PYTHONPATH="$PWD/src''${PYTHONPATH:+:$PYTHONPATH}"
 
     case " $NODE_OPTIONS " in


### PR DESCRIPTION
Add `mypy` and `ruff` (just some basic python tools).

I also removed the unneeded extra `PATH` settings, because `nix` handles this automatically.