### PR TITLE
Tighten Python reference doc types

### DIFF
--- a/scripts/generated_reference_nav.py
+++ b/scripts/generated_reference_nav.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import cast
+
+from x2mdx.types import JsonObject, MintlifyNavGroup, MintlifyNavItems
 
 
 def docs_json_page_ref(path: Path, docs_json_path: Path) -> str:
@@ -13,11 +15,11 @@ def docs_json_page_ref(path: Path, docs_json_path: Path) -> str:
     return relative.with_suffix("").as_posix()
 
 
-def load_json(path: Path) -> dict[str, Any]:
+def load_json(path: Path) -> JsonObject:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected JSON object in {path}")
-    return payload
+    return cast(JsonObject, payload)
 
 
 def slugify(value: str) -> str:
@@ -60,36 +62,35 @@ def _asyncapi_channel_name(path: Path) -> str:
     return mdx_title(path)
 
 
+def nav_group(label: str, pages: MintlifyNavItems) -> MintlifyNavGroup:
+    return {"group": label, "pages": pages}
+
+
 def build_asyncapi_nav_group(
     *,
     output_dir: Path,
     docs_json_path: Path,
     group_label: str,
-) -> dict[str, Any]:
-    pages: list[Any] = []
-    channel_groups: list[Any] = []
+) -> MintlifyNavGroup:
+    pages: MintlifyNavItems = []
+    channel_groups: MintlifyNavItems = []
     operation_root = output_dir / "operations"
     for channel_details_page in sorted(operation_root.glob("*/details.mdx"), key=lambda path: path.parent.name):
         channel_slug = channel_details_page.parent.name
         operation_dir = output_dir / "operations" / channel_slug
