### PR TITLE
Handle current synchronizer info payload

### DIFF
--- a/scripts/generate_network_component_versions.py
+++ b/scripts/generate_network_component_versions.py
@@ -279,7 +279,12 @@ def require_value(pairs: dict[str, str], label: str, url: str) -> str:
 
 def choose_observed_release(info_payload: dict, info_url: str) -> tuple[str, str, str]:
     sv = info_payload.get("sv", {})
-    synchronizer = info_payload.get("synchronizer", {}).get("active", {})
+    synchronizers = info_payload.get("synchronizer", {})
+    synchronizer_label = "active"
+    synchronizer = synchronizers.get(synchronizer_label, {})
+    if not synchronizer:
+        synchronizer_label = "current"
+        synchronizer = synchronizers.get(synchronizer_label, {})
     sv_version = sv.get("version")
     sync_version = synchronizer.get("version")
     sv_migration_id = sv.get("migration_id")
@@ -291,16 +296,23 @@ def choose_observed_release(info_payload: dict, info_url: str) -> tuple[str, str
     if sv_version != sync_version:
         raise RuntimeError(
             f"Version mismatch in {info_url}: "
-            f"sv.version={sv_version} synchronizer.active.version={sync_version}"
+            f"sv.version={sv_version} synchronizer.{synchronizer_label}.version={sync_version}"
         )
-    if str(sv_migration_id) != str(sync_migration_id):
+    if sv_migration_id is None:
+        raise RuntimeError(f"Missing sv.migration_id in {info_url}")
+    if sync_migration_id is None and synchronizer_label == "active":
+        raise RuntimeError(f"Missing synchronizer.active.migration_id in {info_url}")
+    if sync_migration_id is not None and str(sv_migration_id) != str(sync_migration_id):
         raise RuntimeError(
             f"Migration mismatch in {info_url}: "
-            f"sv.migration_id={sv_migration_id} synchronizer.active.migration_id={sync_migration_id}"
+            f"sv.migration_id={sv_migration_id} "
+            f"synchronizer.{synchronizer_label}.migration_id={sync_migration_id}"
         )
     if chain_id_suffix is None:
-        raise RuntimeError(f"Missing synchronizer.active.chain_id_suffix in {info_url}")
-    return str(sv_version), str(sync_migration_id), str(chain_id_suffix)
+        raise RuntimeError(
+            f"Missing synchronizer.{synchronizer_label}.chain_id_suffix in {info_url}"
+        )
+    return str(sv_version), str(sv_migration_id), str(chain_id_suffix)
 
 
 def read_existing_config(path: Path) -> dict:

--- a/tests/test_generate_network_component_versions.py
+++ b/tests/test_generate_network_component_versions.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -90,6 +92,65 @@ def test_build_config_keeps_new_generated_at_when_dashboard_data_changes() -> No
     )
 
     assert result["_generated"]["generatedAt"] == "2026-06-03T12:00:00+00:00"
+
+
+def test_choose_observed_release_accepts_active_synchronizer_payload() -> None:
+    module = load_script_module()
+
+    assert module.choose_observed_release(
+        {
+            "sv": {"migration_id": 4, "version": "0.6.5"},
+            "synchronizer": {
+                "active": {
+                    "chain_id_suffix": "2",
+                    "migration_id": 4,
+                    "version": "0.6.5",
+                }
+            },
+        },
+        "https://example.com/info",
+    ) == ("0.6.5", "4", "2")
+
+
+def test_choose_observed_release_accepts_current_synchronizer_payload() -> None:
+    module = load_script_module()
+
+    assert module.choose_observed_release(
+        {
+            "sv": {"migration_id": 1, "serial_id": 2, "version": "0.6.7"},
+            "synchronizer": {
+                "current": {
+                    "chain_id_suffix": "6",
+                    "serial_id": 2,
+                    "version": "0.6.7",
+                },
+                "legacy": {
+                    "chain_id_suffix": "6",
+                    "serial_id": 1,
+                    "version": "0.6.6",
+                },
+            },
+        },
+        "https://example.com/info",
+    ) == ("0.6.7", "1", "6")
+
+
+def test_choose_observed_release_rejects_version_mismatch() -> None:
+    module = load_script_module()
+
+    with pytest.raises(RuntimeError, match="Version mismatch"):
+        module.choose_observed_release(
+            {
+                "sv": {"migration_id": 1, "version": "0.6.7"},
+                "synchronizer": {
+                    "current": {
+                        "chain_id_suffix": "6",
+                        "version": "0.6.6",
+                    }
+                },
+            },
+            "https://example.com/info",
+        )
 
 
 def test_latest_stable_version_ignores_prerelease_and_debug_tags() -> None:


### PR DESCRIPTION
## Summary

- update the version dashboard generator to accept both `synchronizer.active` and `synchronizer.current` `/info` payload shapes

## Context

The merged scheduled version-dashboard workflow from #689 started failing on DevNet because its live `/info` payload now exposes the selected synchronizer under `synchronizer.current`, while MainNet/TestNet still use `synchronizer.active`.