### PR TITLE
Fix stale release note links

### DIFF
--- a/docs-main/appdev/get-started/upgrading-from-previous-versions.mdx
+++ b/docs-main/appdev/get-started/upgrading-from-previous-versions.mdx
@@ -7,7 +7,7 @@ Per-version migration steps live with the component release notes. Use the links
 
 ## Within Canton 3.x
 
-- **Splice and the Global Synchronizer** — [Release notes](/global-synchronizer/release-notes/release-notes), [release history](/global-synchronizer/release-notes/release-history), [weekly patch releases](/global-synchronizer/release-notes/weekly-patch-releases)
+- **Splice and the Global Synchronizer** — [Release notes](/release-notes), [release history](/global-synchronizer/release-notes/release-history), [weekly patch releases](/global-synchronizer/release-notes/weekly-patch-releases)
 - **Wallet SDK** — [Wallet SDK release notes](/integrations/wallet/release-notes)
 - **Canton and Daml SDK** — [GitHub releases (digital-asset/daml)](https://github.com/digital-asset/daml/releases)
 

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2491,10 +2491,6 @@
       "destination": "/global-synchronizer/troubleshooting-guide/troubleshooting-methodology"
     },
     {
-      "source": "/global-synchronizer/release-notes/release-notes",
-      "destination": "/release-notes"
-    },
-    {
       "source": "/global-synchronizer/release-notes/current-release",
       "destination": "/global-synchronizer/release-notes/splice"
     },

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2491,6 +2491,10 @@
       "destination": "/global-synchronizer/troubleshooting-guide/troubleshooting-methodology"
     },
     {
+      "source": "/global-synchronizer/release-notes/release-notes",
+      "destination": "/release-notes"
+    },
+    {
       "source": "/global-synchronizer/release-notes/current-release",
       "destination": "/global-synchronizer/release-notes/splice"
     },

--- a/docs-main/shared/support-channels.mdx
+++ b/docs-main/shared/support-channels.mdx
@@ -106,7 +106,7 @@ Before contacting support, check these resources:
 |----------|---------|
 | [FAQ](/appdev/faq) | Common questions |
 | [Troubleshooting](/appdev/troubleshooting) | Error solutions |
-| [Release Notes](/global-synchronizer/release-notes/release-notes) | Version changes |
+| [Release Notes](/release-notes) | Version changes |
 | [Documentation](/) | Full documentation |
 
 ## Mailing Lists


### PR DESCRIPTION
## Summary

Fixes stale authored release-note links that pointed at `/global-synchronizer/release-notes/release-notes`, which returns 404 on the live site.

Changes:
- Updates the support channels and upgrade guide links to the release notes landing page.
- Does not add redirects; this PR only updates authored links.

## Root cause

The release notes structure now uses the top-level `/release-notes` landing page and component-specific release-note pages, but two authored pages still referenced an older nested route.
