### PR TITLE
fixes link to manual installation instructions by adding heading

### DIFF
--- a/docs-main/sdks-tools/cli-tools/dpm.mdx
+++ b/docs-main/sdks-tools/cli-tools/dpm.mdx
@@ -787,6 +787,8 @@ To fix this, you can:
 
 {/* COPIED_START source="docs-website:docs/replicated/dpm/3.5/manual-install.rst" hash="3c8275c7" */}
 
+# Manual Installation Instructions
+
 ## Mac/Linux
 
 If you cannot / wish not to use the shell script to install for Linux or OSX, you can alternatively install dpm manually by running this set of commands in your terminal:


### PR DESCRIPTION
Adds heading so link to manual installation instructions navigates properly. 