### PR TITLE
Update section header from Six to Five Trust Domains

### DIFF
--- a/docs-main/overview/learn/trust-model.mdx
+++ b/docs-main/overview/learn/trust-model.mdx
@@ -11,7 +11,7 @@ In any distributed system, the key question is: **Who do you need to trust, and 
 
 Canton breaks this into distinct trust domains, each with different participants and assumptions.
 
-## Six Trust Domains
+## Five Trust Domains
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
There are five different trust domains mentioned on this page; however, the header incorrectly states that there are six.