### PR TITLE
Add Wallet Gateway generated reference PR target

### DIFF
--- a/scripts/update_generated_reference_prs.py
+++ b/scripts/update_generated_reference_prs.py
@@ -53,6 +53,33 @@ UPDATE_TARGETS = (
             "git diff --check",
         ),
     ),
+    UpdateTarget(
+        key="wallet-gateway-openrpc",
+        title="Update Wallet Gateway OpenRPC reference",
+        branch="generated-references/wallet-gateway-openrpc/update",
+        description=(
+            "Updates the Wallet Gateway OpenRPC source pin to the latest stable "
+            "wallet-gateway-remote release and regenerates the checked-in Wallet Gateway "
+            "OpenRPC reference pages."
+        ),
+        generate_commands=(
+            ("nix-shell", "--run", "npm run update:generated-reference-sources -- --source wallet-gateway-openrpc"),
+            ("nix-shell", "--run", "npm run generate:wallet-gateway-openrpc-reference"),
+        ),
+        paths=(
+            "config/x2mdx/wallet-gateway-openrpc/source-artifacts.json",
+            "docs-main/docs.json",
+            "docs-main/reference/wallet-gateway-json-rpc",
+        ),
+        summary_kind="source-config",
+        summary_path="config/x2mdx/wallet-gateway-openrpc/source-artifacts.json",
+        summary_label="Wallet Gateway OpenRPC",
+        validation=(
+            "npm run update:generated-reference-sources -- --source wallet-gateway-openrpc",
+            "npm run generate:wallet-gateway-openrpc-reference",
+            "git diff --check",
+        ),
+    ),
 )
 
 

--- a/tests/test_update_generated_reference_prs.py
+++ b/tests/test_update_generated_reference_prs.py
@@ -51,12 +51,12 @@ def test_targets_to_run_rejects_mixed_all_and_target_keys() -> None:
         raise AssertionError("Expected targets_to_run to reject mixed all and target keys")
 
 
-def test_targets_to_run_accepts_dashboard_target_key() -> None:
+def test_targets_to_run_preserves_declared_target_order_for_target_keys() -> None:
     module = load_script_module()
 
-    targets = module.targets_to_run(["version-dashboard"])
+    targets = module.targets_to_run(["wallet-gateway-openrpc", "version-dashboard"])
 
-    assert [target.key for target in targets] == ["version-dashboard"]
+    assert [target.key for target in targets] == ["version-dashboard", "wallet-gateway-openrpc"]
 
 
 def test_generated_clean_paths_include_target_paths_and_internal_output() -> None:
@@ -65,21 +65,22 @@ def test_generated_clean_paths_include_target_paths_and_internal_output() -> Non
     clean_paths = module.generated_clean_paths()
 
     assert ".internal" in clean_paths
+    assert "docs-main/reference/wallet-gateway-json-rpc" in clean_paths
     assert "docs-main/snippets/generated/version-dashboard-data.mdx" in clean_paths
 
 
 def test_body_markdown_includes_description_changes_and_validation() -> None:
     module = load_script_module()
-    target = next(target for target in module.UPDATE_TARGETS if target.key == "version-dashboard")
+    target = next(target for target in module.UPDATE_TARGETS if target.key == "wallet-gateway-openrpc")
 
     body = module.body_markdown(
         target=target,
-        changes=["- DevNet Splice: 0.6.6 -> 0.6.7"],
+        changes=["- Wallet Gateway OpenRPC publish_version: 0.25.0 -> 1.4.0"],
     )
 
-    assert body.startswith("Updates the committed Canton Network version dashboard data")
-    assert "Version changes:\n- DevNet Splice: 0.6.6 -> 0.6.7" in body
-    assert "- `npm run generate:version-compatibility-dashboard`" in body
+    assert body.startswith("Updates the Wallet Gateway OpenRPC source pin")
+    assert "Version changes:\n- Wallet Gateway OpenRPC publish_version: 0.25.0 -> 1.4.0" in body
+    assert "- `npm run generate:wallet-gateway-openrpc-reference`" in body
 
 
 def test_body_markdown_notes_when_no_versions_changed() -> None:


### PR DESCRIPTION
## Summary
- Adds Wallet Gateway OpenRPC as a second generated-reference PR target so the workflow opens separate draft PRs per target.

## Stack
This is PR 8/8 in the generated-reference automation split.

Base: `generated-reference-07-dashboard-pr-orchestrator`
Head: `generated-reference-08-wallet-pr-target`

## Validation
- python3 -m pytest tests/test_docs_env.py tests/test_update_generated_reference_sources.py tests/test_update_generated_reference_prs.py tests/test_summarize_version_changes.py tests/test_generate_network_component_versions.py tests/test_wallet_kernel_nav.py tests/test_openrpc.py; python3 scripts/update_generated_reference_prs.py --help; python3 scripts/update_generated_reference_sources.py --help; workflow YAML parse; no-Any/env scan; git diff --check
