### PR TITLE
Update docs for the removal of the migration id

### DIFF
--- a/docs-main/appdev/faq.mdx
+++ b/docs-main/appdev/faq.mdx
@@ -188,12 +188,6 @@ Network upgrades follow a coordinated schedule. When an upgrade occurs:
 
 3. **For version upgrades** (e.g., 0.4.x → 0.5.x):
    - Take backups/snapshots before upgrading
-   - Update migration configuration:
-     ```yaml
-     migration:
-       id: 4  # Match current network migration
-       migrating: true
-     ```
    - Update database name if required:
      ```yaml
      persistence:

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -602,7 +602,7 @@ Please modify the file `splice-node/examples/sv-helm/participant-values.yaml` as
 
 </div>
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 - Replace `OIDC_AUTHORITY_LEDGER_API_AUDIENCE` in the `auth.targetAudience` entry with audience for the ledger API. e.g. `https://ledger_api.example.com`. If you are not ready to use a custom audience, you can use the suggested default `https://canton.network.global`.
 - Update the `auth.jwksUrl` entry to point to your auth provider's JWK set document by replacing `OIDC_AUTHORITY_URL` with your auth provider's OIDC URL, as explained above.
 - If you are running on a version of Kubernetes earlier than 1.24, set `enableHealthProbes` to `false` to disable the gRPC liveness and readiness probes.
@@ -616,7 +616,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
@@ -632,7 +632,7 @@ An SV node includes a validator app so you also need to configure that. Please m
 Additionally, please modify the file `splice-node/examples/sv-helm/sv-validator-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with dev.global.canton.network.digitalasset.com, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 The private and public key for your SV are defined in a K8s secret. If you haven't done so yet, please first follow the instructions in the Generating an SV Identity section to obtain and register a name and keypair for your SV. Replace `YOUR_PUBLIC_KEY` and `YOUR_PRIVATE_KEY` with the `public-key` and `private-key` values obtained as part of generating your SV identity.
@@ -645,7 +645,7 @@ kubectl create secret --namespace sv generic splice-app-sv-key \
 For configuring your sv app, please modify the file `splice-node/examples/sv-helm/sv-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with dev.global.canton.network.digitalasset.com, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - If you want to configure the audience for the SV app backend API, replace `OIDC_AUTHORITY_SV_AUDIENCE` in the `auth.audience` entry with audience for the SV app backend API. e.g. `https://sv.example.com/api`.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity (this must be an exact match of the string for your SV to be approved to onboard)
@@ -704,7 +704,7 @@ Please modify the file `splice-node/examples/sv-helm/participant-values.yaml` as
 
 </div>
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 - Replace `OIDC_AUTHORITY_LEDGER_API_AUDIENCE` in the `auth.targetAudience` entry with audience for the ledger API. e.g. `https://ledger_api.example.com`. If you are not ready to use a custom audience, you can use the suggested default `https://canton.network.global`.
 - Update the `auth.jwksUrl` entry to point to your auth provider's JWK set document by replacing `OIDC_AUTHORITY_URL` with your auth provider's OIDC URL, as explained above.
 - If you are running on a version of Kubernetes earlier than 1.24, set `enableHealthProbes` to `false` to disable the gRPC liveness and readiness probes.
@@ -718,7 +718,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
@@ -734,7 +734,7 @@ An SV node includes a validator app so you also need to configure that. Please m
 Additionally, please modify the file `splice-node/examples/sv-helm/sv-validator-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with test.global.canton.network.digitalasset.com, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 The private and public key for your SV are defined in a K8s secret. If you haven't done so yet, please first follow the instructions in the Generating an SV Identity section to obtain and register a name and keypair for your SV. Replace `YOUR_PUBLIC_KEY` and `YOUR_PRIVATE_KEY` with the `public-key` and `private-key` values obtained as part of generating your SV identity.
@@ -747,7 +747,7 @@ kubectl create secret --namespace sv generic splice-app-sv-key \
 For configuring your sv app, please modify the file `splice-node/examples/sv-helm/sv-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with test.global.canton.network.digitalasset.com, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - If you want to configure the audience for the SV app backend API, replace `OIDC_AUTHORITY_SV_AUDIENCE` in the `auth.audience` entry with audience for the SV app backend API. e.g. `https://sv.example.com/api`.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity (this must be an exact match of the string for your SV to be approved to onboard)
