### PR TITLE
Fix external snippet helper copy

### DIFF
--- a/config/snippet-config/splice-snippet-list-remote.json
+++ b/config/snippet-config/splice-snippet-list-remote.json
@@ -134,20 +134,6 @@
       }
     },
     {
-      "snippetName": "splice-literal-marker-apps-app-src-pack-examples-sv-helm-sv-values-migration-start",
-      "sourceRepo": "splice",
-      "sourceFilepath": "apps/app/src/pack/examples/sv-helm/sv-values.yaml",
-      "location": {
-        "type": "stringMarker",
-        "start": "MIGRATION_START",
-        "end": "MIGRATION_END"
-      },
-      "description": "",
-      "options": {
-        "language": "yaml"
-      }
-    },
-    {
       "snippetName": "splice-literal-marker-apps-app-src-pack-examples-sv-helm-validator-values-auto-accept-start",
       "sourceRepo": "splice",
       "sourceFilepath": "apps/app/src/pack/examples/sv-helm/validator-values.yaml",
@@ -930,7 +916,7 @@
       "location": {
         "type": "lines",
         "start": 1135,
-        "end": 1143
+        "end": 1139
       },
       "description": "",
       "options": {

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -657,12 +657,6 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
 
-```yaml
-# Replace MIGRATION_ID with the migration ID of the global synchronizer.
-migration:
-  # This should stay constant after the introduction of logical synchronizer upgrades.
-  id: "MIGRATION_ID"
-```
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 
 - Replace `TARGET_CLUSTER` with dev
@@ -765,12 +759,6 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
 
-```yaml
-# Replace MIGRATION_ID with the migration ID of the global synchronizer.
-migration:
-  # This should stay constant after the introduction of logical synchronizer upgrades.
-  id: "MIGRATION_ID"
-```
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 
 - Replace `TARGET_CLUSTER` with test
@@ -873,12 +861,6 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
 
-```yaml
-# Replace MIGRATION_ID with the migration ID of the global synchronizer.
-migration:
-  # This should stay constant after the introduction of logical synchronizer upgrades.
-  id: "MIGRATION_ID"
-```
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 
 - Replace `TARGET_CLUSTER` with main

--- a/docs-main/snippets/external/splice/main/splice-literal-marker-apps-app-src-pack-examples-sv-helm-sv-values-migration-start.mdx
+++ b/docs-main/snippets/external/splice/main/splice-literal-marker-apps-app-src-pack-examples-sv-helm-sv-values-migration-start.mdx
@@ -1,6 +1,0 @@
-```yaml
-# Replace MIGRATION_ID with the migration ID of the global synchronizer.
-migration:
-  # This should stay constant after the introduction of logical synchronizer upgrades.
-  id: "MIGRATION_ID"
-```

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
@@ -1,4 +1,3 @@
-import ExternalSpliceMainSpliceRstLiteralMarkerAppsAppSrcPackExamplesSvHelmSvValuesMigrationStart from "/snippets/external/splice/main/splice-literal-marker-apps-app-src-pack-examples-sv-helm-sv-values-migration-start.mdx";
 import ExternalSpliceMainSpliceRstCodeDocsSrcSvOperatorSvHelmBash627 from "/snippets/external/splice/main/splice-rst-code-docs-src-sv-operator-sv-helm-bash-627.mdx";
 
 To install the Helm charts needed to start an SV node connected to the cluster, you will need to meet a few preconditions. The first is that there needs to be an environment variable defined to refer to the version of the Helm charts necessary to connect to this environment:
@@ -75,8 +74,6 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
-
-<ExternalSpliceMainSpliceRstLiteralMarkerAppsAppSrcPackExamplesSvHelmSvValuesMigrationStart />
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 

--- a/scripts/generate_external_snippets.py
+++ b/scripts/generate_external_snippets.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 CF_DOCS_ROOT = Path(__file__).resolve().parents[1]
 GIB = 1024**3
+HELPER_SOURCE_DIR = CF_DOCS_ROOT / "scripts" / "helpers"
+HELPER_DEPENDENCIES = ("rstIncludeToMdx.js",)
 
 
 @dataclass(frozen=True)
@@ -130,7 +132,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--copy-output",
         action="store_true",
-        help="Copy docs-output into snippets/external/<repo>/<version> in this cf-docs checkout.",
+        help="Copy docs-output into docs-main/snippets/external/<repo>/<version> in this cf-docs checkout.",
     )
     parser.add_argument(
         "--version",
@@ -140,7 +142,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--replace-output",
         action="store_true",
-        help="With --copy-output, remove the target snippets/external folder before copying.",
+        help="With --copy-output, remove the target docs-main/snippets/external folder before copying.",
     )
     parser.add_argument(
         "--min-free-gb",
@@ -166,7 +168,11 @@ def config_path(repo: SnippetRepo) -> Path:
 
 
 def helper_path() -> Path:
-    return CF_DOCS_ROOT / "scripts" / "generateOutputDocs.js"
+    return HELPER_SOURCE_DIR / "generateOutputDocs.js"
+
+
+def helper_dependency_paths() -> list[Path]:
+    return [HELPER_SOURCE_DIR / name for name in HELPER_DEPENDENCIES]
 
 
 def repo_label(repo: SnippetRepo) -> str:
@@ -327,12 +333,16 @@ def copy_helper_and_config(repo: SnippetRepo, source_dir: Path, dry_run: bool) -
     target_export = target_scripts / "exportConfig.json"
 
     print(f"Copy helper: {helper_path()} -> {target_helper}")
+    for dependency in helper_dependency_paths():
+        print(f"Copy helper dependency: {dependency} -> {target_scripts / dependency.name}")
     print(f"Copy config: {config_path(repo)} -> {target_export}")
     if dry_run:
         return target_helper
 
     target_scripts.mkdir(parents=True, exist_ok=True)
     shutil.copy2(helper_path(), target_helper)
+    for dependency in helper_dependency_paths():
+        shutil.copy2(dependency, target_scripts / dependency.name)
     shutil.copy2(config_path(repo), target_export)
     return target_helper
 
@@ -366,7 +376,7 @@ def run_extraction(
 
 def copy_output(repo: SnippetRepo, source_dir: Path, version: str, replace: bool, dry_run: bool) -> Path:
     source_output = source_dir / "docs-output"
-    target = CF_DOCS_ROOT / "snippets" / "external" / repo_label(repo) / version
+    target = CF_DOCS_ROOT / "docs-main" / "snippets" / "external" / repo_label(repo) / version
     if not dry_run and not source_output.is_dir():
         raise SystemExit(f"Expected generated docs-output directory does not exist: {source_output}")
     print(f"Copy output: {source_output} -> {target}")
@@ -382,7 +392,7 @@ def copy_output(repo: SnippetRepo, source_dir: Path, version: str, replace: bool
 def validate_inputs(repo: SnippetRepo) -> None:
     missing = [
         path
-        for path in (helper_path(), config_path(repo))
+        for path in (helper_path(), *helper_dependency_paths(), config_path(repo))
         if not path.is_file()
     ]
     if missing:

--- a/tests/test_generate_external_snippets.py
+++ b/tests/test_generate_external_snippets.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import generate_external_snippets as generator
+
+
+def test_copy_helper_and_config_copies_helper_dependency(tmp_path: Path) -> None:
+    source_dir = tmp_path / "splice"
+    helper = generator.copy_helper_and_config(
+        generator.REPOS["splice"],
+        source_dir,
+        dry_run=False,
+    )
+
+    target_scripts = source_dir / "scripts" / "docs"
+    assert helper == target_scripts / "generateOutputDocs.js"
+    assert helper.is_file()
+    assert (target_scripts / "rstIncludeToMdx.js").is_file()
+    assert (target_scripts / "exportConfig.json").is_file()
+
+
+def test_copy_helper_and_config_preserves_repo_specific_helper_name(tmp_path: Path) -> None:
+    source_dir = tmp_path / "splice-wallet-kernel"
+    helper = generator.copy_helper_and_config(
+        generator.REPOS["splice-wallet-kernel"],
+        source_dir,
+        dry_run=False,
+    )
+
+    target_scripts = source_dir / "scripts" / "docs"
+    assert helper == target_scripts / "generateOutputDocs.cjs"
+    assert helper.is_file()
+    assert (target_scripts / "rstIncludeToMdx.js").is_file()
+
+
+def test_validate_inputs_reports_missing_helper_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_root = tmp_path / "cf-docs"
+    fake_helpers = fake_root / "scripts" / "helpers"
+    fake_config = fake_root / "config" / "snippet-config"
+    fake_helpers.mkdir(parents=True)
+    fake_config.mkdir(parents=True)
+    (fake_helpers / "generateOutputDocs.js").write_text("", encoding="utf-8")
+    (fake_config / "splice-snippet-list-remote.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(generator, "CF_DOCS_ROOT", fake_root)
+    monkeypatch.setattr(generator, "HELPER_SOURCE_DIR", fake_helpers)
+
+    with pytest.raises(SystemExit) as error:
+        generator.validate_inputs(generator.REPOS["splice"])
+
+    assert "rstIncludeToMdx.js" in str(error.value)
+
+
+def test_copy_output_targets_docs_main_snippets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source_dir = tmp_path / "splice"
+    docs_output = source_dir / "docs-output"
+    docs_output.mkdir(parents=True)
+    (docs_output / "example.mdx").write_text("content", encoding="utf-8")
+    fake_root = tmp_path / "cf-docs"
+
+    monkeypatch.setattr(generator, "CF_DOCS_ROOT", fake_root)
+
+    target = generator.copy_output(
+        generator.REPOS["splice"],
+        source_dir,
+        version="main",
+        replace=False,
+        dry_run=False,
+    )
+
+    assert target == fake_root / "docs-main" / "snippets" / "external" / "splice" / "main"
+    assert (target / "example.mdx").read_text(encoding="utf-8") == "content"


### PR DESCRIPTION
## Summary

- fixes `generate:external-snippets` after `generateOutputDocs.js` moved under `scripts/helpers`
- copies `rstIncludeToMdx.js` beside the helper in source repos so the helper can resolve its local require
- fixes `--copy-output` to write to `docs-main/snippets/external/...`
- removes the stale Splice `sv-values.yaml` migration snippet/import because latest Splice main no longer has the `MIGRATION_START` marker

## Root cause

PR #662 deleted the root-level `scripts/generateOutputDocs.js`, but `scripts/generate_external_snippets.py` still expected that path and copied only one helper file. Current helper code lives under `scripts/helpers/` and requires `./rstIncludeToMdx`, so the wrapper had to copy both files together.

## Validation

- `PYTHONPATH=/tmp/cf-docs-pytest python3 -m pytest tests/test_generate_external_snippets.py tests/test_network_variable_tabs.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate_network_variable_tabs.py`
- `jq empty config/snippet-config/splice-snippet-list-remote.json docs-main/docs.json`
- `python3 -m py_compile scripts/generate_external_snippets.py scripts/generate_network_variable_tabs.py tests/test_generate_external_snippets.py`
- `node --check scripts/helpers/generateOutputDocs.js`
- `node --check scripts/helpers/rstIncludeToMdx.js`
- missing `/snippets` import scan
- `git diff --check`
- real Splice extraction against a fresh Splice `origin/main` worktree: `165 succeeded, 0 failed`

## Follow-up

A broad `--replace-output` Splice snippet refresh still exposes stale line-number snippets in `sv_helm.rst`; those should be converted to stable markers or rebaselined before committing broad generated snippet drift.