### PR TITLE
ci: add Python type libraries

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,8 @@ let
     ps.protobuf
     ps.pytest
     ps.pyyaml
+    ps.types-protobuf
+    ps.types-pyyaml
   ]);
 in
 pkgs.mkShell {


### PR DESCRIPTION
Stop `mypy` from complaining about missing stub libraries.