@@ -806,7 +806,7 @@ Please modify the file `splice-node/examples/sv-helm/participant-values.yaml` as
 
 </div>
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 - Replace `OIDC_AUTHORITY_LEDGER_API_AUDIENCE` in the `auth.targetAudience` entry with audience for the ledger API. e.g. `https://ledger_api.example.com`. If you are not ready to use a custom audience, you can use the suggested default `https://canton.network.global`.
 - Update the `auth.jwksUrl` entry to point to your auth provider's JWK set document by replacing `OIDC_AUTHORITY_URL` with your auth provider's OIDC URL, as explained above.
 - If you are running on a version of Kubernetes earlier than 1.24, set `enableHealthProbes` to `false` to disable the gRPC liveness and readiness probes.
@@ -820,7 +820,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
@@ -836,7 +836,7 @@ An SV node includes a validator app so you also need to configure that. Please m
 Additionally, please modify the file `splice-node/examples/sv-helm/sv-validator-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with global.canton.network.digitalasset.com, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 The private and public key for your SV are defined in a K8s secret. If you haven't done so yet, please first follow the instructions in the Generating an SV Identity section to obtain and register a name and keypair for your SV. Replace `YOUR_PUBLIC_KEY` and `YOUR_PRIVATE_KEY` with the `public-key` and `private-key` values obtained as part of generating your SV identity.
@@ -849,7 +849,7 @@ kubectl create secret --namespace sv generic splice-app-sv-key \
 For configuring your sv app, please modify the file `splice-node/examples/sv-helm/sv-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with global.canton.network.digitalasset.com, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - If you want to configure the audience for the SV app backend API, replace `OIDC_AUTHORITY_SV_AUDIENCE` in the `auth.audience` entry with audience for the SV app backend API. e.g. `https://sv.example.com/api`.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity (this must be an exact match of the string for your SV to be approved to onboard)

--- a/docs-main/global-synchronizer/deployment/sv-network-resets.mdx
+++ b/docs-main/global-synchronizer/deployment/sv-network-resets.mdx
@@ -36,14 +36,11 @@ To complete the reset, go through the following steps:
     1.  Uninstall all helm charts.
     2.  Delete all PVCs, docker volumes and databases (including databases in Amazon AWS, GCP CloudSQL or similar).
 3.  Deploy your new node
-    1.  Set the migration id to 0 in helm chart values. The migration id appears in all helm charts, both as its own value, e.g.:
-
-        >    migration:
-        >      id: "MIGRATION_ID"
+    1.  Set the serial id to 0 in helm chart values. The serial id appears in all helm charts, both as its own value, e.g.:
 
         and as part of various values, e.g.:
 
-        >    sequencerPublicUrl: "https://sequencer-MIGRATION_ID.sv.YOUR_HOSTNAME"
+        >    sequencerPublicUrl: "https://sequencer-SERIAL_ID.sv.YOUR_HOSTNAME"
 
     2.  Set `skipInitialization` to `false` in `sv-values.yaml`.
 
@@ -116,14 +113,11 @@ To complete the reset, go through the following steps:
     1.  Uninstall all helm charts.
     2.  Delete all PVCs, docker volumes and databases (including databases in Amazon AWS, GCP CloudSQL or similar).
 3.  Deploy your new node
-    1.  Set the migration id to 0 in helm chart values. The migration id appears in all helm charts, both as its own value, e.g.:
-
-        >    migration:
-        >      id: "MIGRATION_ID"
+    1.  Set the serial id to 0 in helm chart values. The serial id appears in all helm charts, both as its own value, e.g.:
 
         and as part of various values, e.g.:
 
