### PR TITLE
Remove misleading reference doc type alias renames

### DIFF
--- a/scripts/generated_reference_nav.py
+++ b/scripts/generated_reference_nav.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import cast
 
-from x2mdx.types import JsonObject, MintlifyNavGroup, MintlifyNavItems
+from x2mdx.types import JsonValue, MintlifyNavGroup, MintlifyNavItems, require_json_object, require_mintlify_nav_items
 
 
 def docs_json_page_ref(path: Path, docs_json_path: Path) -> str:
@@ -15,11 +14,8 @@ def docs_json_page_ref(path: Path, docs_json_path: Path) -> str:
     return relative.with_suffix("").as_posix()
 
 
-def load_json(path: Path) -> JsonObject:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected JSON object in {path}")
-    return cast(JsonObject, payload)
+def load_json(path: Path) -> dict[str, JsonValue]:
+    return require_json_object(json.loads(path.read_text(encoding="utf-8")), path=str(path))
 
 
 def slugify(value: str) -> str:
@@ -192,7 +188,7 @@ def replace_group_in_dropdown(*, docs_json_path: Path, dropdown_label: str, grou
     if not isinstance(pages, list):
         raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
 
-    nav_pages = cast(MintlifyNavItems, pages)
+    nav_pages = require_mintlify_nav_items(pages, path=f"{docs_json_path}.navigation.dropdowns[{dropdown_label}].pages")
     if not _replace_group(nav_pages, group):
         nav_pages.append(group)
     docs_json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/scripts/reference_nav.py
+++ b/scripts/reference_nav.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
-from x2mdx.types import JsonObject, MintlifyNavGroup, MintlifyNavItem, MintlifyNavItems
+from x2mdx.types import JsonValue, MintlifyNavGroup, MintlifyNavItem, MintlifyNavItems, require_json_object, require_mintlify_nav_items
 
 
 LEDGER_API_PARENT_GROUP = "Ledger API"
@@ -45,11 +44,8 @@ LANGUAGE_GROUPS = {"Javadocs"}
 JAVADOC_PREFIX = "reference/java/"
 
 
-def load_json(path: Path) -> JsonObject:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected JSON object in {path}")
-    return cast(JsonObject, payload)
+def load_json(path: Path) -> dict[str, JsonValue]:
+    return require_json_object(json.loads(path.read_text(encoding="utf-8")), path=str(path))
 
 
 def _find_group(items: MintlifyNavItems, label: str) -> MintlifyNavGroup | None:
@@ -299,7 +295,7 @@ def _absorb_known_item(item: MintlifyNavItem, collected: dict[str, MintlifyNavGr
     return False
 
 
-def navigation_pages(docs: JsonObject, *, label: str, docs_json_path: Path) -> MintlifyNavItems:
+def navigation_pages(docs: dict[str, JsonValue], *, label: str, docs_json_path: Path) -> MintlifyNavItems:
     navigation = docs.get("navigation")
     if not isinstance(navigation, dict):
         raise ValueError(f"docs.json missing navigation object: {docs_json_path}")
@@ -315,7 +311,7 @@ def navigation_pages(docs: JsonObject, *, label: str, docs_json_path: Path) -> M
         pages = dropdown.get("pages")
         if not isinstance(pages, list):
             raise ValueError(f"Dropdown does not expose a pages list: {label}")
-        return cast(MintlifyNavItems, pages)
+        return require_mintlify_nav_items(pages, path=f"{docs_json_path}.navigation.dropdowns[{label}].pages")
 
     products = navigation.get("products")
     if isinstance(products, list):
@@ -328,7 +324,7 @@ def navigation_pages(docs: JsonObject, *, label: str, docs_json_path: Path) -> M
         pages = product.get("pages")
         if not isinstance(pages, list):
             raise ValueError(f"Product does not expose a pages list: {label}")
-        return cast(MintlifyNavItems, pages)
+        return require_mintlify_nav_items(pages, path=f"{docs_json_path}.navigation.products[{label}].pages")
 
     raise ValueError(f"docs.json navigation must define dropdowns or products: {docs_json_path}")
 

--- a/src/x2mdx/asyncapi/lifecycle.py
+++ b/src/x2mdx/asyncapi/lifecycle.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from typing import cast
 
 import yaml
 
@@ -19,7 +18,7 @@ from x2mdx.asyncapi.models import (
     AsyncApiReport,
     AsyncApiSourceSnapshot,
 )
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue, require_json_object, require_json_value
 
 REQUEST_SAMPLE_MAX_DEPTH = 4
 REQUEST_SAMPLE_MAX_PROPERTIES = 8
@@ -44,12 +43,28 @@ def version_key(version: str) -> tuple[tuple[int, int | str], ...]:
 
 
 def parse_asyncapi(raw_text: str) -> AsyncApiDocument:
-    obj = yaml.safe_load(raw_text)
-    if not isinstance(obj, dict):
-        raise ValueError("AsyncAPI document is not an object")
-    if "asyncapi" not in obj:
+    obj = require_json_object(yaml.safe_load(raw_text))
+    version = obj.get("asyncapi")
+    if not isinstance(version, str) or not version:
         raise ValueError("Document does not contain top-level `asyncapi` key")
-    return cast(AsyncApiDocument, obj)
+
+    document: AsyncApiDocument = {"asyncapi": version}
+    info = obj.get("info")
+    if info is not None:
+        if not isinstance(info, dict):
+            raise ValueError("AsyncAPI document `info` must be an object")
+        document["info"] = info
+    channels = obj.get("channels")
+    if channels is not None:
+        if not isinstance(channels, dict):
+            raise ValueError("AsyncAPI document `channels` must be an object")
+        document["channels"] = channels
+    components = obj.get("components")
+    if components is not None:
+        if not isinstance(components, dict):
+            raise ValueError("AsyncAPI document `components` must be an object")
+        document["components"] = components
+    return document
 
 
 def slugify(value: str) -> str:
@@ -79,7 +94,7 @@ def resolve_local_ref(doc: AsyncApiDocument, node: JsonValue | None, max_depth: 
         ref = current["$ref"]
         if not isinstance(ref, str) or not ref.startswith("#/"):
             break
-        target = cast(JsonValue, doc)
+        target = require_json_value(doc)
         valid = True
         for part in ref[2:].split("/"):
             if isinstance(target, dict) and part in target:
@@ -111,7 +126,7 @@ def object_schema_properties_and_required(
     schema: JsonValue | None,
     *,
     max_depth: int = 6,
-) -> tuple[JsonObject, set[str]]:
+) -> tuple[dict[str, JsonValue], set[str]]:
     if max_depth <= 0:
         return {}, set()
 
@@ -119,7 +134,7 @@ def object_schema_properties_and_required(
     if not isinstance(resolved, dict):
         return {}, set()
 
-    properties: JsonObject = {}
+    properties: dict[str, JsonValue] = {}
     required: set[str] = set()
 
     all_of = resolved.get("allOf")
@@ -273,7 +288,7 @@ def schema_sample_value(
         if not names_to_render and unknown_required_names:
             names_to_render = unknown_required_names
 
-        sample: JsonObject = {}
+        sample: dict[str, JsonValue] = {}
         for name in names_to_render[:max_properties]:
             if name in properties:
                 sample[name] = schema_sample_value(

--- a/src/x2mdx/asyncapi/models.py
+++ b/src/x2mdx/asyncapi/models.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypedDict
 
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue
 
 
 class AsyncApiDocument(TypedDict, total=False):
     asyncapi: str
-    info: JsonObject
+    info: dict[str, JsonValue]
     channels: dict[str, JsonValue]
-    components: JsonObject
+    components: dict[str, JsonValue]
 
 
 class AsyncApiMessageDetail(TypedDict):

--- a/src/x2mdx/asyncapi/snapshots.py
+++ b/src/x2mdx/asyncapi/snapshots.py
@@ -4,30 +4,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import yaml
 
 from x2mdx.asyncapi.lifecycle import parse_asyncapi, version_key
 from x2mdx.asyncapi.models import AsyncApiSourceSnapshot
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue, require_json_object, require_json_value
 
 
 def _load_data(path: Path) -> JsonValue:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
-        return cast(JsonValue, json.loads(raw))
-    return cast(JsonValue, yaml.safe_load(raw))
+        return require_json_value(json.loads(raw), path=str(path))
+    return require_json_value(yaml.safe_load(raw), path=str(path))
 
 
-def load_snapshot_manifest(path: Path) -> JsonObject:
-    data = _load_data(path)
-    if not isinstance(data, dict):
-        raise ValueError("Snapshot manifest must be a JSON/YAML object")
+def load_snapshot_manifest(path: Path) -> dict[str, JsonValue]:
+    data = require_json_object(_load_data(path), path=str(path))
     versions = data.get("versions")
     if not isinstance(versions, list):
         raise ValueError("Snapshot manifest must include a `versions` list")
-    return cast(JsonObject, data)
+    return data
 
 
 def load_asyncapi_source_snapshots(
@@ -38,9 +35,12 @@ def load_asyncapi_source_snapshots(
 ) -> list[AsyncApiSourceSnapshot]:
     manifest = load_snapshot_manifest(manifest_path)
     root = fixture_root or manifest_path.parent
+    versions = manifest.get("versions")
+    if not isinstance(versions, list):
+        raise ValueError("Snapshot manifest must include a `versions` list")
 
     snapshots: list[AsyncApiSourceSnapshot] = []
-    for entry in manifest["versions"]:
+    for entry in versions:
         if not isinstance(entry, dict):
             continue
         version = entry.get("version")

--- a/src/x2mdx/daml_json/models.py
+++ b/src/x2mdx/daml_json/models.py
@@ -3,10 +3,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
-from x2mdx.types import JsonObject
+from x2mdx.types import JsonValue
 
-DamlJsonModule = JsonObject
+
+class DamlJsonModule(TypedDict, total=False):
+    md_name: str
+    md_anchor: str
+    md_descr: JsonValue
+    md_warn: JsonValue
+    md_adts: list[JsonValue]
+    md_classes: list[JsonValue]
+    md_functions: list[JsonValue]
+    md_interfaces: list[JsonValue]
+    md_templates: list[JsonValue]
+    md_instances: list[JsonValue]
 
 
 @dataclass(frozen=True)

--- a/src/x2mdx/daml_json/snapshots.py
+++ b/src/x2mdx/daml_json/snapshots.py
@@ -4,34 +4,86 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import yaml
 
 from x2mdx.daml_json.models import DamlDocsSnapshot, DamlDocsSources, DamlJsonModule
-from x2mdx.types import JsonObject
+from x2mdx.types import JsonValue, require_json_object, require_json_value
 
 
-def _load_manifest(path: Path) -> JsonObject:
+def _load_manifest(path: Path) -> dict[str, JsonValue]:
     if path.suffix.lower() in {".yaml", ".yml"}:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     else:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected object at manifest root: {path}")
-    return cast(JsonObject, payload)
+    return require_json_object(payload, path=str(path))
+
+
+def _optional_string(payload: dict[str, JsonValue], key: str, path: Path) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Expected string `{key}` in {path}")
+    return value
+
+
+def _optional_json_list(payload: dict[str, JsonValue], key: str, path: Path) -> list[JsonValue] | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(f"Expected list `{key}` in {path}")
+    return value
+
+
+def _load_module_payload(payload: dict[str, JsonValue], path: Path) -> DamlJsonModule:
+    name = _optional_string(payload, "md_name", path)
+    if not name:
+        raise ValueError(f"Expected non-empty string `md_name` in {path}")
+
+    module: DamlJsonModule = {"md_name": name}
+    anchor = _optional_string(payload, "md_anchor", path)
+    if anchor is not None:
+        module["md_anchor"] = anchor
+    if "md_descr" in payload:
+        module["md_descr"] = payload["md_descr"]
+    if "md_warn" in payload:
+        module["md_warn"] = payload["md_warn"]
+
+    md_adts = _optional_json_list(payload, "md_adts", path)
+    if md_adts is not None:
+        module["md_adts"] = md_adts
+    md_classes = _optional_json_list(payload, "md_classes", path)
+    if md_classes is not None:
+        module["md_classes"] = md_classes
+    md_functions = _optional_json_list(payload, "md_functions", path)
+    if md_functions is not None:
+        module["md_functions"] = md_functions
+    md_interfaces = _optional_json_list(payload, "md_interfaces", path)
+    if md_interfaces is not None:
+        module["md_interfaces"] = md_interfaces
+    md_templates = _optional_json_list(payload, "md_templates", path)
+    if md_templates is not None:
+        module["md_templates"] = md_templates
+    md_instances = _optional_json_list(payload, "md_instances", path)
+    if md_instances is not None:
+        module["md_instances"] = md_instances
+    return module
 
 
 def _load_modules(path: Path) -> list[DamlJsonModule]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = require_json_value(json.loads(path.read_text(encoding="utf-8")), path=str(path))
     if isinstance(payload, dict):
         payload = [payload]
     if not isinstance(payload, list):
         raise ValueError(f"Expected top-level JSON list or object in {path}")
     modules: list[DamlJsonModule] = []
-    for item in payload:
+    for index, item in enumerate(payload):
         if isinstance(item, dict):
-            modules.append(cast(DamlJsonModule, item))
+            modules.append(_load_module_payload(item, path))
+        else:
+            raise ValueError(f"Expected module object at {path}[{index}]")
     return modules
 
 
@@ -80,5 +132,5 @@ def load_daml_doc_sources(
     return DamlDocsSources(
         snapshots=snapshots,
         publish_version=publish_version,
-        source=manifest.get("source") if isinstance(manifest.get("source"), str) else None,
+        source=source if isinstance((source := manifest.get("source")), str) else None,
     )

--- a/src/x2mdx/jvm_docs/snapshots.py
+++ b/src/x2mdx/jvm_docs/snapshots.py
@@ -4,30 +4,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import yaml
 
 from x2mdx.jvm_docs.lifecycle import version_key
 from x2mdx.jvm_docs.models import JvmDocArtifactSource, JvmDocVersionSource, JVM_DOC_OBJECT_STATUSES
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue, require_json_object, require_json_value
 
 
 def _load_data(path: Path) -> JsonValue:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
-        return cast(JsonValue, json.loads(raw))
-    return cast(JsonValue, yaml.safe_load(raw))
+        return require_json_value(json.loads(raw), path=str(path))
+    return require_json_value(yaml.safe_load(raw), path=str(path))
 
 
-def load_jvm_doc_manifest(path: Path) -> JsonObject:
-    data = _load_data(path)
-    if not isinstance(data, dict):
-        raise ValueError("JVM doc manifest must be a JSON/YAML object")
+def load_jvm_doc_manifest(path: Path) -> dict[str, JsonValue]:
+    data = require_json_object(_load_data(path), path=str(path))
     artifacts = data.get("artifacts")
     if not isinstance(artifacts, list):
         raise ValueError("JVM doc manifest must include an `artifacts` list")
-    return cast(JsonObject, data)
+    return data
 
 
 def load_jvm_doc_status_manifest(path: Path) -> dict[str, str]:
@@ -64,9 +61,12 @@ def load_jvm_doc_sources(
 ) -> list[JvmDocArtifactSource]:
     manifest = load_jvm_doc_manifest(manifest_path)
     root = fixture_root or manifest_path.parent
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("JVM doc manifest must include an `artifacts` list")
 
     artifact_sources: list[JvmDocArtifactSource] = []
-    for entry in manifest["artifacts"]:
+    for entry in artifacts:
         if not isinstance(entry, dict):
             continue
 
@@ -74,16 +74,18 @@ def load_jvm_doc_sources(
         artifact = entry.get("artifact")
         language = entry.get("language")
         versions = entry.get("versions")
-        include_prefixes = entry.get("include_prefixes") or []
+        include_prefixes = entry.get("include_prefixes")
         status_manifest = entry.get("status_manifest")
         if not isinstance(group, str) or not group:
             continue
         if not isinstance(artifact, str) or not artifact:
             continue
-        if language not in {"java", "scala"}:
+        if not isinstance(language, str) or language not in {"java", "scala"}:
             continue
         if not isinstance(versions, list):
             continue
+        if not isinstance(include_prefixes, list):
+            include_prefixes = []
 
         version_sources: list[JvmDocVersionSource] = []
         for version_entry in versions:

--- a/src/x2mdx/mintlify.py
+++ b/src/x2mdx/mintlify.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
 
 from x2mdx.output import Page
 from x2mdx.render import write_pages
-from x2mdx.types import JsonArray, JsonObject, JsonValue, MintlifyNavGroup, MintlifyNavItems
+from x2mdx.types import JsonValue, MintlifyNavGroup, MintlifyNavItems, require_json_object
 
 
 @dataclass(frozen=True)
@@ -69,7 +68,7 @@ def _remove_page_reference(node: JsonValue, page_ref: str) -> None:
     if isinstance(node, dict):
         pages = node.get("pages")
         if isinstance(pages, list):
-            filtered_pages: JsonArray = [item for item in pages if item != page_ref]
+            filtered_pages: list[JsonValue] = [item for item in pages if item != page_ref]
             node["pages"] = filtered_pages
             for item in filtered_pages:
                 _remove_page_reference(item, page_ref)
@@ -81,14 +80,14 @@ def _remove_page_reference(node: JsonValue, page_ref: str) -> None:
             _remove_page_reference(item, page_ref)
 
 
-def _find_group(groups: JsonArray, label: str) -> JsonObject | None:
+def _find_group(groups: list[JsonValue], label: str) -> dict[str, JsonValue] | None:
     for item in groups:
         if isinstance(item, dict) and item.get("group") == label:
             return item
     return None
 
 
-def _ensure_list_field(container: JsonObject, key: str) -> JsonArray:
+def _ensure_list_field(container: dict[str, JsonValue], key: str) -> list[JsonValue]:
     value = container.get(key)
     if isinstance(value, list):
         return value
@@ -97,12 +96,12 @@ def _ensure_list_field(container: JsonObject, key: str) -> JsonArray:
     return value
 
 
-def _ensure_group_path(container: JsonObject, group_path: list[str]) -> JsonArray:
+def _ensure_group_path(container: dict[str, JsonValue], group_path: list[str]) -> list[JsonValue]:
     if not group_path:
         return _ensure_list_field(container, "pages")
 
     current_groups = _ensure_list_field(container, "groups")
-    current: JsonObject | None = None
+    current: dict[str, JsonValue] | None = None
     for index, label in enumerate(group_path):
         current = _find_group(current_groups, label)
         if current is None:
@@ -141,7 +140,7 @@ def update_docs_json_navigation(
     output_file: Path,
     target: MintlifyNavTarget,
 ) -> Path:
-    docs = cast(JsonObject, json.loads(docs_json_path.read_text(encoding="utf-8")))
+    docs = require_json_object(json.loads(docs_json_path.read_text(encoding="utf-8")), path=str(docs_json_path))
     page_ref = docs_json_page_ref(output_file, docs_json_path)
     navigation = docs.get("navigation")
     if not isinstance(navigation, dict):

--- a/src/x2mdx/openrpc/lifecycle.py
+++ b/src/x2mdx/openrpc/lifecycle.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import cast
 
 import yaml
 
@@ -20,9 +19,8 @@ from x2mdx.openrpc.models import (
     OpenRpcResultDetail,
     OpenRpcSourceSnapshot,
     OpenRpcSpecLifecycle,
-    OpenRpcValueDetail,
 )
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue, require_json_object, require_json_value
 
 REQUEST_SAMPLE_MAX_DEPTH = 4
 REQUEST_SAMPLE_MAX_PROPERTIES = 8
@@ -51,12 +49,28 @@ def version_key(version: str) -> tuple[tuple[int, int | str], ...]:
 
 
 def parse_openrpc(raw_text: str) -> OpenRpcDocument:
-    obj = yaml.safe_load(raw_text)
-    if not isinstance(obj, dict):
-        raise ValueError("OpenRPC document is not an object")
-    if "openrpc" not in obj:
+    obj = require_json_object(yaml.safe_load(raw_text))
+    version = obj.get("openrpc")
+    if not isinstance(version, str) or not version:
         raise ValueError("Document does not contain top-level `openrpc` key")
-    return cast(OpenRpcDocument, obj)
+
+    document: OpenRpcDocument = {"openrpc": version}
+    info = obj.get("info")
+    if info is not None:
+        if not isinstance(info, dict):
+            raise ValueError("OpenRPC document `info` must be an object")
+        document["info"] = info
+    methods = obj.get("methods")
+    if methods is not None:
+        if not isinstance(methods, list) or not all(isinstance(method, dict) for method in methods):
+            raise ValueError("OpenRPC document `methods` must be a list of objects")
+        document["methods"] = [method for method in methods if isinstance(method, dict)]
+    components = obj.get("components")
+    if components is not None:
+        if not isinstance(components, dict):
+            raise ValueError("OpenRPC document `components` must be an object")
+        document["components"] = components
+    return document
 
 
 def slugify(value: str) -> str:
@@ -95,7 +109,7 @@ def build_version_doc_index(snapshots: list[OpenRpcSourceSnapshot]) -> OpenRpcVe
 
 
 def resolve_local_fragment(document: OpenRpcDocument, fragment: str) -> JsonValue | None:
-    target = cast(JsonValue, document)
+    target = require_json_value(document)
     for part in fragment.split("/"):
         if isinstance(target, dict) and part in target:
             target = target[part]
@@ -160,7 +174,7 @@ def object_schema_properties_and_required(
     schema: JsonValue | None,
     *,
     max_depth: int = 6,
-) -> tuple[JsonObject, set[str]]:
+) -> tuple[dict[str, JsonValue], set[str]]:
     if max_depth <= 0:
         return {}, set()
 
@@ -168,7 +182,7 @@ def object_schema_properties_and_required(
     if not isinstance(resolved, dict):
         return {}, set()
 
-    properties: JsonObject = {}
+    properties: dict[str, JsonValue] = {}
     required: set[str] = set()
 
     all_of = resolved.get("allOf")
@@ -307,7 +321,7 @@ def schema_sample_value(
         if not names_to_render and unknown_required_names:
             names_to_render = unknown_required_names
 
-        sample: JsonObject = {}
+        sample: dict[str, JsonValue] = {}
         for name in names_to_render[:max_properties]:
             if name in properties:
                 sample[name] = schema_sample_value(
@@ -348,7 +362,7 @@ def schema_sample_value(
 def extract_param_detail(
     doc_index: OpenRpcDocumentIndex,
     current_source_path: str,
-    param: JsonObject,
+    param: dict[str, JsonValue],
 ) -> OpenRpcParamDetail:
     schema = param.get("schema")
     return {
@@ -435,7 +449,7 @@ def render_name_list(names: list[str]) -> str:
     return ", ".join(f"`{name}`" for name in names)
 
 
-def describe_param_changes(previous: OpenRpcValueDetail, current: OpenRpcValueDetail) -> list[str]:
+def describe_param_changes(previous: OpenRpcParamDetail, current: OpenRpcParamDetail) -> list[str]:
     changes: list[str] = []
     if previous["description"] != current["description"]:
         changes.append("description")

--- a/src/x2mdx/openrpc/models.py
+++ b/src/x2mdx/openrpc/models.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypedDict
 
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue
 
 
 class OpenRpcDocument(TypedDict, total=False):
     openrpc: str
-    info: JsonObject
-    methods: list[JsonObject]
-    components: JsonObject
+    info: dict[str, JsonValue]
+    methods: list[dict[str, JsonValue]]
+    components: dict[str, JsonValue]
 
 
-class OpenRpcValueDetail(TypedDict):
+class OpenRpcParamDetail(TypedDict):
     name: str
     description: str
     schema_name: str | None
@@ -24,8 +24,13 @@ class OpenRpcValueDetail(TypedDict):
     sample: JsonValue | None
 
 
-OpenRpcParamDetail = OpenRpcValueDetail
-OpenRpcResultDetail = OpenRpcValueDetail
+class OpenRpcResultDetail(TypedDict):
+    name: str
+    description: str
+    schema_name: str | None
+    schema: str
+    required_fields: list[str]
+    sample: JsonValue | None
 
 
 class OpenRpcMethodDetail(TypedDict):

--- a/src/x2mdx/openrpc/snapshots.py
+++ b/src/x2mdx/openrpc/snapshots.py
@@ -4,30 +4,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import yaml
 
 from x2mdx.openrpc.lifecycle import parse_openrpc, version_key
 from x2mdx.openrpc.models import OpenRpcSourceSnapshot
-from x2mdx.types import JsonObject, JsonValue
+from x2mdx.types import JsonValue, require_json_object, require_json_value
 
 
 def _load_data(path: Path) -> JsonValue:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
-        return cast(JsonValue, json.loads(raw))
-    return cast(JsonValue, yaml.safe_load(raw))
+        return require_json_value(json.loads(raw), path=str(path))
+    return require_json_value(yaml.safe_load(raw), path=str(path))
 
 
-def load_snapshot_manifest(path: Path) -> JsonObject:
-    data = _load_data(path)
-    if not isinstance(data, dict):
-        raise ValueError("Snapshot manifest must be a JSON/YAML object")
+def load_snapshot_manifest(path: Path) -> dict[str, JsonValue]:
+    data = require_json_object(_load_data(path), path=str(path))
     specs = data.get("specs")
     if not isinstance(specs, list):
         raise ValueError("Snapshot manifest must include a `specs` list")
-    return cast(JsonObject, data)
+    return data
 
 
 def load_openrpc_source_snapshots(
@@ -38,9 +35,12 @@ def load_openrpc_source_snapshots(
 ) -> list[OpenRpcSourceSnapshot]:
     manifest = load_snapshot_manifest(manifest_path)
     root = fixture_root or manifest_path.parent
+    specs = manifest.get("specs")
+    if not isinstance(specs, list):
+        raise ValueError("Snapshot manifest must include a `specs` list")
 
     snapshots: list[OpenRpcSourceSnapshot] = []
-    for spec_entry in manifest["specs"]:
+    for spec_entry in specs:
         if not isinstance(spec_entry, dict):
             continue
         spec_id = spec_entry.get("spec_id")

--- a/src/x2mdx/protobuf/models.py
+++ b/src/x2mdx/protobuf/models.py
@@ -3,8 +3,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
-from x2mdx.types import JsonObject
+from x2mdx.types import JsonValue
+
+
+class ProtobufMetadataOverlay(TypedDict, total=False):
+    schemaVersion: int
+    files: dict[str, JsonValue]
+    services: dict[str, JsonValue]
+    endpoints: dict[str, JsonValue]
+    messages: dict[str, JsonValue]
+    fields: dict[str, JsonValue]
+    enums: dict[str, JsonValue]
+    enumValues: dict[str, JsonValue]
 
 
 @dataclass(frozen=True)
@@ -22,4 +34,4 @@ class ProtobufSources:
     source: str | None = None
     repo_remote: str | None = None
     repo_web_url: str | None = None
-    metadata_overlay: JsonObject | None = None
+    metadata_overlay: ProtobufMetadataOverlay | None = None

--- a/src/x2mdx/protobuf/snapshots.py
+++ b/src/x2mdx/protobuf/snapshots.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import yaml
 
-from x2mdx.protobuf.models import ProtobufSourceSnapshot, ProtobufSources
-from x2mdx.types import JsonObject
+from x2mdx.protobuf.models import ProtobufMetadataOverlay, ProtobufSourceSnapshot, ProtobufSources
+from x2mdx.types import JsonValue, require_json_object
 
 DEFAULT_METADATA_SHAPE = {
     "schemaVersion": 1,
@@ -23,28 +22,70 @@ DEFAULT_METADATA_SHAPE = {
 }
 
 
-def _load_manifest(path: Path) -> JsonObject:
+def _load_manifest(path: Path) -> dict[str, JsonValue]:
     if path.suffix.lower() in {".yaml", ".yml"}:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     else:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected object at manifest root: {path}")
-    return cast(JsonObject, payload)
+    return require_json_object(payload, path=str(path))
 
 
-def _load_metadata_overlay(path: Path | None) -> JsonObject:
-    data = cast(JsonObject, json.loads(json.dumps(DEFAULT_METADATA_SHAPE)))
+def _load_metadata_overlay(path: Path | None) -> ProtobufMetadataOverlay:
+    data: ProtobufMetadataOverlay = {
+        "schemaVersion": 1,
+        "files": {},
+        "services": {},
+        "endpoints": {},
+        "messages": {},
+        "fields": {},
+        "enums": {},
+        "enumValues": {},
+    }
     if path is None or not path.exists():
         return data
-    raw = json.loads(path.read_text(encoding="utf-8"))
-    for key in data:
-        if key == "schemaVersion":
-            data[key] = raw.get(key, data[key])
-            continue
-        value = raw.get(key, {})
-        if isinstance(value, dict):
-            data[key] = value
+
+    raw = require_json_object(json.loads(path.read_text(encoding="utf-8")), path=str(path))
+    schema_version = raw.get("schemaVersion")
+    if schema_version is not None:
+        if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+            raise ValueError(f"Expected integer `schemaVersion` in {path}")
+        data["schemaVersion"] = schema_version
+
+    files = raw.get("files")
+    if files is not None:
+        if not isinstance(files, dict):
+            raise ValueError(f"Expected object `files` in {path}")
+        data["files"] = files
+    services = raw.get("services")
+    if services is not None:
+        if not isinstance(services, dict):
+            raise ValueError(f"Expected object `services` in {path}")
+        data["services"] = services
+    endpoints = raw.get("endpoints")
+    if endpoints is not None:
+        if not isinstance(endpoints, dict):
+            raise ValueError(f"Expected object `endpoints` in {path}")
+        data["endpoints"] = endpoints
+    messages = raw.get("messages")
+    if messages is not None:
+        if not isinstance(messages, dict):
+            raise ValueError(f"Expected object `messages` in {path}")
+        data["messages"] = messages
+    fields = raw.get("fields")
+    if fields is not None:
+        if not isinstance(fields, dict):
+            raise ValueError(f"Expected object `fields` in {path}")
+        data["fields"] = fields
+    enums = raw.get("enums")
+    if enums is not None:
+        if not isinstance(enums, dict):
+            raise ValueError(f"Expected object `enums` in {path}")
+        data["enums"] = enums
+    enum_values = raw.get("enumValues")
+    if enum_values is not None:
+        if not isinstance(enum_values, dict):
+            raise ValueError(f"Expected object `enumValues` in {path}")
+        data["enumValues"] = enum_values
     return data
 
 
@@ -67,7 +108,7 @@ def load_protobuf_sources(
         version = entry.get("version")
         tag = entry.get("tag")
         raw_image_path = entry.get("descriptor_image_path")
-        import_to_repo_path = entry.get("import_to_repo_path")
+        raw_import_to_repo_path = entry.get("import_to_repo_path")
         if not isinstance(version, str) or not version:
             continue
         if include_versions is not None and version not in include_versions:
@@ -76,10 +117,12 @@ def load_protobuf_sources(
             continue
         if not isinstance(raw_image_path, str) or not raw_image_path:
             continue
-        if not isinstance(import_to_repo_path, dict) or not all(
-            isinstance(key, str) and isinstance(value, str) for key, value in import_to_repo_path.items()
+        if not isinstance(raw_import_to_repo_path, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in raw_import_to_repo_path.items()
         ):
             raise ValueError(f"Manifest entry for protobuf version {version} must define string import_to_repo_path")
+        import_to_repo_path = {str(key): str(value) for key, value in raw_import_to_repo_path.items()}
+        date = entry.get("date")
 
         image_path = Path(raw_image_path)
         if not image_path.is_absolute():
@@ -88,9 +131,9 @@ def load_protobuf_sources(
             ProtobufSourceSnapshot(
                 version=version,
                 tag=tag,
-                date=entry.get("date") if isinstance(entry.get("date"), str) else None,
+                date=date if isinstance(date, str) else None,
                 descriptor_image_path=str(image_path.resolve()),
-                import_to_repo_path=dict(import_to_repo_path),
+                import_to_repo_path=import_to_repo_path,
             )
         )
 
@@ -105,11 +148,14 @@ def load_protobuf_sources(
             resolved_metadata_path = manifest_root / resolved_metadata_path
 
     raw_repo = manifest.get("repo")
-    repo: JsonObject = raw_repo if isinstance(raw_repo, dict) else {}
+    repo = raw_repo if isinstance(raw_repo, dict) else {}
+    source = manifest.get("source")
+    repo_remote = repo.get("remote")
+    repo_web_url = repo.get("web_url")
     return ProtobufSources(
         snapshots=snapshots,
-        source=manifest.get("source") if isinstance(manifest.get("source"), str) else None,
-        repo_remote=repo.get("remote") if isinstance(repo.get("remote"), str) else None,
-        repo_web_url=repo.get("web_url") if isinstance(repo.get("web_url"), str) else None,
+        source=source if isinstance(source, str) else None,
+        repo_remote=repo_remote if isinstance(repo_remote, str) else None,
+        repo_web_url=repo_web_url if isinstance(repo_web_url, str) else None,
         metadata_overlay=_load_metadata_overlay(resolved_metadata_path),
     )

--- a/src/x2mdx/typedoc/models.py
+++ b/src/x2mdx/typedoc/models.py
@@ -3,11 +3,43 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
-from x2mdx.types import JsonObject
+from x2mdx.types import JsonValue
 
-TypeDocDocument = JsonObject
-TypeDocExport = JsonObject
+
+class TypeDocDocument(TypedDict, total=False):
+    packageName: str
+    name: str
+    groups: list[JsonValue]
+    children: list[JsonValue]
+
+
+class TypeDocChangeDetail(TypedDict):
+    version: str
+    changes: list[str]
+
+
+class TypeDocExport(TypedDict):
+    name: str
+    anchor: str
+    group: str
+    kind_label: str
+    summary: str
+    signature: str
+    type_parameters: list[JsonValue]
+    signature_docs: list[JsonValue]
+    members: list[JsonValue]
+    lifecycle_state: str | None
+    lifecycle_label: str | None
+    replaces: str | None
+    deprecated_text: str | None
+    source_location: str | None
+    introduced_in: str
+    removed_in: str | None
+    status: str
+    sort_item_index: int
+    change_details: list[TypeDocChangeDetail]
 
 
 @dataclass(frozen=True)

--- a/src/x2mdx/typedoc/snapshots.py
+++ b/src/x2mdx/typedoc/snapshots.py
@@ -4,29 +4,55 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import yaml
 
 from x2mdx.typedoc.models import TypeDocDocument, TypeDocSnapshot, TypeDocSources
-from x2mdx.types import JsonObject
+from x2mdx.types import JsonValue, require_json_object
 
 
-def _load_manifest(path: Path) -> JsonObject:
+def _load_manifest(path: Path) -> dict[str, JsonValue]:
     if path.suffix.lower() in {".yaml", ".yml"}:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     else:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected object at manifest root: {path}")
-    return cast(JsonObject, payload)
+    return require_json_object(payload, path=str(path))
+
+
+def _optional_string(payload: dict[str, JsonValue], key: str, path: Path) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Expected string `{key}` in {path}")
+    return value
+
+
+def _optional_json_list(payload: dict[str, JsonValue], key: str, path: Path) -> list[JsonValue] | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(f"Expected list `{key}` in {path}")
+    return value
 
 
 def _load_document(path: Path) -> TypeDocDocument:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected top-level JSON object in {path}")
-    return cast(TypeDocDocument, payload)
+    payload = require_json_object(json.loads(path.read_text(encoding="utf-8")), path=str(path))
+    document: TypeDocDocument = {}
+    package_name = _optional_string(payload, "packageName", path)
+    if package_name is not None:
+        document["packageName"] = package_name
+    name = _optional_string(payload, "name", path)
+    if name is not None:
+        document["name"] = name
+    groups = _optional_json_list(payload, "groups", path)
+    if groups is not None:
+        document["groups"] = groups
+    children = _optional_json_list(payload, "children", path)
+    if children is not None:
+        document["children"] = children
+    return document
 
 
 def load_typedoc_sources(

--- a/src/x2mdx/types.py
+++ b/src/x2mdx/types.py
@@ -4,13 +4,7 @@ from __future__ import annotations
 
 from typing import TypeAlias, TypedDict
 
-JsonPrimitive: TypeAlias = str | int | float | bool | None
-JsonObject: TypeAlias = dict[str, "JsonValue"]
-JsonArray: TypeAlias = list["JsonValue"]
-JsonValue: TypeAlias = JsonPrimitive | JsonObject | JsonArray
-
-VersionSortPart: TypeAlias = int | str
-VersionSortKey: TypeAlias = tuple[VersionSortPart, ...]
+JsonValue: TypeAlias = str | int | float | bool | None | dict[str, "JsonValue"] | list["JsonValue"]
 
 
 class MintlifyNavGroup(TypedDict, total=False):
@@ -24,3 +18,62 @@ class MintlifyNavGroup(TypedDict, total=False):
 
 MintlifyNavItem: TypeAlias = str | MintlifyNavGroup
 MintlifyNavItems: TypeAlias = list[MintlifyNavItem]
+
+
+def require_json_value(value: object, *, path: str = "$") -> JsonValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, list):
+        return [require_json_value(item, path=f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, dict):
+        output: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"Expected string key at {path}, got {type(key).__name__}")
+            output[key] = require_json_value(item, path=f"{path}.{key}")
+        return output
+    raise ValueError(f"Expected JSON-compatible value at {path}, got {type(value).__name__}")
+
+
+def require_json_object(value: object, *, path: str = "$") -> dict[str, JsonValue]:
+    json_value = require_json_value(value, path=path)
+    if not isinstance(json_value, dict):
+        raise ValueError(f"Expected JSON object at {path}, got {type(json_value).__name__}")
+    return json_value
+
+
+def require_json_array(value: object, *, path: str = "$") -> list[JsonValue]:
+    json_value = require_json_value(value, path=path)
+    if not isinstance(json_value, list):
+        raise ValueError(f"Expected JSON array at {path}, got {type(json_value).__name__}")
+    return json_value
+
+
+def require_mintlify_nav_items(value: object, *, path: str = "$") -> MintlifyNavItems:
+    if not isinstance(value, list):
+        raise ValueError(f"Expected Mintlify nav items list at {path}, got {type(value).__name__}")
+    for index, item in enumerate(value):
+        require_mintlify_nav_item(item, path=f"{path}[{index}]")
+    return value
+
+
+def require_mintlify_nav_item(value: object, *, path: str = "$") -> None:
+    if isinstance(value, str):
+        return
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected Mintlify nav string or group at {path}, got {type(value).__name__}")
+
+    group = value.get("group")
+    if group is not None and not isinstance(group, str):
+        raise ValueError(f"Expected Mintlify group label string at {path}.group")
+    for key in ("pages", "groups"):
+        nested = value.get(key)
+        if nested is not None:
+            require_mintlify_nav_items(nested, path=f"{path}.{key}")
+    expanded = value.get("expanded")
+    if expanded is not None and not isinstance(expanded, bool):
+        raise ValueError(f"Expected Mintlify expanded flag boolean at {path}.expanded")
+    for key in ("openapi", "asyncapi"):
+        spec_path = value.get(key)
+        if spec_path is not None and not isinstance(spec_path, str):
+            raise ValueError(f"Expected Mintlify {key} path string at {path}.{key}")


### PR DESCRIPTION
## Summary

- Remove plain `NewType = OldType` aliases left from PR #684 in the Python reference-doc typing surface.
- Inline generic JSON object/list types where a separate name was only a rename.
- Replace semantic aliases for Daml JSON modules, TypeDoc documents/exports, OpenRPC params/results, and protobuf metadata overlays with concrete `TypedDict` shapes.
- Add shared parsed-JSON and Mintlify navigation validators so JSON/YAML boundary code earns `JsonValue`, object, array, and nav item types instead of relying on `cast(...)`.
- Add shape-specific loaders for Daml JSON modules, TypeDoc documents, AsyncAPI/OpenRPC documents, and protobuf metadata overlays.
- Keep only recursive structural aliases that are not simple renames: `JsonValue`, `MintlifyNavItem`, and `MintlifyNavItems`.

## Validation

- `direnv exec . python3 -m compileall -q scripts/generated_reference_nav.py scripts/reference_nav.py src/x2mdx/asyncapi/lifecycle.py src/x2mdx/asyncapi/models.py src/x2mdx/asyncapi/snapshots.py src/x2mdx/daml_json/models.py src/x2mdx/daml_json/snapshots.py src/x2mdx/jvm_docs/snapshots.py src/x2mdx/mintlify.py src/x2mdx/openrpc/lifecycle.py src/x2mdx/openrpc/models.py src/x2mdx/openrpc/snapshots.py src/x2mdx/protobuf/models.py src/x2mdx/protobuf/snapshots.py src/x2mdx/typedoc/models.py src/x2mdx/typedoc/snapshots.py src/x2mdx/types.py`
- `direnv exec . ruff check scripts/generated_reference_nav.py scripts/reference_nav.py src/x2mdx/asyncapi/lifecycle.py src/x2mdx/asyncapi/models.py src/x2mdx/asyncapi/snapshots.py src/x2mdx/daml_json/models.py src/x2mdx/daml_json/snapshots.py src/x2mdx/jvm_docs/snapshots.py src/x2mdx/mintlify.py src/x2mdx/openrpc/lifecycle.py src/x2mdx/openrpc/models.py src/x2mdx/openrpc/snapshots.py src/x2mdx/protobuf/models.py src/x2mdx/protobuf/snapshots.py src/x2mdx/typedoc/models.py src/x2mdx/typedoc/snapshots.py src/x2mdx/types.py`
- `direnv exec . mypy scripts/generated_reference_nav.py scripts/reference_nav.py src/x2mdx/asyncapi/lifecycle.py src/x2mdx/asyncapi/models.py src/x2mdx/asyncapi/snapshots.py src/x2mdx/daml_json/models.py src/x2mdx/daml_json/snapshots.py src/x2mdx/jvm_docs/snapshots.py src/x2mdx/mintlify.py src/x2mdx/openrpc/lifecycle.py src/x2mdx/openrpc/models.py src/x2mdx/openrpc/snapshots.py src/x2mdx/protobuf/models.py src/x2mdx/protobuf/snapshots.py src/x2mdx/typedoc/models.py src/x2mdx/typedoc/snapshots.py src/x2mdx/types.py`
- Cast scan over `src/x2mdx`, `scripts/generated_reference_nav.py`, and `scripts/reference_nav.py` finds no `cast(...)` usage.
- Alias scan over the PR-touched files finds no plain rename aliases; only recursive structural aliases remain.
- `PYTHONDONTWRITEBYTECODE=1 direnv exec . python3 -m pytest tests/test_api_reference_navigation.py tests/test_asyncapi.py tests/test_openrpc.py tests/test_daml_json.py tests/test_jvm_docs.py tests/test_protobuf.py tests/test_protobuf_nav.py tests/test_typedoc.py tests/test_typescript_bindings_reference.py -k 'not test_build_report_requires_status_for_non_deprecated_types and not test_build_report_tracks_lifecycle_from_local_jars and not test_cli_builds_pages_and_updates_docs_json and not test_cli_builds_overview_and_package_pages'` passed: 31 passed, 4 deselected.
- `git diff --check`

## Known base failures

The full focused pytest command currently has 4 failures that reproduce outside this branch:

- Three `tests/test_jvm_docs.py` cases fail while building fixture jars under Python 3.14 with `struct.error: 'H' format requires 0 <= number <= 65535`.
- `tests/test_protobuf.py::ProtobufTests::test_cli_builds_overview_and_package_pages` expects `href="packages/com-example-v1"`, while the renderer emits `href="./packages/com-example-v1"`.