-        operation_refs = [
+        operation_refs: MintlifyNavItems = [
             docs_json_page_ref(path, docs_json_path)
             for path in sorted(
                 operation_dir.glob("*.mdx"),
                 key=lambda path: (path.name == "details.mdx", mdx_title(path)),
             )
         ]
-        channel_groups.append(
-            {
-                "group": _asyncapi_channel_name(channel_details_page),
-                "pages": operation_refs,
-            }
-        )
+        channel_groups.append(nav_group(_asyncapi_channel_name(channel_details_page), operation_refs))
     pages.extend(channel_groups)
     details_page = operation_root / "details.mdx"
     if details_page.exists():
         pages.append(docs_json_page_ref(details_page, docs_json_path))
-    return {"group": group_label, "pages": pages}
+    return nav_group(group_label, pages)
 
 
 def build_openrpc_nav_group(
@@ -100,15 +101,15 @@ def build_openrpc_nav_group(
     spec_ids: list[str],
     spec_dir_name: str = "specs",
     spec_group_sections: dict[str, str] | None = None,
-) -> dict[str, Any]:
-    pages: list[Any] = []
-    section_pages: dict[str, list[Any]] = {}
+) -> MintlifyNavGroup:
+    pages: MintlifyNavItems = []
+    section_pages: dict[str, MintlifyNavItems] = {}
     for spec_id in spec_ids:
         spec_page = output_dir / spec_dir_name / f"{slugify(spec_id)}.mdx"
         if not spec_page.exists():
             continue
         operation_dir = output_dir / "operations" / slugify(spec_id)
-        operation_refs = [
+        operation_refs: MintlifyNavItems = [
             docs_json_page_ref(path, docs_json_path)
             for path in sorted(operation_dir.glob("*.mdx"), key=mdx_title)
             if path.name != "details.mdx"
@@ -118,28 +119,18 @@ def build_openrpc_nav_group(
             operation_refs.append(docs_json_page_ref(details_page, docs_json_path))
         section = spec_group_sections.get(spec_id) if spec_group_sections else None
         if section:
-            section_pages.setdefault(section, []).append(
-                {
-                    "group": mdx_title(spec_page),
-                    "pages": operation_refs,
-                }
-            )
+            section_pages.setdefault(section, []).append(nav_group(mdx_title(spec_page), operation_refs))
         else:
-            pages.append(
-                {
-                    "group": mdx_title(spec_page),
-                    "pages": operation_refs,
-                }
-            )
+            pages.append(nav_group(mdx_title(spec_page), operation_refs))
     if spec_group_sections:
         for section in dict.fromkeys(spec_group_sections[spec_id] for spec_id in spec_ids if spec_id in spec_group_sections):
             grouped_pages = section_pages.get(section)
             if grouped_pages:
-                pages.append({"group": section, "pages": grouped_pages})
+                pages.append(nav_group(section, grouped_pages))
     details_page = output_dir / "operations" / "details.mdx"
     if details_page.exists():
         pages.append(docs_json_page_ref(details_page, docs_json_path))
-    return {"group": group_label, "pages": pages}
+    return nav_group(group_label, pages)
 
 
 def build_protobuf_nav_group(
@@ -149,17 +140,17 @@ def build_protobuf_nav_group(
     group_label: str,
     extra_page_refs: list[str] | None = None,
     include_details_page: bool = True,
-) -> dict[str, Any]:
+) -> MintlifyNavGroup:
     details_page_ref = docs_json_page_ref(output_dir / "index.mdx", docs_json_path)
-    pages: list[Any] = []
-    package_groups: list[Any] = []
+    pages: MintlifyNavItems = []
+    package_groups: MintlifyNavItems = []
     for package_page in sorted((output_dir / "packages").glob("*.mdx"), key=mdx_title):
         package_slug = package_page.stem
-        package_pages: list[Any] = [docs_json_page_ref(package_page, docs_json_path)]
+        package_pages: MintlifyNavItems = [docs_json_page_ref(package_page, docs_json_path)]
         operation_root = output_dir / "operations" / package_slug
-        service_groups: list[Any] = []
+        service_groups: MintlifyNavItems = []
         if not operation_root.is_dir():
-            package_groups.append({"group": mdx_title(package_page), "pages": package_pages})
+            package_groups.append(nav_group(mdx_title(package_page), package_pages))
             continue
         service_dirs = sorted(
             (path for path in operation_root.iterdir() if path.is_dir()),
@@ -169,25 +160,21 @@ def build_protobuf_nav_group(
             operation_pages = sorted(service_dir.glob("*.mdx"), key=mdx_title)
             if not operation_pages:
                 continue
-            service_groups.append(
-                {
-                    "group": _protobuf_service_name(operation_pages[0]),
-                    "pages": [docs_json_page_ref(path, docs_json_path) for path in operation_pages],
-                }
-            )
+            service_pages: MintlifyNavItems = [docs_json_page_ref(path, docs_json_path) for path in operation_pages]
+            service_groups.append(nav_group(_protobuf_service_name(operation_pages[0]), service_pages))
         if service_groups:
-            package_pages.append({"group": "Services", "pages": service_groups})
-        package_groups.append({"group": mdx_title(package_page), "pages": package_pages})
+            package_pages.append(nav_group("Services", service_groups))
+        package_groups.append(nav_group(mdx_title(package_page), package_pages))
     if package_groups:
-        pages.append({"group": "Packages", "pages": package_groups})
+        pages.append(nav_group("Packages", package_groups))
     details_refs = [details_page_ref] if include_details_page else []
     for page_ref in [*(extra_page_refs or []), *details_refs]:
         if page_ref not in pages:
             pages.append(page_ref)
-    return {"group": group_label, "pages": pages}
+    return nav_group(group_label, pages)
 
 
-def replace_group_in_dropdown(*, docs_json_path: Path, dropdown_label: str, group: dict[str, Any]) -> None:
+def replace_group_in_dropdown(*, docs_json_path: Path, dropdown_label: str, group: MintlifyNavGroup) -> None:
     payload = load_json(docs_json_path)
     navigation = payload.get("navigation")
     if not isinstance(navigation, dict):
@@ -205,12 +192,13 @@ def replace_group_in_dropdown(*, docs_json_path: Path, dropdown_label: str, grou
     if not isinstance(pages, list):
         raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
 
-    if not _replace_group(pages, group):
-        pages.append(group)
+    nav_pages = cast(MintlifyNavItems, pages)
+    if not _replace_group(nav_pages, group):
+        nav_pages.append(group)
     docs_json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
-def _replace_group(items: list[Any], group: dict[str, Any]) -> bool:
+def _replace_group(items: MintlifyNavItems, group: MintlifyNavGroup) -> bool:
     label = group.get("group")
     replaced = False
     for index, item in enumerate(list(items)):

--- a/scripts/reference_nav.py
+++ b/scripts/reference_nav.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
+
+from x2mdx.types import JsonObject, MintlifyNavGroup, MintlifyNavItem, MintlifyNavItems
 
 
 LEDGER_API_PARENT_GROUP = "Ledger API"
@@ -43,21 +45,45 @@ LANGUAGE_GROUPS = {"Javadocs"}
 JAVADOC_PREFIX = "reference/java/"
 
 
-def load_json(path: Path) -> dict[str, Any]:
+def load_json(path: Path) -> JsonObject:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected JSON object in {path}")
-    return payload
+    return cast(JsonObject, payload)
 
 
-def _find_group(items: list[Any], label: str) -> dict[str, Any] | None:
+def _find_group(items: MintlifyNavItems, label: str) -> MintlifyNavGroup | None:
     for item in items:
         if isinstance(item, dict) and item.get("group") == label:
             return item
     return None
 
 
-def _merge_group_entries(target: dict[str, Any], source: dict[str, Any]) -> None:
+def _nav_group(label: str, pages: MintlifyNavItems | None = None) -> MintlifyNavGroup:
+    group: MintlifyNavGroup = {"group": label}
+    if pages is not None:
+        group["pages"] = pages
+    return group
+
+
+def _copy_group_with_pages(group: MintlifyNavGroup, pages: MintlifyNavItems) -> MintlifyNavGroup:
+    copied: MintlifyNavGroup = {"pages": pages}
+    label = group.get("group")
+    if isinstance(label, str):
+        copied["group"] = label
+    expanded = group.get("expanded")
+    if isinstance(expanded, bool):
+        copied["expanded"] = expanded
+    openapi = group.get("openapi")
+    if isinstance(openapi, str):
+        copied["openapi"] = openapi
+    asyncapi = group.get("asyncapi")
+    if isinstance(asyncapi, str):
+        copied["asyncapi"] = asyncapi
+    return copied
+
+
+def _merge_group_entries(target: MintlifyNavGroup, source: MintlifyNavGroup) -> None:
     for spec_key in ("openapi", "asyncapi"):
         if spec_key in source:
             target[spec_key] = source[spec_key]
@@ -93,10 +119,10 @@ def _merge_group_entries(target: dict[str, Any], source: dict[str, Any]) -> None
         target_pages.append(item)
 
 
-def _upsert_group(collected: dict[str, dict[str, Any]], label: str) -> dict[str, Any]:
+def _upsert_group(collected: dict[str, MintlifyNavGroup], label: str) -> MintlifyNavGroup:
     group = collected.get(label)
     if group is None:
-        group = {"group": label}
+        group = _nav_group(label)
         collected[label] = group
     return group
 
@@ -107,7 +133,7 @@ def _append_unique(items: list[str], values: list[str]) -> None:
             items.append(value)
 
 
-def _java_bindings_nav_item(item: Any) -> Any | None:
+def _java_bindings_nav_item(item: MintlifyNavItem) -> MintlifyNavItem | None:
     if isinstance(item, str):
         if item in {BINDINGS_OVERVIEW_PAGE_REF, LEGACY_BINDINGS_OVERVIEW_PAGE_REF}:
             return BINDINGS_OVERVIEW_PAGE_REF
@@ -126,9 +152,7 @@ def _java_bindings_nav_item(item: Any) -> Any | None:
     ]
     if not filtered_pages:
         return None
-    filtered_item = dict(item)
-    filtered_item["pages"] = filtered_pages
-    return filtered_item
+    return _copy_group_with_pages(item, filtered_pages)
 
 
 def _normalized_grpc_ref(page_ref: str) -> str | None:
@@ -144,8 +168,8 @@ def _normalized_grpc_ref(page_ref: str) -> str | None:
     return None
 
 
-def _absorb_grpc_pages(items: list[Any], collected: dict[str, dict[str, Any]]) -> bool:
-    normalized_items: list[Any] = []
+def _absorb_grpc_pages(items: MintlifyNavItems, collected: dict[str, MintlifyNavGroup]) -> bool:
+    normalized_items: MintlifyNavItems = []
     for item in items:
         normalized = _normalized_grpc_nav_item(item)
         if normalized is not None:
@@ -153,13 +177,13 @@ def _absorb_grpc_pages(items: list[Any], collected: dict[str, dict[str, Any]]) -
     if normalized_items:
         _merge_group_entries(
             _upsert_group(collected, GRPC_GROUP),
-            {"group": GRPC_GROUP, "pages": normalized_items},
+            _nav_group(GRPC_GROUP, normalized_items),
         )
         return True
     return False
 
 
-def _normalized_grpc_nav_item(item: Any) -> Any | None:
+def _normalized_grpc_nav_item(item: MintlifyNavItem) -> MintlifyNavItem | None:
     if isinstance(item, str):
         return _normalized_grpc_ref(item)
     if not isinstance(item, dict):
@@ -174,39 +198,37 @@ def _normalized_grpc_nav_item(item: Any) -> Any | None:
     ]
     if not normalized_pages:
         return None
-    normalized_item = dict(item)
-    normalized_item["pages"] = normalized_pages
-    return normalized_item
+    return _copy_group_with_pages(item, normalized_pages)
 
 
-def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
+def _absorb_known_item(item: MintlifyNavItem, collected: dict[str, MintlifyNavGroup]) -> bool:
     if isinstance(item, str):
         normalized_grpc = _normalized_grpc_ref(item)
         if normalized_grpc is not None:
             _merge_group_entries(
                 _upsert_group(collected, GRPC_GROUP),
-                {"group": GRPC_GROUP, "pages": [normalized_grpc]},
+                _nav_group(GRPC_GROUP, [normalized_grpc]),
             )
             return True
         if item == OPENAPI_PAGE_REF:
-            _merge_group_entries(_upsert_group(collected, OPENAPI_GROUP), {"group": OPENAPI_GROUP, "pages": [item]})
+            _merge_group_entries(_upsert_group(collected, OPENAPI_GROUP), _nav_group(OPENAPI_GROUP, [item]))
             return True
         elif item == ASYNCAPI_PAGE_REF:
-            _merge_group_entries(_upsert_group(collected, ASYNCAPI_GROUP), {"group": ASYNCAPI_GROUP, "pages": [item]})
+            _merge_group_entries(_upsert_group(collected, ASYNCAPI_GROUP), _nav_group(ASYNCAPI_GROUP, [item]))
             return True
         elif item == PROTOBUF_OVERVIEW_PAGE_REF:
-            _merge_group_entries(_upsert_group(collected, PROTOBUF_GROUP), {"group": PROTOBUF_GROUP, "pages": [item]})
+            _merge_group_entries(_upsert_group(collected, PROTOBUF_GROUP), _nav_group(PROTOBUF_GROUP, [item]))
             return True
         elif item in {BINDINGS_OVERVIEW_PAGE_REF, LEGACY_BINDINGS_OVERVIEW_PAGE_REF}:
             _merge_group_entries(
                 _upsert_group(collected, BINDINGS_GROUP),
-                {"group": BINDINGS_GROUP, "pages": [BINDINGS_OVERVIEW_PAGE_REF]},
+                _nav_group(BINDINGS_GROUP, [BINDINGS_OVERVIEW_PAGE_REF]),
             )
             return True
         elif item.startswith(JAVADOC_PREFIX):
             _merge_group_entries(
                 _upsert_group(collected, BINDINGS_GROUP),
-                {"group": BINDINGS_GROUP, "pages": [{"group": "Javadocs", "pages": [item]}]},
+                _nav_group(BINDINGS_GROUP, [_nav_group("Javadocs", [item])]),
             )
             return True
         return False
@@ -247,7 +269,7 @@ def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
         return True
 
     if label in PROTOBUF_GROUP_ALIASES:
-        normalized = {"group": PROTOBUF_GROUP, "pages": []}
+        normalized = _nav_group(PROTOBUF_GROUP, [])
         _merge_group_entries(normalized, item)
         _merge_group_entries(_upsert_group(collected, PROTOBUF_GROUP), normalized)
         return True
@@ -257,8 +279,11 @@ def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
         if normalized_item is None:
             _upsert_group(collected, BINDINGS_GROUP)
         else:
-            normalized = {"group": BINDINGS_GROUP, "pages": []}
-            _merge_group_entries(normalized, normalized_item)
+            normalized = _nav_group(BINDINGS_GROUP, [])
+            if isinstance(normalized_item, dict):
+                _merge_group_entries(normalized, normalized_item)
+            else:
+                _merge_group_entries(normalized, _nav_group(BINDINGS_GROUP, [normalized_item]))
             _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), normalized)
         return True
 
@@ -268,13 +293,13 @@ def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
             return _absorb_grpc_pages(pages, collected)
 
     if label in LANGUAGE_GROUPS:
-        _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), {"group": BINDINGS_GROUP, "pages": [item]})
+        _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), _nav_group(BINDINGS_GROUP, [item]))
         return True
 
     return False
 
 