-        >    sequencerPublicUrl: "https://sequencer-MIGRATION_ID.sv.YOUR_HOSTNAME"
+        >    sequencerPublicUrl: "https://sequencer-SERIAL_ID.sv.YOUR_HOSTNAME"
 
     2.  Set `skipInitialization` to `false` in `sv-values.yaml`.
 
@@ -196,14 +190,11 @@ To complete the reset, go through the following steps:
     1.  Uninstall all helm charts.
     2.  Delete all PVCs, docker volumes and databases (including databases in Amazon AWS, GCP CloudSQL or similar).
 3.  Deploy your new node
-    1.  Set the migration id to 0 in helm chart values. The migration id appears in all helm charts, both as its own value, e.g.:
-
-        >    migration:
-        >      id: "MIGRATION_ID"
+    1.  Set the serial id to 0 in helm chart values. The serial id appears in all helm charts, both as its own value, e.g.:
 
         and as part of various values, e.g.:
 
-        >    sequencerPublicUrl: "https://sequencer-MIGRATION_ID.sv.YOUR_HOSTNAME"
+        >    sequencerPublicUrl: "https://sequencer-SERIAL_ID.sv.YOUR_HOSTNAME"
 
     2.  Set `skipInitialization` to `false` in `sv-values.yaml`.
 

--- a/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
@@ -318,6 +318,10 @@ cd splice-node/docker-compose/validator
 > `<party_hint>` will be used as the prefix of the Party ID of your validator's administrator.
 > This must be of format `<organization>-<function>-<enumerator>`, e.g. `myCompany-myWallet-1`. It cannot be changed over time as it is part of the validator operator party ID.
 
+<Note>
+Since splice `0.6.8` the `-m` flag is optional. For new validator nodes it should be omitted. For existing validator nodes it must still be provided with the last known migration ID value.
+</Note>
+
 Note that the validator may be stopped with the command `./stop.sh` and restarted again with the same `start.sh` command as above. Its data will be retained between invocations. In subseqent invocations, the secret itself may be left empty, but the `-o` is still mandatory, so a `-o ""` argument should be provided.
 
 </Tab>
@@ -341,6 +345,10 @@ cd splice-node/docker-compose/validator
 > `<party_hint>` will be used as the prefix of the Party ID of your validator's administrator.
 > This must be of format `<organization>-<function>-<enumerator>`, e.g. `myCompany-myWallet-1`. It cannot be changed over time as it is part of the validator operator party ID.
 
+<Note>
+Since splice `0.6.8` the `-m` flag is optional. For new validator nodes it should be omitted. For existing validator nodes it must still be provided with the last known migration ID value.
+</Note>
+
 Note that the validator may be stopped with the command `./stop.sh` and restarted again with the same `start.sh` command as above. Its data will be retained between invocations. In subseqent invocations, the secret itself may be left empty, but the `-o` is still mandatory, so a `-o ""` argument should be provided.
 
 </Tab>
@@ -363,6 +371,10 @@ cd splice-node/docker-compose/validator
 >
 > `<party_hint>` will be used as the prefix of the Party ID of your validator's administrator.
 > This must be of format `<organization>-<function>-<enumerator>`, e.g. `myCompany-myWallet-1`. It cannot be changed over time as it is part of the validator operator party ID.
+
+<Note>
+Since splice `0.6.8` the `-m` flag is optional. For new validator nodes it should be omitted. For existing validator nodes it must still be provided with the last known migration ID value.
+</Note>
 
 Note that the validator may be stopped with the command `./stop.sh` and restarted again with the same `start.sh` command as above. Its data will be retained between invocations. In subseqent invocations, the secret itself may be left empty, but the `-o` is still mandatory, so a `-o ""` argument should be provided.
 

