### PR TITLE
Simplify docs direnv re-entry

### DIFF
--- a/scripts/docs_env.py
+++ b/scripts/docs_env.py
@@ -9,7 +9,16 @@ from typing import Sequence
 DIRENV_ENV_MARKER = "DIGITAL_ASSET_DOCS_DIRENV"
 
 
+def already_reentered_direnv() -> bool:
+    return os.environ.get(DIRENV_ENV_MARKER) == "1"
+
+
 def repo_direnv_command(repo_root: Path, *args: str) -> list[str]:
+    if already_reentered_direnv():
+        if args and args[0] == "x2mdx":
+            return ["python3", "-m", "x2mdx.cli", *args[1:]]
+        return list(args)
+
     if args and args[0] == "x2mdx":
         return [
             "direnv",
@@ -25,7 +34,7 @@ def repo_direnv_command(repo_root: Path, *args: str) -> list[str]:
 
 
 def ensure_repo_direnv(*, repo_root: Path, script_path: Path, argv: Sequence[str]) -> None:
-    if os.environ.get(DIRENV_ENV_MARKER) == "1":
+    if already_reentered_direnv():
         return
 
     env = os.environ.copy()

--- a/tests/test_docs_env.py
+++ b/tests/test_docs_env.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def load_docs_env():
+    return importlib.import_module("scripts.docs_env")
+
+
+def test_repo_direnv_command_runs_x2mdx_directly_after_direnv_reentry(monkeypatch) -> None:
+    docs_env = load_docs_env()
+    monkeypatch.setenv(docs_env.DIRENV_ENV_MARKER, "1")
+
+    assert docs_env.repo_direnv_command(Path("/repo"), "x2mdx", "openrpc") == [
+        "python3",
+        "-m",
+        "x2mdx.cli",
+        "openrpc",
+    ]
+
+
+def test_repo_direnv_command_uses_direnv_even_inside_nix_shell(monkeypatch) -> None:
+    docs_env = load_docs_env()
+    monkeypatch.delenv(docs_env.DIRENV_ENV_MARKER, raising=False)
+    monkeypatch.setenv("IN_NIX_SHELL", "pure")
+
+    assert docs_env.repo_direnv_command(Path("/repo"), "python3", "script.py") == [
+        "direnv",
+        "exec",
+        "/repo",
+        "python3",
+        "script.py",
+    ]


### PR DESCRIPTION
## Summary
- Simplifies docs environment re-entry so repo commands assume direnv exec and only run directly after the script re-enters with its marker.

## Stack
This is PR 1/8 in the generated-reference automation split.

Base: `main`
Head: `generated-reference-01-docs-env-direnv`

## Validation
- python3 -m pytest tests/test_docs_env.py; python3 -m py_compile scripts/docs_env.py; git diff --check