-def navigation_pages(docs: dict[str, Any], *, label: str, docs_json_path: Path) -> list[Any]:
+def navigation_pages(docs: JsonObject, *, label: str, docs_json_path: Path) -> MintlifyNavItems:
     navigation = docs.get("navigation")
     if not isinstance(navigation, dict):
         raise ValueError(f"docs.json missing navigation object: {docs_json_path}")
@@ -290,7 +315,7 @@ def navigation_pages(docs: dict[str, Any], *, label: str, docs_json_path: Path) 
         pages = dropdown.get("pages")
         if not isinstance(pages, list):
             raise ValueError(f"Dropdown does not expose a pages list: {label}")
-        return pages
+        return cast(MintlifyNavItems, pages)
 
     products = navigation.get("products")
     if isinstance(products, list):
@@ -303,7 +328,7 @@ def navigation_pages(docs: dict[str, Any], *, label: str, docs_json_path: Path) 
         pages = product.get("pages")
         if not isinstance(pages, list):
             raise ValueError(f"Product does not expose a pages list: {label}")
-        return pages
+        return cast(MintlifyNavItems, pages)
 
     raise ValueError(f"docs.json navigation must define dropdowns or products: {docs_json_path}")
 
@@ -319,9 +344,9 @@ def regroup_ledger_api_nav(*, docs_json_path: Path, dropdown_label: str) -> None
         *PROTOBUF_GROUP_ALIASES,
         *BINDINGS_GROUP_ALIASES,
     }
-    collected: dict[str, dict[str, Any]] = {}
-    preserved_ledger_children: list[Any] = []
-    remaining: list[Any] = []
+    collected: dict[str, MintlifyNavGroup] = {}
+    preserved_ledger_children: MintlifyNavItems = []
+    remaining: MintlifyNavItems = []
     insert_at: int | None = None
 
     for index, item in enumerate(pages):
@@ -344,13 +369,11 @@ def regroup_ledger_api_nav(*, docs_json_path: Path, dropdown_label: str) -> None
     if not collected:
         return
 
-    parent_group = {
-        "group": LEDGER_API_PARENT_GROUP,
-        "pages": [
-            *preserved_ledger_children,
-            *[collected[label] for label in LEDGER_API_CHILD_ORDER if label in collected],
-        ],
-    }
+    parent_pages: MintlifyNavItems = [
+        *preserved_ledger_children,
+        *[collected[label] for label in LEDGER_API_CHILD_ORDER if label in collected],
+    ]
+    parent_group = _nav_group(LEDGER_API_PARENT_GROUP, parent_pages)
 
     if insert_at is None:
         remaining.append(parent_group)

--- a/src/x2mdx/asyncapi/lifecycle.py
+++ b/src/x2mdx/asyncapi/lifecycle.py
@@ -5,17 +5,28 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from typing import Any
+from typing import cast
 
 import yaml
 
-from x2mdx.asyncapi.models import AsyncApiChannelLifecycle, AsyncApiReport, AsyncApiSourceSnapshot
+from x2mdx.asyncapi.models import (
+    AsyncApiActionDetail,
+    AsyncApiChannelDetail,
+    AsyncApiChannelHistory,
+    AsyncApiDocument,
+    AsyncApiChannelLifecycle,
+    AsyncApiMessageDetail,
+    AsyncApiReport,
+    AsyncApiSourceSnapshot,
+)
+from x2mdx.types import JsonObject, JsonValue
 
 REQUEST_SAMPLE_MAX_DEPTH = 4
 REQUEST_SAMPLE_MAX_PROPERTIES = 8
+AsyncApiChannelsByName = dict[str, AsyncApiChannelDetail]
 
 
-def sha256_json(value: Any) -> str:
+def sha256_json(value: object) -> str:
     payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -32,13 +43,13 @@ def version_key(version: str) -> tuple[tuple[int, int | str], ...]:
     return tuple(key)
 
 
-def parse_asyncapi(raw_text: str) -> dict[str, Any]:
+def parse_asyncapi(raw_text: str) -> AsyncApiDocument:
     obj = yaml.safe_load(raw_text)
     if not isinstance(obj, dict):
         raise ValueError("AsyncAPI document is not an object")
     if "asyncapi" not in obj:
         raise ValueError("Document does not contain top-level `asyncapi` key")
-    return obj
+    return cast(AsyncApiDocument, obj)
 
 
 def slugify(value: str) -> str:
@@ -52,7 +63,7 @@ def channel_anchor(channel: str) -> str:
     return f"channel-{slugify(channel)}"
 
 
-def normalize_lifecycle_state(value: Any) -> str | None:
+def normalize_lifecycle_state(value: object) -> str | None:
     if not isinstance(value, str):
         return None
     normalized = value.strip().lower()
@@ -61,14 +72,14 @@ def normalize_lifecycle_state(value: Any) -> str | None:
     return None
 
 
-def resolve_local_ref(doc: dict[str, Any], node: Any, max_depth: int = 8) -> Any:
+def resolve_local_ref(doc: AsyncApiDocument, node: JsonValue | None, max_depth: int = 8) -> JsonValue | None:
     current = node
     depth = 0
     while isinstance(current, dict) and "$ref" in current and depth < max_depth:
         ref = current["$ref"]
         if not isinstance(ref, str) or not ref.startswith("#/"):
             break
-        target: Any = doc
+        target = cast(JsonValue, doc)
         valid = True
         for part in ref[2:].split("/"):
             if isinstance(target, dict) and part in target:
@@ -83,7 +94,7 @@ def resolve_local_ref(doc: dict[str, Any], node: Any, max_depth: int = 8) -> Any
     return current
 
 
-def local_ref_name(node: Any, *, prefix: str) -> str | None:
+def local_ref_name(node: JsonValue | None, *, prefix: str) -> str | None:
     if not isinstance(node, dict):
         return None
     ref = node.get("$ref")