--- a/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
@@ -459,7 +459,7 @@ If you are using the provided postgres helm chart, modify `splice-node/examples/
 
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-participant-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to (devnet/testnet/mainnet).
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 
 You need to configure how your validator connects to the network's **scan** services by defining a `scanClient` block in your `standalone-validator-values.yaml`.
 
@@ -541,7 +541,7 @@ synchronizer:
 ```
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-validator-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
+- No longer needed since splice `0.6.8`: Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
 - Replace `SPONSOR_SV_URL` with the URL of the SV that provided you your secret.
 - Replace `YOUR_VALIDATOR_PARTY_HINT` with the desired name for your validator operator party. It must be of the format `<organization>-<function>-<enumerator>`.
 - Replace `YOUR_VALIDATOR_NODE_NAME` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your `validatorPartyHint`.
@@ -570,7 +570,7 @@ If you are using the provided postgres helm chart, modify `splice-node/examples/
 
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-participant-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to (devnet/testnet/mainnet).
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 
 You need to configure how your validator connects to the network's **scan** services by defining a `scanClient` block in your `standalone-validator-values.yaml`.
 
@@ -652,7 +652,7 @@ synchronizer:
 ```
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-validator-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
+- No longer needed since splice `0.6.8`: Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
 - Replace `SPONSOR_SV_URL` with the URL of the SV that provided you your secret.
 - Replace `YOUR_VALIDATOR_PARTY_HINT` with the desired name for your validator operator party. It must be of the format `<organization>-<function>-<enumerator>`.
 - Replace `YOUR_VALIDATOR_NODE_NAME` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your `validatorPartyHint`.
@@ -681,7 +681,7 @@ If you are using the provided postgres helm chart, modify `splice-node/examples/
 
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-participant-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to (devnet/testnet/mainnet).
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 
 You need to configure how your validator connects to the network's **scan** services by defining a `scanClient` block in your `standalone-validator-values.yaml`.
 
@@ -763,7 +763,7 @@ synchronizer:
 ```
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-validator-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
+- No longer needed since splice `0.6.8`: Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
 - Replace `SPONSOR_SV_URL` with the URL of the SV that provided you your secret.
 - Replace `YOUR_VALIDATOR_PARTY_HINT` with the desired name for your validator operator party. It must be of the format `<organization>-<function>-<enumerator>`.
 - Replace `YOUR_VALIDATOR_NODE_NAME` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your `validatorPartyHint`.

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
@@ -23,7 +23,7 @@ Please modify the file `splice-node/examples/sv-helm/participant-values.yaml` as
 
 </div>
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 - Replace `OIDC_AUTHORITY_LEDGER_API_AUDIENCE` in the `auth.targetAudience` entry with audience for the ledger API. e.g. `https://ledger_api.example.com`. If you are not ready to use a custom audience, you can use the suggested default `https://canton.network.global`.
 - Update the `auth.jwksUrl` entry to point to your auth provider's JWK set document by replacing `OIDC_AUTHORITY_URL` with your auth provider's OIDC URL, as explained above.
 - If you are running on a version of Kubernetes earlier than 1.24, set `enableHealthProbes` to `false` to disable the gRPC liveness and readiness probes.
