### PR TITLE
Remove accidental section from release notes for 0.6.8

### DIFF
--- a/docs-main/global-synchronizer/release-notes/splice.mdx
+++ b/docs-main/global-synchronizer/release-notes/splice.mdx
@@ -7,11 +7,6 @@ description: "Release notes and version history for Global Synchronizer software
 
   - Deployment
 
-      - The ``migration.id`` value is no longer required by the SV (sv, validator, scan apps) and validator (validator app) helm charts and has been removed.
-        These apps now resolve the synchronizer migration id automatically at start-up. For the scan helm chart the
-        ``migration.id`` value is now optional and only needs to be set to bootstrap a scan that does not yet have any
-        migration id in its database (e.g. the network-founding or a freshly joining scan).
-
       - SV
 
           - The ``migration.id`` value was removed from the SV helm charts (sv, validator, scan apps).


### PR DESCRIPTION
This section contains incorrect information about scan it was re-added accidentally in https://github.com/canton-network/splice/commit/77bd27ce30a3cfde762d90a60a7af9bbca8f463c