@@ -96,11 +107,11 @@ def local_ref_name(node: Any, *, prefix: str) -> str | None:
 
 
 def object_schema_properties_and_required(
-    doc: dict[str, Any],
-    schema: Any,
+    doc: AsyncApiDocument,
+    schema: JsonValue | None,
     *,
     max_depth: int = 6,
-) -> tuple[dict[str, Any], set[str]]:
+) -> tuple[JsonObject, set[str]]:
     if max_depth <= 0:
         return {}, set()
 
@@ -108,7 +119,7 @@ def object_schema_properties_and_required(
     if not isinstance(resolved, dict):
         return {}, set()
 
-    properties: dict[str, Any] = {}
+    properties: JsonObject = {}
     required: set[str] = set()
 
     all_of = resolved.get("allOf")
@@ -133,7 +144,7 @@ def object_schema_properties_and_required(
     return properties, required
 
 
-def schema_required_field_names(doc: dict[str, Any], schema: Any) -> list[str]:
+def schema_required_field_names(doc: AsyncApiDocument, schema: JsonValue | None) -> list[str]:
     properties, required = object_schema_properties_and_required(doc, schema)
     if not required:
         return []
@@ -143,7 +154,7 @@ def schema_required_field_names(doc: dict[str, Any], schema: Any) -> list[str]:
     return [*known, *unknown]
 
 
-def schema_brief(doc: dict[str, Any], schema: Any) -> str:
+def schema_brief(doc: AsyncApiDocument, schema: JsonValue | None) -> str:
     resolved = resolve_local_ref(doc, schema)
     if not isinstance(resolved, dict):
         return "-"
@@ -165,7 +176,7 @@ def schema_brief(doc: dict[str, Any], schema: Any) -> str:
     return "-"
 
 
-def schema_type_token(doc: dict[str, Any], schema: Any) -> Any:
+def schema_type_token(doc: AsyncApiDocument, schema: JsonValue | None) -> JsonValue:
     resolved = resolve_local_ref(doc, schema)
     if not isinstance(resolved, dict):
         return "<value>"
@@ -198,14 +209,14 @@ def schema_type_token(doc: dict[str, Any], schema: Any) -> Any:
 
 
 def schema_sample_value(
-    doc: dict[str, Any],
-    schema: Any,
+    doc: AsyncApiDocument,
+    schema: JsonValue | None,
     *,
     max_depth: int = REQUEST_SAMPLE_MAX_DEPTH,
     max_properties: int = REQUEST_SAMPLE_MAX_PROPERTIES,
     required_only: bool = True,
     seen_refs: set[str] | None = None,
-) -> Any:
+) -> JsonValue:
     if max_depth <= 0:
         return schema_type_token(doc, schema)
 
@@ -262,7 +273,7 @@ def schema_sample_value(
         if not names_to_render and unknown_required_names:
             names_to_render = unknown_required_names
 
-        sample: dict[str, Any] = {}
+        sample: JsonObject = {}
         for name in names_to_render[:max_properties]:
             if name in properties:
                 sample[name] = schema_sample_value(
@@ -301,7 +312,7 @@ def schema_sample_value(
     return schema_type_token(doc, resolved)
 
 
-def extract_message_detail(doc: dict[str, Any], message_node: Any) -> dict[str, Any]:
+def extract_message_detail(doc: AsyncApiDocument, message_node: JsonValue | None) -> AsyncApiMessageDetail:
     resolved_message = resolve_local_ref(doc, message_node)
     message_name = local_ref_name(message_node, prefix="components/messages")
     if not isinstance(resolved_message, dict):
@@ -323,7 +334,7 @@ def extract_message_detail(doc: dict[str, Any], message_node: Any) -> dict[str, 
     }
 
 
-def extract_action_detail(doc: dict[str, Any], action_name: str, action_node: Any) -> dict[str, Any]:
+def extract_action_detail(doc: AsyncApiDocument, action_name: str, action_node: JsonValue | None) -> AsyncApiActionDetail:
     resolved_action = resolve_local_ref(doc, action_node)
     if not isinstance(resolved_action, dict):
         return {
@@ -350,12 +361,12 @@ def extract_action_detail(doc: dict[str, Any], action_name: str, action_node: An
     }
 
 
-def extract_channel_detail(doc: dict[str, Any], channel_name: str, channel_node: Any) -> dict[str, Any]:
+def extract_channel_detail(doc: AsyncApiDocument, channel_name: str, channel_node: JsonValue | None) -> AsyncApiChannelDetail:
     resolved_channel = resolve_local_ref(doc, channel_node)
     if not isinstance(resolved_channel, dict):
         resolved_channel = {}
 
-    actions: list[dict[str, Any]] = []
+    actions: list[AsyncApiActionDetail] = []
     for action_name in ("publish", "subscribe"):
         if action_name in resolved_channel:
             actions.append(extract_action_detail(doc, action_name, resolved_channel[action_name]))
@@ -375,7 +386,12 @@ def render_name_list(names: list[str]) -> str:
     return ", ".join(f"`{name}`" for name in names)
 
 
-def describe_action_changes(previous: dict[str, Any] | None, current: dict[str, Any] | None, *, action_name: str) -> list[str]:
+def describe_action_changes(
+    previous: AsyncApiActionDetail | None,
+    current: AsyncApiActionDetail | None,
+    *,
+    action_name: str,
+) -> list[str]:
     if previous is None and current is None:
         return []
     label = action_name
@@ -420,7 +436,7 @@ def describe_action_changes(previous: dict[str, Any] | None, current: dict[str, 
     return changes
 
 
-def describe_channel_changes(previous: dict[str, Any], current: dict[str, Any]) -> list[str]:
+def describe_channel_changes(previous: AsyncApiChannelDetail, current: AsyncApiChannelDetail) -> list[str]:
     changes: list[str] = []
     if previous["description"] != current["description"]:
         changes.append("channel description updated")
@@ -442,12 +458,12 @@ def describe_channel_changes(previous: dict[str, Any], current: dict[str, Any]) 
     return changes
 
 
-def collect_snapshot_channels(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def collect_snapshot_channels(document: AsyncApiDocument) -> AsyncApiChannelsByName:
     channels = document.get("channels")
     if not isinstance(channels, dict):
         return {}
 
-    details: dict[str, dict[str, Any]] = {}
+    details: AsyncApiChannelsByName = {}
     for channel_name in sorted(channels):
         details[channel_name] = extract_channel_detail(document, channel_name, channels[channel_name])
     return details
@@ -474,11 +490,11 @@ def build_asyncapi_report_from_sources(
     publish_index = ordered_versions.index(selected_publish_version)
     scoped_sources = ordered_sources[: publish_index + 1]
 
-    snapshot_channels: dict[str, dict[str, dict[str, Any]]] = {}
+    snapshot_channels: dict[str, AsyncApiChannelsByName] = {}
     for snapshot in scoped_sources:
         snapshot_channels[snapshot.version] = collect_snapshot_channels(snapshot.document)
 
-    channel_history: dict[str, dict[str, Any]] = {}
+    channel_history: dict[str, AsyncApiChannelHistory] = {}
     for snapshot in scoped_sources:
         current_channels = snapshot_channels[snapshot.version]
         for channel_name, channel_detail in current_channels.items():

--- a/src/x2mdx/asyncapi/models.py
+++ b/src/x2mdx/asyncapi/models.py
@@ -3,14 +3,62 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TypedDict
+
+from x2mdx.types import JsonObject, JsonValue
+
+
+class AsyncApiDocument(TypedDict, total=False):
+    asyncapi: str
+    info: JsonObject
+    channels: dict[str, JsonValue]
+    components: JsonObject
+
+
+class AsyncApiMessageDetail(TypedDict):
+    name: str
+    content_type: str
+    payload_schema: str
+    required_fields: list[str]
+    sample: JsonValue | None
+
+
+class AsyncApiActionDetail(TypedDict):
+    action: str
+    operation_id: str
+    description: str
+    ws_method: str
+    message: AsyncApiMessageDetail
+
+
+class AsyncApiChannelDetail(TypedDict):
+    channel: str
+    anchor: str
+    description: str
+    lifecycle_state: str | None
+    replaces: str | None
+    actions: list[AsyncApiActionDetail]
+    action_names: list[str]
+
+
+class AsyncApiChangeDetail(TypedDict):
+    version: str
+    changes: list[str]
+
+
+class AsyncApiChannelHistory(TypedDict):
+    versions: list[str]
+    details: dict[str, AsyncApiChannelDetail]
+    fingerprints: dict[str, str]
+    changed_in: list[str]
+    change_details: list[AsyncApiChangeDetail]
 
 
 @dataclass(frozen=True)
 class AsyncApiSourceSnapshot:
     version: str
     source_path: str
-    document: dict[str, Any]
+    document: AsyncApiDocument
 
 
 @dataclass(frozen=True)
@@ -19,13 +67,13 @@ class AsyncApiChannelLifecycle:
     anchor: str
     introduced_version: str
     changed_in_versions: list[str]
-    change_details: list[dict[str, Any]]
+    change_details: list[AsyncApiChangeDetail]
     removed_version: str | None
     last_seen_in: str
     status: str
     lifecycle_state: str | None
     replaces: str | None
-    latest: dict[str, Any]
+    latest: AsyncApiChannelDetail
 
 
 @dataclass(frozen=True)

--- a/src/x2mdx/asyncapi/snapshots.py
+++ b/src/x2mdx/asyncapi/snapshots.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
 from x2mdx.asyncapi.lifecycle import parse_asyncapi, version_key
 from x2mdx.asyncapi.models import AsyncApiSourceSnapshot
+from x2mdx.types import JsonObject, JsonValue
 
 
-def _load_data(path: Path) -> Any:
+def _load_data(path: Path) -> JsonValue:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
-        return json.loads(raw)
-    return yaml.safe_load(raw)
+        return cast(JsonValue, json.loads(raw))
+    return cast(JsonValue, yaml.safe_load(raw))
 
 
-def load_snapshot_manifest(path: Path) -> dict[str, Any]:
+def load_snapshot_manifest(path: Path) -> JsonObject:
     data = _load_data(path)
     if not isinstance(data, dict):
         raise ValueError("Snapshot manifest must be a JSON/YAML object")
     versions = data.get("versions")
     if not isinstance(versions, list):
         raise ValueError("Snapshot manifest must include a `versions` list")
-    return data
+    return cast(JsonObject, data)
 
 
 def load_asyncapi_source_snapshots(
@@ -67,4 +68,3 @@ def load_asyncapi_source_snapshots(
 
     snapshots.sort(key=lambda snapshot: version_key(snapshot.version))
     return snapshots
-

--- a/src/x2mdx/daml_json/models.py
+++ b/src/x2mdx/daml_json/models.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+
+from x2mdx.types import JsonObject
+
+DamlJsonModule = JsonObject
 
 
 @dataclass(frozen=True)
 class DamlDocsSnapshot:
     version: str
     json_path: str
-    modules: list[dict[str, Any]]
+    modules: list[DamlJsonModule]
 
 
 @dataclass(frozen=True)
@@ -26,7 +29,6 @@ class DamlDocsReport:
     version_filter: str
     publish_version: str
     versions: list[str]
-    modules: list[dict[str, Any]]
+    modules: list[DamlJsonModule]
     module_lifecycle: dict[str, dict[str, str | None]]
     module_deprecation_first_seen: dict[str, str]
-

--- a/src/x2mdx/daml_json/snapshots.py
+++ b/src/x2mdx/daml_json/snapshots.py
@@ -4,33 +4,34 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
-from x2mdx.daml_json.models import DamlDocsSnapshot, DamlDocsSources
+from x2mdx.daml_json.models import DamlDocsSnapshot, DamlDocsSources, DamlJsonModule
+from x2mdx.types import JsonObject
 
 
-def _load_manifest(path: Path) -> dict[str, Any]:
+def _load_manifest(path: Path) -> JsonObject:
     if path.suffix.lower() in {".yaml", ".yml"}:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     else:
         payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected object at manifest root: {path}")
-    return payload
+    return cast(JsonObject, payload)
 
 
-def _load_modules(path: Path) -> list[dict[str, Any]]:
+def _load_modules(path: Path) -> list[DamlJsonModule]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(payload, dict):
         payload = [payload]
     if not isinstance(payload, list):
         raise ValueError(f"Expected top-level JSON list or object in {path}")
-    modules: list[dict[str, Any]] = []
+    modules: list[DamlJsonModule] = []
     for item in payload:
         if isinstance(item, dict):
-            modules.append(item)
+            modules.append(cast(DamlJsonModule, item))
     return modules
 
 
@@ -81,4 +82,3 @@ def load_daml_doc_sources(
         publish_version=publish_version,
         source=manifest.get("source") if isinstance(manifest.get("source"), str) else None,
     )
-

--- a/src/x2mdx/jvm_docs/snapshots.py
+++ b/src/x2mdx/jvm_docs/snapshots.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
 from x2mdx.jvm_docs.lifecycle import version_key
 from x2mdx.jvm_docs.models import JvmDocArtifactSource, JvmDocVersionSource, JVM_DOC_OBJECT_STATUSES
+from x2mdx.types import JsonObject, JsonValue
 
 
-def _load_data(path: Path) -> Any:
+def _load_data(path: Path) -> JsonValue:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
-        return json.loads(raw)
-    return yaml.safe_load(raw)
+        return cast(JsonValue, json.loads(raw))
+    return cast(JsonValue, yaml.safe_load(raw))
 
 
-def load_jvm_doc_manifest(path: Path) -> dict[str, Any]:
+def load_jvm_doc_manifest(path: Path) -> JsonObject:
     data = _load_data(path)
     if not isinstance(data, dict):
         raise ValueError("JVM doc manifest must be a JSON/YAML object")
     artifacts = data.get("artifacts")
     if not isinstance(artifacts, list):
         raise ValueError("JVM doc manifest must include an `artifacts` list")
-    return data
+    return cast(JsonObject, data)
 
 
 def load_jvm_doc_status_manifest(path: Path) -> dict[str, str]:

--- a/src/x2mdx/mintlify.py
+++ b/src/x2mdx/mintlify.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 from x2mdx.output import Page
 from x2mdx.render import write_pages
+from x2mdx.types import JsonArray, JsonObject, JsonValue, MintlifyNavGroup, MintlifyNavItems
 
 
 @dataclass(frozen=True)
 class MintlifyGroup:
     group: str
-    pages: list[Any]
+    pages: MintlifyNavItems | list["MintlifyGroup"]
     expanded: bool | None = None
 
 
@@ -25,8 +26,8 @@ class MintlifyNavTarget:
     versions: list[str] | None = None
 
 
-def _group_to_json(group: MintlifyGroup) -> dict[str, Any]:
-    payload: dict[str, Any] = {
+def _group_to_json(group: MintlifyGroup) -> MintlifyNavGroup:
+    payload: MintlifyNavGroup = {
         "group": group.group,
         "pages": [
             _group_to_json(item) if isinstance(item, MintlifyGroup) else item
@@ -64,12 +65,13 @@ def write_docs_json(
     return target
 
 
-def _remove_page_reference(node: Any, page_ref: str) -> None:
+def _remove_page_reference(node: JsonValue, page_ref: str) -> None:
     if isinstance(node, dict):
         pages = node.get("pages")
         if isinstance(pages, list):
-            node["pages"] = [item for item in pages if item != page_ref]
-            for item in node["pages"]:
+            filtered_pages: JsonArray = [item for item in pages if item != page_ref]
+            node["pages"] = filtered_pages
+            for item in filtered_pages:
                 _remove_page_reference(item, page_ref)
         for value in node.values():
             if value is not pages:
@@ -79,30 +81,39 @@ def _remove_page_reference(node: Any, page_ref: str) -> None:
             _remove_page_reference(item, page_ref)
 
 
-def _find_group(groups: list[dict[str, Any]], label: str) -> dict[str, Any] | None:
+def _find_group(groups: JsonArray, label: str) -> JsonObject | None:
     for item in groups:
         if isinstance(item, dict) and item.get("group") == label:
             return item
     return None
 
 
-def _ensure_group_path(container: dict[str, Any], group_path: list[str]) -> list[Any]:
-    if not group_path:
-        return container.setdefault("pages", [])
+def _ensure_list_field(container: JsonObject, key: str) -> JsonArray:
+    value = container.get(key)
+    if isinstance(value, list):
+        return value
+    value = []
+    container[key] = value
+    return value
 
-    current_groups = container.setdefault("groups", [])
-    current: dict[str, Any] | None = None
+
+def _ensure_group_path(container: JsonObject, group_path: list[str]) -> JsonArray:
+    if not group_path:
+        return _ensure_list_field(container, "pages")
+
+    current_groups = _ensure_list_field(container, "groups")
+    current: JsonObject | None = None
     for index, label in enumerate(group_path):
         current = _find_group(current_groups, label)
         if current is None:
             current = {"group": label, "pages": []}
             current_groups.append(current)
         if index < len(group_path) - 1:
-            current_groups = current.setdefault("groups", [])
-    return current.setdefault("pages", []) if current is not None else container.setdefault("pages", [])
+            current_groups = _ensure_list_field(current, "groups")
+    return _ensure_list_field(current, "pages") if current is not None else _ensure_list_field(container, "pages")
 
 
-def _prune_empty_groups(node: Any) -> None:
+def _prune_empty_groups(node: JsonValue) -> None:
     if isinstance(node, dict):
         for value in list(node.values()):
             _prune_empty_groups(value)
@@ -130,9 +141,12 @@ def update_docs_json_navigation(
     output_file: Path,
     target: MintlifyNavTarget,
 ) -> Path:
-    docs = json.loads(docs_json_path.read_text(encoding="utf-8"))
+    docs = cast(JsonObject, json.loads(docs_json_path.read_text(encoding="utf-8")))
     page_ref = docs_json_page_ref(output_file, docs_json_path)
-    navigation = docs.setdefault("navigation", {})
+    navigation = docs.get("navigation")
+    if not isinstance(navigation, dict):
+        navigation = {}
+        docs["navigation"] = navigation
     dropdowns = navigation.get("dropdowns")
     if not isinstance(dropdowns, list):
         raise ValueError("docs.json navigation.dropdowns must be present")
@@ -149,9 +163,11 @@ def update_docs_json_navigation(
     versions = dropdown.get("versions")
     if isinstance(versions, list):
         version_names = target.versions or [
-            item.get("version")
+            version
             for item in versions
-            if isinstance(item, dict) and item.get("version")
+            if isinstance(item, dict)
+            and isinstance(version := item.get("version"), str)
+            and version
         ]
         for version_name in version_names:
             version_entry = next(

--- a/src/x2mdx/openrpc/lifecycle.py
+++ b/src/x2mdx/openrpc/lifecycle.py
@@ -6,22 +6,32 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
 from x2mdx.openrpc.models import (
+    OpenRpcDocument,
+    OpenRpcMethodHistory,
     OpenRpcMethodLifecycle,
+    OpenRpcMethodDetail,
+    OpenRpcParamDetail,
     OpenRpcReport,
+    OpenRpcResultDetail,
     OpenRpcSourceSnapshot,
     OpenRpcSpecLifecycle,
+    OpenRpcValueDetail,
 )
+from x2mdx.types import JsonObject, JsonValue
 
 REQUEST_SAMPLE_MAX_DEPTH = 4
 REQUEST_SAMPLE_MAX_PROPERTIES = 8
+OpenRpcDocumentIndex = dict[str, OpenRpcDocument]
+OpenRpcVersionDocumentIndex = dict[str, OpenRpcDocumentIndex]
+OpenRpcMethodDetailsByName = dict[str, OpenRpcMethodDetail]
 
 
-def sha256_json(value: Any) -> str:
+def sha256_json(value: object) -> str:
     payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -40,13 +50,13 @@ def version_key(version: str) -> tuple[tuple[int, int | str], ...]:
     return tuple(key)
 
 
-def parse_openrpc(raw_text: str) -> dict[str, Any]:
+def parse_openrpc(raw_text: str) -> OpenRpcDocument:
     obj = yaml.safe_load(raw_text)
     if not isinstance(obj, dict):
         raise ValueError("OpenRPC document is not an object")
     if "openrpc" not in obj:
         raise ValueError("Document does not contain top-level `openrpc` key")
-    return obj
+    return cast(OpenRpcDocument, obj)
 
 
 def slugify(value: str) -> str:
@@ -60,7 +70,7 @@ def method_anchor(name: str) -> str:
     return f"method-{slugify(name)}"
 
 
-def normalize_lifecycle_state(value: Any) -> str | None:
+def normalize_lifecycle_state(value: object) -> str | None:
     if not isinstance(value, str):
         return None
     normalized = value.strip().lower()
@@ -73,8 +83,8 @@ def doc_lookup_key(source_path: str) -> str:
     return source_path.replace("\\", "/")
 
 
-def build_version_doc_index(snapshots: list[OpenRpcSourceSnapshot]) -> dict[str, dict[str, dict[str, Any]]]:
-    index: dict[str, dict[str, dict[str, Any]]] = {}
+def build_version_doc_index(snapshots: list[OpenRpcSourceSnapshot]) -> OpenRpcVersionDocumentIndex:
+    index: OpenRpcVersionDocumentIndex = {}
     for snapshot in snapshots:
         version_index = index.setdefault(snapshot.version, {})
         normalized = doc_lookup_key(snapshot.source_path)
@@ -84,8 +94,8 @@ def build_version_doc_index(snapshots: list[OpenRpcSourceSnapshot]) -> dict[str,
     return index
 
 
-def resolve_local_fragment(document: dict[str, Any], fragment: str) -> Any:
-    target: Any = document
+def resolve_local_fragment(document: OpenRpcDocument, fragment: str) -> JsonValue | None:
+    target = cast(JsonValue, document)
     for part in fragment.split("/"):
         if isinstance(target, dict) and part in target:
             target = target[part]
@@ -95,12 +105,12 @@ def resolve_local_fragment(document: dict[str, Any], fragment: str) -> Any:
 
 
 def resolve_ref(
-    doc_index: dict[str, dict[str, Any]],
+    doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-    node: Any,
+    node: JsonValue | None,
     *,
     max_depth: int = 8,
-) -> Any:
+) -> JsonValue | None:
     current = node
     current_doc_key = doc_lookup_key(current_source_path)
     depth = 0
@@ -133,7 +143,7 @@ def resolve_ref(
     return current
 
 
-def ref_schema_name(node: Any) -> str | None:
+def ref_schema_name(node: JsonValue | None) -> str | None:
     if not isinstance(node, dict):
         return None
     ref = node.get("$ref")
@@ -145,12 +155,12 @@ def ref_schema_name(node: Any) -> str | None:
 
 
 def object_schema_properties_and_required(
-    doc_index: dict[str, dict[str, Any]],
+    doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-    schema: Any,
+    schema: JsonValue | None,
     *,
     max_depth: int = 6,
-) -> tuple[dict[str, Any], set[str]]:
+) -> tuple[JsonObject, set[str]]:
     if max_depth <= 0:
         return {}, set()
 
@@ -158,7 +168,7 @@ def object_schema_properties_and_required(
     if not isinstance(resolved, dict):
         return {}, set()
 
-    properties: dict[str, Any] = {}
+    properties: JsonObject = {}
     required: set[str] = set()
 
     all_of = resolved.get("allOf")
@@ -184,7 +194,7 @@ def object_schema_properties_and_required(
     return properties, required
 
 
-def schema_required_field_names(doc_index: dict[str, dict[str, Any]], current_source_path: str, schema: Any) -> list[str]:
+def schema_required_field_names(doc_index: OpenRpcDocumentIndex, current_source_path: str, schema: JsonValue | None) -> list[str]:
     properties, required = object_schema_properties_and_required(doc_index, current_source_path, schema)
     if not required:
         return []
@@ -193,7 +203,7 @@ def schema_required_field_names(doc_index: dict[str, dict[str, Any]], current_so
     return [*known, *unknown]
 
 
-def schema_brief(doc_index: dict[str, dict[str, Any]], current_source_path: str, schema: Any) -> str:
+def schema_brief(doc_index: OpenRpcDocumentIndex, current_source_path: str, schema: JsonValue | None) -> str:
     resolved = resolve_ref(doc_index, current_source_path, schema)
     if not isinstance(resolved, dict):
         return "-"
@@ -213,7 +223,7 @@ def schema_brief(doc_index: dict[str, dict[str, Any]], current_source_path: str,
     return "-"
 
 
-def schema_type_token(doc_index: dict[str, dict[str, Any]], current_source_path: str, schema: Any) -> Any:
+def schema_type_token(doc_index: OpenRpcDocumentIndex, current_source_path: str, schema: JsonValue | None) -> JsonValue:
     resolved = resolve_ref(doc_index, current_source_path, schema)
     if not isinstance(resolved, dict):
         return "<value>"
@@ -245,14 +255,14 @@ def schema_type_token(doc_index: dict[str, dict[str, Any]], current_source_path:
 
 
 def schema_sample_value(
-    doc_index: dict[str, dict[str, Any]],
+    doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-    schema: Any,
+    schema: JsonValue | None,
     *,
     max_depth: int = REQUEST_SAMPLE_MAX_DEPTH,
     max_properties: int = REQUEST_SAMPLE_MAX_PROPERTIES,
     required_only: bool = True,
-) -> Any:
+) -> JsonValue:
     if max_depth <= 0:
         return schema_type_token(doc_index, current_source_path, schema)
 
@@ -297,7 +307,7 @@ def schema_sample_value(
         if not names_to_render and unknown_required_names:
             names_to_render = unknown_required_names
 
-        sample: dict[str, Any] = {}
+        sample: JsonObject = {}
         for name in names_to_render[:max_properties]:
             if name in properties:
                 sample[name] = schema_sample_value(
@@ -336,10 +346,10 @@ def schema_sample_value(
 
 
 def extract_param_detail(
-    doc_index: dict[str, dict[str, Any]],
+    doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-    param: dict[str, Any],
-) -> dict[str, Any]:
+    param: JsonObject,
+) -> OpenRpcParamDetail:
     schema = param.get("schema")
     return {
         "name": str(param.get("name") or ""),
@@ -352,10 +362,10 @@ def extract_param_detail(
 
 
 def extract_result_detail(
-    doc_index: dict[str, dict[str, Any]],
+    doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-    result: dict[str, Any] | None,
-) -> dict[str, Any]:
+    result: JsonValue | None,
+) -> OpenRpcResultDetail:
     if not isinstance(result, dict):
         return {
             "name": "",
@@ -377,16 +387,16 @@ def extract_result_detail(
 
 
 def extract_method_detail(
-    document: dict[str, Any],
+    document: OpenRpcDocument,
     *,
-    doc_index: dict[str, dict[str, Any]],
+    doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-) -> dict[str, dict[str, Any]]:
+) -> OpenRpcMethodDetailsByName:
     methods = document.get("methods")
     if not isinstance(methods, list):
         return {}
 
-    details: dict[str, dict[str, Any]] = {}
+    details: OpenRpcMethodDetailsByName = {}
     for method in methods:
         if not isinstance(method, dict):
             continue
@@ -396,7 +406,7 @@ def extract_method_detail(
         params = method.get("params")
         if not isinstance(params, list):
             params = []
-        detail = {
+        detail: OpenRpcMethodDetail = {
             "name": name,
             "anchor": method_anchor(name),
             "summary": str(method.get("summary") or ""),
@@ -405,6 +415,7 @@ def extract_method_detail(
             "replaces": str(method.get("x-replaces")) if isinstance(method.get("x-replaces"), str) else None,
             "params": [extract_param_detail(doc_index, current_source_path, param) for param in params if isinstance(param, dict)],
             "result": extract_result_detail(doc_index, current_source_path, method.get("result")),
+            "fingerprint": "",
         }
         detail["fingerprint"] = sha256_json(
             {
@@ -424,7 +435,7 @@ def render_name_list(names: list[str]) -> str:
     return ", ".join(f"`{name}`" for name in names)
 
 
-def describe_param_changes(previous: dict[str, Any], current: dict[str, Any]) -> list[str]:
+def describe_param_changes(previous: OpenRpcValueDetail, current: OpenRpcValueDetail) -> list[str]:
     changes: list[str] = []
     if previous["description"] != current["description"]:
         changes.append("description")
@@ -437,7 +448,7 @@ def describe_param_changes(previous: dict[str, Any], current: dict[str, Any]) ->
     return changes
 
 
-def describe_method_changes(previous: dict[str, Any], current: dict[str, Any]) -> list[str]:
+def describe_method_changes(previous: OpenRpcMethodDetail, current: OpenRpcMethodDetail) -> list[str]:
     changes: list[str] = []
     if previous["summary"] != current["summary"]:
         changes.append("summary updated")
@@ -511,7 +522,7 @@ def build_openrpc_report_from_sources(
         versions_present = [snapshot.version for snapshot in spec_snapshots]
         display_name = spec_snapshots[-1].display_name
 
-        per_version_methods: dict[str, dict[str, dict[str, Any]]] = {}
+        per_version_methods: dict[str, OpenRpcMethodDetailsByName] = {}
         for snapshot in spec_snapshots:
             per_version_methods[snapshot.version] = extract_method_detail(
                 snapshot.document,
@@ -519,7 +530,7 @@ def build_openrpc_report_from_sources(
                 current_source_path=snapshot.source_path,
             )
 
-        method_history: dict[str, dict[str, Any]] = {}
+        method_history: dict[str, OpenRpcMethodHistory] = {}
         for snapshot in spec_snapshots:
             current_methods = per_version_methods[snapshot.version]
             for method_name, method_detail in current_methods.items():

--- a/src/x2mdx/openrpc/models.py
+++ b/src/x2mdx/openrpc/models.py
@@ -3,7 +3,54 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TypedDict
+
+from x2mdx.types import JsonObject, JsonValue
+
+
+class OpenRpcDocument(TypedDict, total=False):
+    openrpc: str
+    info: JsonObject
+    methods: list[JsonObject]
+    components: JsonObject
+
+
+class OpenRpcValueDetail(TypedDict):
+    name: str
+    description: str
+    schema_name: str | None
+    schema: str
+    required_fields: list[str]
+    sample: JsonValue | None
+
+
+OpenRpcParamDetail = OpenRpcValueDetail
+OpenRpcResultDetail = OpenRpcValueDetail
+
+
+class OpenRpcMethodDetail(TypedDict):
+    name: str
+    anchor: str
+    summary: str
+    description: str
+    lifecycle_state: str | None
+    replaces: str | None
+    params: list[OpenRpcParamDetail]
+    result: OpenRpcResultDetail
+    fingerprint: str
+
+
+class OpenRpcChangeDetail(TypedDict):
+    version: str
+    changes: list[str]
+
+
+class OpenRpcMethodHistory(TypedDict):
+    versions: list[str]
+    details: dict[str, OpenRpcMethodDetail]
+    fingerprints: dict[str, str]
+    changed_in: list[str]
+    change_details: list[OpenRpcChangeDetail]
 
 
 @dataclass(frozen=True)
@@ -12,7 +59,7 @@ class OpenRpcSourceSnapshot:
     spec_id: str
     display_name: str
     source_path: str
-    document: dict[str, Any]
+    document: OpenRpcDocument
 
 
 @dataclass(frozen=True)
@@ -21,13 +68,13 @@ class OpenRpcMethodLifecycle:
     anchor: str
     introduced_version: str
     changed_in_versions: list[str]
-    change_details: list[dict[str, Any]]
+    change_details: list[OpenRpcChangeDetail]
     removed_version: str | None
     last_seen_in: str
     status: str
     lifecycle_state: str | None
     replaces: str | None
-    latest: dict[str, Any]
+    latest: OpenRpcMethodDetail
 
 
 @dataclass(frozen=True)

--- a/src/x2mdx/openrpc/snapshots.py
+++ b/src/x2mdx/openrpc/snapshots.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
 from x2mdx.openrpc.lifecycle import parse_openrpc, version_key
 from x2mdx.openrpc.models import OpenRpcSourceSnapshot
+from x2mdx.types import JsonObject, JsonValue
 
 
-def _load_data(path: Path) -> Any:
+def _load_data(path: Path) -> JsonValue:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
-        return json.loads(raw)
-    return yaml.safe_load(raw)
+        return cast(JsonValue, json.loads(raw))
+    return cast(JsonValue, yaml.safe_load(raw))
 
 
-def load_snapshot_manifest(path: Path) -> dict[str, Any]:
+def load_snapshot_manifest(path: Path) -> JsonObject:
     data = _load_data(path)
     if not isinstance(data, dict):
         raise ValueError("Snapshot manifest must be a JSON/YAML object")
     specs = data.get("specs")
     if not isinstance(specs, list):
         raise ValueError("Snapshot manifest must include a `specs` list")
-    return data
+    return cast(JsonObject, data)
 
 
 def load_openrpc_source_snapshots(
@@ -83,4 +84,3 @@ def load_openrpc_source_snapshots(
 
     snapshots.sort(key=lambda snapshot: (version_key(snapshot.version), snapshot.spec_id))
     return snapshots
-

--- a/src/x2mdx/protobuf/models.py
+++ b/src/x2mdx/protobuf/models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+
+from x2mdx.types import JsonObject
 
 
 @dataclass(frozen=True)
@@ -21,5 +22,4 @@ class ProtobufSources:
     source: str | None = None
     repo_remote: str | None = None
     repo_web_url: str | None = None
-    metadata_overlay: dict[str, Any] | None = None
-
+    metadata_overlay: JsonObject | None = None

--- a/src/x2mdx/protobuf/snapshots.py
+++ b/src/x2mdx/protobuf/snapshots.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
 from x2mdx.protobuf.models import ProtobufSourceSnapshot, ProtobufSources
+from x2mdx.types import JsonObject
 
 DEFAULT_METADATA_SHAPE = {
     "schemaVersion": 1,
@@ -22,18 +23,18 @@ DEFAULT_METADATA_SHAPE = {
 }
 
 
-def _load_manifest(path: Path) -> dict[str, Any]:
+def _load_manifest(path: Path) -> JsonObject:
     if path.suffix.lower() in {".yaml", ".yml"}:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     else:
         payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected object at manifest root: {path}")
-    return payload
+    return cast(JsonObject, payload)
 
 
-def _load_metadata_overlay(path: Path | None) -> dict[str, Any]:
-    data = json.loads(json.dumps(DEFAULT_METADATA_SHAPE))
+def _load_metadata_overlay(path: Path | None) -> JsonObject:
+    data = cast(JsonObject, json.loads(json.dumps(DEFAULT_METADATA_SHAPE)))
     if path is None or not path.exists():
         return data
     raw = json.loads(path.read_text(encoding="utf-8"))
@@ -103,7 +104,8 @@ def load_protobuf_sources(
         if not resolved_metadata_path.is_absolute():
             resolved_metadata_path = manifest_root / resolved_metadata_path
 
-    repo = manifest.get("repo") if isinstance(manifest.get("repo"), dict) else {}
+    raw_repo = manifest.get("repo")
+    repo: JsonObject = raw_repo if isinstance(raw_repo, dict) else {}
     return ProtobufSources(
         snapshots=snapshots,
         source=manifest.get("source") if isinstance(manifest.get("source"), str) else None,

--- a/src/x2mdx/typedoc/models.py
+++ b/src/x2mdx/typedoc/models.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+
+from x2mdx.types import JsonObject
+
+TypeDocDocument = JsonObject
+TypeDocExport = JsonObject
 
 
 @dataclass(frozen=True)
 class TypeDocSnapshot:
     version: str
     json_path: str
-    document: dict[str, Any]
+    document: TypeDocDocument
 
 
 @dataclass(frozen=True)
@@ -29,5 +33,4 @@ class TypeDocReport:
     publish_version: str
     versions: list[str]
     export_groups: list[str]
-    exports: list[dict[str, Any]]
-
+    exports: list[TypeDocExport]

--- a/src/x2mdx/typedoc/snapshots.py
+++ b/src/x2mdx/typedoc/snapshots.py
@@ -4,28 +4,29 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import yaml
 
-from x2mdx.typedoc.models import TypeDocSnapshot, TypeDocSources
+from x2mdx.typedoc.models import TypeDocDocument, TypeDocSnapshot, TypeDocSources
+from x2mdx.types import JsonObject
 
 
-def _load_manifest(path: Path) -> dict[str, Any]:
+def _load_manifest(path: Path) -> JsonObject:
     if path.suffix.lower() in {".yaml", ".yml"}:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     else:
         payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected object at manifest root: {path}")
-    return payload
+    return cast(JsonObject, payload)
 
 
-def _load_document(path: Path) -> dict[str, Any]:
+def _load_document(path: Path) -> TypeDocDocument:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected top-level JSON object in {path}")
-    return payload
+    return cast(TypeDocDocument, payload)
 
 
 def load_typedoc_sources(
@@ -85,4 +86,3 @@ def load_typedoc_sources(
         source=source,
         package_name=package_name,
     )
-

--- a/src/x2mdx/types.py
+++ b/src/x2mdx/types.py
@@ -1,0 +1,26 @@
+"""Shared types for parsed reference-doc data structures."""
+
+from __future__ import annotations
+
+from typing import TypeAlias, TypedDict
+
+JsonPrimitive: TypeAlias = str | int | float | bool | None
+JsonObject: TypeAlias = dict[str, "JsonValue"]
+JsonArray: TypeAlias = list["JsonValue"]
+JsonValue: TypeAlias = JsonPrimitive | JsonObject | JsonArray
+
+VersionSortPart: TypeAlias = int | str
+VersionSortKey: TypeAlias = tuple[VersionSortPart, ...]
+
+
+class MintlifyNavGroup(TypedDict, total=False):
+    group: str
+    pages: "MintlifyNavItems"
+    groups: "MintlifyNavItems"
+    expanded: bool
+    openapi: str
+    asyncapi: str
+
+
+MintlifyNavItem: TypeAlias = str | MintlifyNavGroup
+MintlifyNavItems: TypeAlias = list[MintlifyNavItem]


### PR DESCRIPTION
## Summary

- Add recursive parsed-JSON aliases and a concrete recursive `MintlifyNavGroup` `TypedDict` for Mintlify navigation items.
- Replace broad `Any`/generic aliases in AsyncAPI and OpenRPC models with format-specific `TypedDict` records for documents, extracted detail rows, change details, and history buckets.
- Keep dynamic parsed JSON casts at checked ingress points or immediately after runtime validation of `docs.json` navigation lists.