@@ -37,7 +37,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
@@ -53,7 +53,7 @@ An SV node includes a validator app so you also need to configure that. Please m
 Additionally, please modify the file `splice-node/examples/sv-helm/sv-validator-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with |da_hostname|, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 
 The private and public key for your SV are defined in a K8s secret. If you haven't done so yet, please first follow the instructions in the Generating an SV Identity section to obtain and register a name and keypair for your SV. Replace `YOUR_PUBLIC_KEY` and `YOUR_PRIVATE_KEY` with the `public-key` and `private-key` values obtained as part of generating your SV identity.
@@ -63,7 +63,7 @@ The private and public key for your SV are defined in a K8s secret. If you haven
 For configuring your sv app, please modify the file `splice-node/examples/sv-helm/sv-values.yaml` as follows:
 
 - Replace all instances of `TARGET_HOSTNAME` with |da_hostname|, per the cluster to which you are connecting.
-- Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
+- No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - If you want to configure the audience for the SV app backend API, replace `OIDC_AUTHORITY_SV_AUDIENCE` in the `auth.audience` entry with audience for the SV app backend API. e.g. `https://sv.example.com/api`.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity (this must be an exact match of the string for your SV to be approved to onboard)

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/sv-network-resets-1.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/sv-network-resets-1.mdx
@@ -29,14 +29,11 @@ To complete the reset, go through the following steps:
     1.  Uninstall all helm charts.
     2.  Delete all PVCs, docker volumes and databases (including databases in Amazon AWS, GCP CloudSQL or similar).
 3.  Deploy your new node
-    1.  Set the migration id to 0 in helm chart values. The migration id appears in all helm charts, both as its own value, e.g.:
-
-        >    migration:
-        >      id: "MIGRATION_ID"
+    1.  Set the serial id to 0 in helm chart values. The serial id appears in all helm charts, both as its own value, e.g.:
 
         and as part of various values, e.g.:
 
-        >    sequencerPublicUrl: "https://sequencer-MIGRATION_ID.sv.YOUR_HOSTNAME"
+        >    sequencerPublicUrl: "https://sequencer-SERIAL_ID.sv.YOUR_HOSTNAME"
 
     2.  Set `skipInitialization` to `false` in `sv-values.yaml`.
 

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/validator-docker-compose-2.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/validator-docker-compose-2.mdx
@@ -16,4 +16,8 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcValidatorOperatorValidatorComposeBa
 > `<party_hint>` will be used as the prefix of the Party ID of your validator's administrator.
 > This must be of format `<organization>-<function>-<enumerator>`, e.g. `myCompany-myWallet-1`. It cannot be changed over time as it is part of the validator operator party ID.
 
+<Note>
+Since splice `0.6.8` the `-m` flag is optional. For new validator nodes it should be omitted. For existing validator nodes it must still be provided with the last known migration ID value.
+</Note>
+
 Note that the validator may be stopped with the command `./stop.sh` and restarted again with the same `start.sh` command as above. Its data will be retained between invocations. In subseqent invocations, the secret itself may be left empty, but the `-o` is still mandatory, so a `-o ""` argument should be provided.

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/validator-kubernetes-2.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/validator-kubernetes-2.mdx
@@ -19,7 +19,7 @@ If you are using the provided postgres helm chart, modify `splice-node/examples/
 
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-participant-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to (devnet/testnet/mainnet).
+- The `persistence.databaseName` includes by default the `MIGRATION_ID`, for new deployments you should set this to just `participant`, ignoring the `MIGRATION_ID`. Existing nodes must keep their current database name.
 
 You need to configure how your validator connects to the network's **scan** services by defining a `scanClient` block in your `standalone-validator-values.yaml`.
 
@@ -39,7 +39,7 @@ You need to configure how your validator's participant connects to **sequencers*
 
 Additionally, please modify the file `splice-node/examples/sv-helm/standalone-validator-values.yaml` as follows:
 
-- Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
+- No longer needed since splice `0.6.8`: Replace `MIGRATION_ID` with the migration ID of the global synchronizer on the network you are connecting to.
 - Replace `SPONSOR_SV_URL` with the URL of the SV that provided you your secret.
 - Replace `YOUR_VALIDATOR_PARTY_HINT` with the desired name for your validator operator party. It must be of the format `<organization>-<function>-<enumerator>`.
 - Replace `YOUR_VALIDATOR_NODE_NAME` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your `validatorPartyHint`.


### PR DESCRIPTION
Minimal changes, further cleanup will be done once 0.6.8 is in mainnet

further clean-up https://github.com/canton-network/splice/issues/5930

https://github.com/canton-network/splice/issues/5425