### PR TITLE
Fix token standard OpenAPI links

### DIFF
--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -328,7 +328,7 @@ Refer to [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/
 ### Token Metadata
 
 - Daml reference: [splice-api-token-metadata-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1)
-- OpenAPI reference: [Token Metadata Service](/reference/splice-token-metadata-service/get-registry-metadata-v1-info)
+- OpenAPI reference: [Token Metadata Service](/reference/splice-token-metadata-service/registrymetadatav1info)
 
 ### Holding
 
@@ -341,19 +341,19 @@ This allows implementation of a [Portfolio View](https://github.com/global-synch
 This allows implementation of [Direct Peer-to-Peer / Free of Payment (FOP) Transfers](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#direct-peer-to-peer--free-of-payment-fop-transfer-workflow).
 
 - Daml reference: [splice-api-token-transfer-instruction-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1)
-- OpenAPI reference: [Transfer Instruction API](/reference/splice-transfer-instruction-api/post-registry-transfer-instruction-v1-transfer-factory)
+- OpenAPI reference: [Transfer Instruction API](/reference/splice-transfer-instruction-api/registrytransfer-instructionv1transfer-factory)
 
 ### Allocation
 
 This allows implementation of [Delivery versus Payment (DVP) Transfer Workflows](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#delivery-versus-payment-dvp-transfer-workflows), jointly with the Allocation Instruction and Allocation Request APIs below.
 
 - Daml reference: [splice-api-token-allocation-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1)
-- OpenAPI reference: [Allocation API](/reference/splice-allocation-api/post-registry-allocations-v1-allocationid-choice-contexts-execute-transfer)
+- OpenAPI reference: [Allocation API](/reference/splice-allocation-api/registryallocationsv1-choice-contextsexecute-transfer)
 
 ### Allocation Instruction
 
 - Daml reference: [splice-api-token-allocation-instruction-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1)
-- OpenAPI reference: [Allocation Instruction API](/reference/splice-allocation-instruction-api/post-registry-allocation-instruction-v1-allocation-factory)
+- OpenAPI reference: [Allocation Instruction API](/reference/splice-allocation-instruction-api/registryallocation-instructionv1allocation-factory)
 
 ### Allocation Request
 

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2491,6 +2491,22 @@
       "destination": "/global-synchronizer/troubleshooting-guide/troubleshooting-methodology"
     },
     {
+      "source": "/reference/splice-token-metadata-service/get-registry-metadata-v1-info",
+      "destination": "/reference/splice-token-metadata-service/registrymetadatav1info"
+    },
+    {
+      "source": "/reference/splice-transfer-instruction-api/post-registry-transfer-instruction-v1-transfer-factory",
+      "destination": "/reference/splice-transfer-instruction-api/registrytransfer-instructionv1transfer-factory"
+    },
+    {
+      "source": "/reference/splice-allocation-api/post-registry-allocations-v1-allocationid-choice-contexts-execute-transfer",
+      "destination": "/reference/splice-allocation-api/registryallocationsv1-choice-contextsexecute-transfer"
+    },
+    {
+      "source": "/reference/splice-allocation-instruction-api/post-registry-allocation-instruction-v1-allocation-factory",
+      "destination": "/reference/splice-allocation-instruction-api/registryallocation-instructionv1allocation-factory"
+    },
+    {
       "source": "/global-synchronizer/release-notes/current-release",
       "destination": "/global-synchronizer/release-notes/splice"
     },

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2491,22 +2491,6 @@
       "destination": "/global-synchronizer/troubleshooting-guide/troubleshooting-methodology"
     },
     {
-      "source": "/reference/splice-token-metadata-service/get-registry-metadata-v1-info",
-      "destination": "/reference/splice-token-metadata-service/registrymetadatav1info"
-    },
-    {
-      "source": "/reference/splice-transfer-instruction-api/post-registry-transfer-instruction-v1-transfer-factory",
-      "destination": "/reference/splice-transfer-instruction-api/registrytransfer-instructionv1transfer-factory"
-    },
-    {
-      "source": "/reference/splice-allocation-api/post-registry-allocations-v1-allocationid-choice-contexts-execute-transfer",
-      "destination": "/reference/splice-allocation-api/registryallocationsv1-choice-contextsexecute-transfer"
-    },
-    {
-      "source": "/reference/splice-allocation-instruction-api/post-registry-allocation-instruction-v1-allocation-factory",
-      "destination": "/reference/splice-allocation-instruction-api/registryallocation-instructionv1allocation-factory"
-    },
-    {
       "source": "/global-synchronizer/release-notes/current-release",
       "destination": "/global-synchronizer/release-notes/splice"
     },


### PR DESCRIPTION
## Summary

Fixes four stale Token Standard OpenAPI links found by the live-site link audit.

Changes:
- Updates Token Standard links to the current generated OpenAPI operation slugs.

## Root cause

The generated Splice OpenAPI operation routes no longer use the older `get-...` / `post-...` slug shape referenced by the authored Token Standard page.

## Validation

- `jq empty docs-main/docs.json`
- `git diff --check`
- `npm run validate:splice-mintlify-openapi-nav`
- Confirmed all four replacement live targets return `HTTP 200`.