### PR TITLE
Automate TypeScript bindings reference updates

### DIFF
--- a/config/x2mdx/typescript-bindings/source-artifacts.json
+++ b/config/x2mdx/typescript-bindings/source-artifacts.json
@@ -9,12 +9,13 @@
       "page_description": "TypeScript and JavaScript language bindings for Canton.",
       "output_file": "docs-main/reference/typescript.mdx",
       "entry_point": "index.d.ts",
-      "publish_version": "3.4.11",
+      "publish_version": "3.5.2",
       "versions": [
         "3.4.8",
         "3.4.9",
         "3.4.10",
-        "3.4.11"
+        "3.4.11",
+        "3.5.2"
       ]
     },
     {
@@ -44,9 +45,10 @@
       "typedoc_args": [
         "--skipErrorChecking"
       ],
-      "publish_version": "1.1.0",
+      "publish_version": "1.2.0",
       "versions": [
-        "1.1.0"
+        "1.1.0",
+        "1.2.0"
       ]
     }
   ]

--- a/docs-main/reference/typescript.mdx
+++ b/docs-main/reference/typescript.mdx
@@ -58,6 +58,7 @@ Generated from published `@daml/types` TypeDoc snapshots.
 | `3.4.9` | - | `3` | - |
 | `3.4.10` | - | - | - |
 | `3.4.11` | - | - | - |
+| `3.5.2` | - | - | - |
 
 ## Reference
 

--- a/docs-main/reference/typescript/dapp-sdk.mdx
+++ b/docs-main/reference/typescript/dapp-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@canton-network/dapp-sdk"
+title: "dApp SDK"
 description: "TypeScript client library reference for dApp integrations."
 ---
 
@@ -9,15 +9,14 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 
 | Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
 | --- | --- | --- | --- | --- | --- | --- |
-| [`dappAPI`](#namespace-dappapi) | Namespace | - | `1.1.0` | - | - | - |
+| [`dappAPI`](#namespace-dappapi) | Namespace | - | `1.1.0` | `1.2.0`: details updated | - | - |
 | [`ErrorCode`](#enumeration-errorcode) | Enumeration | - | `1.1.0` | - | - | - |
-| [`DappClient`](#class-dappclient) | Class | DappClient is a thin convenience wrapper around a connected<br/>``Provider&lt;DappRpcTypes&gt;``.<br/><br/>It exposes typed RPC helpers, event subscription shortcuts,<br/>``window.canton`` injection, and session-persistence listeners.<br/><br/>How to obtain a provider is **not** this class's concern.<br/>Use ``DiscoveryClient`` + the wallet picker, or construct any<br/>``Provider&lt;DappRpcTypes&gt;`` directly — then pass it here. | `1.1.0` | - | - | - |
-| [`DappSDK`](#class-dappsdk) | Class | - | `1.1.0` | - | - | - |
-| [`DiscoveryClient`](#class-discoveryclient) | Class | DiscoveryClient manages provider adapters and exposes a unified<br/>Provider&lt;DappRpcTypes&gt; regardless of the underlying wallet type.<br/><br/>It is UI-framework agnostic — the wallet picker UI is injected<br/>via the ``walletPicker`` config option.<br/><br/>Client-level events (``discovery:connected``, ``discovery:disconnected``,<br/>``discovery:error``) track the adapter session lifecycle. Provider-level<br/>CIP-103 events (statusChanged, accountsChanged, txChanged) live on<br/>the Provider — subscribe via ``client.getProvider().on(...)``. | `1.1.0` | - | - | - |
+| [`DappClient`](#class-dappclient) | Class | DappClient is a thin convenience wrapper around a connected<br/>``Provider&lt;DappRpcTypes&gt;``.<br/><br/>It exposes typed RPC helpers, event subscription shortcuts,<br/>and session-persistence listeners.<br/><br/>How to obtain a provider is **not** this class's concern.<br/>Use ``DiscoveryClient`` + the wallet picker, or construct any<br/>``Provider&lt;DappRpcTypes&gt;`` directly — then pass it here. | `1.1.0` | `1.2.0`: summary updated; members added: `onMessageSignature`, `removeOnMessageSignature`, `signMessage` | - | - |
+| [`DappSDK`](#class-dappsdk) | Class | - | `1.1.0` | `1.2.0`: members added: `onMessageSignature`, `removeOnMessageSignature`, `signMessage` | - | - |
+| [`DiscoveryClient`](#class-discoveryclient) | Class | DiscoveryClient manages provider adapters and exposes a unified<br/>Provider&lt;DappRpcTypes&gt; regardless of the underlying wallet type.<br/><br/>It is UI-framework agnostic — the wallet picker UI is injected<br/>via the ``walletPicker`` config option.<br/><br/>Client-level events (``discovery:connected``, ``discovery:disconnected``,<br/>``discovery:error``) track the adapter session lifecycle. Provider-level<br/>CIP-103 events (statusChanged, accountsChanged, txChanged) live on<br/>the Provider — subscribe via ``client.getProvider().on(...)``. | `1.1.0` | `1.2.0`: details updated | - | - |
 | [`DiscoveryError`](#class-discoveryerror) | Class | - | `1.1.0` | - | - | - |
 | [`EventEmitter`](#class-eventemitter) | Class | - | `1.1.0` | - | - | - |
 | [`ExtensionAdapter`](#class-extensionadapter) | Class | ProviderAdapter for any CIP-103 compliant wallet exposed as a browser extension.<br/><br/>provider() returns a DappProvider which communicates via postMessage<br/>and implements the full openrpc-dapp-api.json surface directly. | `1.1.0` | - | - | - |
-| [`InjectedAdapter`](#class-injectedadapter) | Class | A ProviderAdapter is a thin factory that knows how to create a<br/>Provider&lt;DappRpcTypes&gt; for a particular wallet type, detect its<br/>availability, and clean up resources.<br/><br/>All RPC methods (connect, disconnect, status, prepareExecute, etc.)<br/>are called directly on the provider — the adapter does not duplicate them. | `1.1.0` | - | - | - |
 | [`NotConnectedError`](#class-notconnectederror) | Class | - | `1.1.0` | - | - | - |
 | [`RemoteAdapter`](#class-remoteadapter) | Class | ProviderAdapter for any CIP-103 compliant wallet reachable over HTTP/SSE.<br/><br/>provider() returns a provider that maps the remote API<br/>(openrpc-dapp-remote-api.json) to the dApp API<br/>(openrpc-dapp-api.json) via dappSDKController. | `1.1.0` | - | - | - |
 | [`SessionExpiredError`](#class-sessionexpirederror) | Class | - | `1.1.0` | - | - | - |
@@ -26,17 +25,18 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | [`WalletConnectAdapter`](#class-walletconnectadapter) | Class | Single-class WalletConnect adapter that implements both ProviderAdapter<br/>(for discovery/wallet-picker) and Provider&lt;DappRpcTypes&gt; (for RPC calls).<br/><br/>Calls signClient.request() directly with ``canton_`` prefixed methods.<br/>Events arriving via session_event are buffered until a listener attaches. | `1.1.0` | - | - | - |
 | [`WalletNotFoundError`](#class-walletnotfounderror) | Class | - | `1.1.0` | - | - | - |
 | [`WalletNotInstalledError`](#class-walletnotinstallederror) | Class | - | `1.1.0` | - | - | - |
+| [`InjectedAdapter`](#class-injectedadapter) | Class | A ProviderAdapter is a thin factory that knows how to create a<br/>Provider&lt;DappRpcTypes&gt; for a particular wallet type, detect its<br/>availability, and clean up resources.<br/><br/>All RPC methods (connect, disconnect, status, prepareExecute, etc.)<br/>are called directly on the provider — the adapter does not duplicate them. | `1.1.0` | - | - | `1.2.0` |
 | [`ActiveSession`](#interface-activesession) | Interface | - | `1.1.0` | - | - | - |
-| [`DappClientOptions`](#interface-dappclientoptions) | Interface | - | `1.1.0` | - | - | - |
+| [`DappClientOptions`](#interface-dappclientoptions) | Interface | - | `1.1.0` | `1.2.0`: members removed: `injectGlobal` | - | - |
 | [`DiscoveryClientConfig`](#interface-discoveryclientconfig) | Interface | - | `1.1.0` | - | - | - |
 | [`DiscoveryConnectedEvent`](#interface-discoveryconnectedevent) | Interface | - | `1.1.0` | - | - | - |
 | [`DiscoveryDisconnectedEvent`](#interface-discoverydisconnectedevent) | Interface | - | `1.1.0` | - | - | - |
 | [`DiscoveryErrorEvent`](#interface-discoveryerrorevent) | Interface | - | `1.1.0` | - | - | - |
-| [`ProviderAdapter`](#interface-provideradapter) | Interface | A ProviderAdapter is a thin factory that knows how to create a<br/>Provider&lt;DappRpcTypes&gt; for a particular wallet type, detect its<br/>availability, and clean up resources.<br/><br/>All RPC methods (connect, disconnect, status, prepareExecute, etc.)<br/>are called directly on the provider — the adapter does not duplicate them. | `1.1.0` | - | - | - |
+| [`ProviderAdapter`](#interface-provideradapter) | Interface | A ProviderAdapter is a thin factory that knows how to create a<br/>Provider&lt;DappRpcTypes&gt; for a particular wallet type, detect its<br/>availability, and clean up resources.<br/><br/>All RPC methods (connect, disconnect, status, prepareExecute, etc.)<br/>are called directly on the provider — the adapter does not duplicate them. | `1.1.0` | `1.2.0`: details updated | - | - |
 | [`RemoteAdapterConfig`](#interface-remoteadapterconfig) | Interface | - | `1.1.0` | - | - | - |
-| [`WalletConnectAdapterConfig`](#interface-walletconnectadapterconfig) | Interface | - | `1.1.0` | - | - | - |
+| [`WalletConnectAdapterConfig`](#interface-walletconnectadapterconfig) | Interface | - | `1.1.0` | `1.2.0`: members added: `onSignInWithCanton`, `signInWithCanton` | - | - |
 | [`WalletInfo`](#interface-walletinfo) | Interface | - | `1.1.0` | - | - | - |
-| [`WalletPickerEntry`](#interface-walletpickerentry) | Interface | Wallet picker entry and result | `1.1.0` | - | - | - |
+| [`WalletPickerEntry`](#interface-walletpickerentry) | Interface | - | `1.1.0` | - | - | - |
 | [`WalletPickerResult`](#interface-walletpickerresult) | Interface | - | `1.1.0` | - | - | - |
 | [`DiscoveryClientEventHandler`](#type-alias-discoveryclienteventhandler) | Type Alias | - | `1.1.0` | - | - | - |
 | [`DiscoveryClientEventMap`](#type-alias-discoveryclienteventmap) | Type Alias | - | `1.1.0` | - | - | - |
@@ -48,7 +48,7 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | [`dappSDK`](#variable-dappsdk) | Variable | - | `1.1.0` | - | - | - |
 | [`ProviderAdapterConfig`](#variable-provideradapterconfig) | Variable | Provider adapter configuration | `1.1.0` | - | - | - |
 | [`WALLET_GATEWAY_ICON`](#variable-wallet-gateway-icon) | Variable | Alias for Wallet Gateway - same as Canton logo | `1.1.0` | - | - | - |
-| [`connect`](#function-connect) | Function | Opens the wallet picker and connects. Prefer init with adapters at startup;<br/>``options`` here is a legacy convenience that forwards to DappSDK.init. | `1.1.0` | - | - | - |
+| [`connect`](#function-connect) | Function | Opens the wallet picker and connects. Prefer init with adapters at startup;<br/>``options`` here is a legacy convenience that forwards to DappSDK.init. | `1.1.0` | `1.2.0`: details updated | - | - |
 | [`disconnect`](#function-disconnect) | Function | - | `1.1.0` | - | - | - |
 | [`getConnectedProvider`](#function-getconnectedprovider) | Function | - | `1.1.0` | - | - | - |
 | [`init`](#function-init) | Function | - | `1.1.0` | - | - | - |
@@ -67,28 +67,29 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | [`removeOnStatusChanged`](#function-removeonstatuschanged) | Function | - | `1.1.0` | - | - | - |
 | [`removeOnTxChanged`](#function-removeontxchanged) | Function | - | `1.1.0` | - | - | - |
 | [`status`](#function-status) | Function | - | `1.1.0` | - | - | - |
-| [`AccountsChangedEvent`](#reference-accountschangedevent) | Reference | - | `1.1.0` | - | - | - |
-| [`ConnectResult`](#reference-connectresult) | Reference | - | `1.1.0` | - | - | - |
-| [`LedgerApiParams`](#reference-ledgerapiparams) | Reference | - | `1.1.0` | - | - | - |
-| [`LedgerApiResult`](#reference-ledgerapiresult) | Reference | - | `1.1.0` | - | - | - |
-| [`ListAccountsResult`](#reference-listaccountsresult) | Reference | - | `1.1.0` | - | - | - |
-| [`Network`](#reference-network) | Reference | - | `1.1.0` | - | - | - |
-| [`PrepareExecuteAndWaitResult`](#reference-prepareexecuteandwaitresult) | Reference | - | `1.1.0` | - | - | - |
-| [`PrepareExecuteParams`](#reference-prepareexecuteparams) | Reference | - | `1.1.0` | - | - | - |
-| [`ProviderId`](#reference-providerid) | Reference | - | `1.1.0` | - | - | - |
-| [`ProviderType`](#reference-providertype) | Reference | - | `1.1.0` | - | - | - |
-| [`Session`](#reference-session) | Reference | - | `1.1.0` | - | - | - |
-| [`SignMessageParams`](#reference-signmessageparams) | Reference | - | `1.1.0` | - | - | - |
-| [`SignMessageResult`](#reference-signmessageresult) | Reference | - | `1.1.0` | - | - | - |
-| [`StatusEvent`](#reference-statusevent) | Reference | - | `1.1.0` | - | - | - |
-| [`TxChangedEvent`](#reference-txchangedevent) | Reference | - | `1.1.0` | - | - | - |
-| [`Wallet`](#reference-wallet) | Reference | - | `1.1.0` | - | - | - |
+| [`AccountsChangedEvent`](#reference-accountschangedevent) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`ConnectResult`](#reference-connectresult) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`LedgerApiParams`](#reference-ledgerapiparams) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`LedgerApiResult`](#reference-ledgerapiresult) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`ListAccountsResult`](#reference-listaccountsresult) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`Network`](#reference-network) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`PrepareExecuteAndWaitResult`](#reference-prepareexecuteandwaitresult) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`PrepareExecuteParams`](#reference-prepareexecuteparams) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`ProviderId`](#reference-providerid) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`ProviderType`](#reference-providertype) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`Session`](#reference-session) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`SignMessageParams`](#reference-signmessageparams) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`SignMessageResult`](#reference-signmessageresult) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`StatusEvent`](#reference-statusevent) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`TxChangedEvent`](#reference-txchangedevent) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
+| [`Wallet`](#reference-wallet) | Reference | - | `1.1.0` | `1.2.0`: details updated | - | - |
 
 ## Version Change Summary
 
 | Version | Added | Changed | Removed |
 | --- | --- | --- | --- |
 | `1.1.0` | `74` | - | - |
+| `1.2.0` | - | `24` | `1` |
 
 ## Reference
 
@@ -100,7 +101,14 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 
 - Kind: `Namespace`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `node_modules/@canton-network/core-wallet-dapp-rpc-client/dist/index.d.ts:1`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 **Members**
 
@@ -109,8 +117,15 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | `WalletJSONRPCDAppAPI` | `void` | - |
 | `Body` | `void` | - |
 | `ConnectResult` | `void` | - |
+| `CreateAndExerciseCommand` | `void` | - |
+| `CreateAndExerciseCommandPayload` | `void` | Inner shape is defined by the Canton Ledger API CreateAndExerciseCommand schema; do not re-specify here. |
+| `CreateCommand` | `void` | - |
+| `CreateCommandPayload` | `void` | Inner shape is defined by the Canton Ledger API CreateCommand schema; do not re-specify here. |
 | `DisclosedContract` | `void` | Structure representing a disclosed contract for transaction execution |
-| `JsCommands` | `void` | Structure representing JS commands for transaction execution |
+| `ExerciseByKeyCommand` | `void` | - |
+| `ExerciseByKeyCommandPayload` | `void` | Inner shape is defined by the Canton Ledger API ExerciseByKeyCommand schema; do not re-specify here. |
+| `ExerciseCommand` | `void` | - |
+| `ExerciseCommandPayload` | `void` | Inner shape is defined by the Canton Ledger API ExerciseCommand schema; do not re-specify here. |
 | `LedgerApiParams` | `void` | Ledger API request structure |
 | `LedgerApiResult` | `void` | Ledger Api response |
 | `MessageSignatureFailedEvent` | `void` | Event emitted when a message signature has failed. |
@@ -137,7 +152,9 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | `AccountsChanged` | `() =&gt; Promise&lt;AccountsChangedEvent&gt;` | - |
 | `AccountsChangedEvent` | `Wallet[]` | Event emitted when the user's accounts change. |
 | `ActAs` | `Party[]` | Set of parties on whose behalf the command should be executed, if submitted. If not set, the primary wallet's party is used. |
+| `Command` | `CreateCommand \| ExerciseCommand \| CreateAndExerciseCommand \| ExerciseByKeyCommand` | A Daml command atom. Mirror of the Canton Ledger API Command union; inner shapes are intentionally opaque so the dApp layer never drifts from the Ledger API contract. |
 | `CommandId` | `string` | The unique identifier of the command associated with the transaction. |
+| `Commands` | `Command[]` | Non-empty array of Daml command atoms to submit atomically as a single transaction. |
 | `CompletionOffset` | `number` | - |
 | `Connect` | `() =&gt; Promise&lt;ConnectResult&gt;` | - |
 | `ContractId` | `string` | The unique identifier of the disclosed contract. |
@@ -229,13 +246,20 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 
 - Kind: `Class`
 - Introduced: `1.1.0`
-- Source: `dist/client.d.ts:22`
+- Changed in: `1.2.0`
+- Source: `dist/client.d.ts:20`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | summary updated; members added: `onMessageSignature`, `removeOnMessageSignature`, `signMessage` |
 
 DappClient is a thin convenience wrapper around a connected
 ``Provider&lt;DappRpcTypes&gt;``.
 
 It exposes typed RPC helpers, event subscription shortcuts,
-``window.canton`` injection, and session-persistence listeners.
+and session-persistence listeners.
 
 How to obtain a provider is **not** this class's concern.
 Use ``DiscoveryClient`` + the wallet picker, or construct any
@@ -254,6 +278,7 @@ Use ``DiscoveryClient`` + the wallet picker, or construct any
 | `listAccounts` | `void` | - |
 | `onAccountsChanged` | `void` | - |
 | `onConnected` | `void` | - |
+| `onMessageSignature` | `void` | - |
 | `onStatusChanged` | `void` | - |
 | `onTxChanged` | `void` | - |
 | `open` | `void` | - |
@@ -261,8 +286,10 @@ Use ``DiscoveryClient`` + the wallet picker, or construct any
 | `prepareExecuteAndWait` | `void` | - |
 | `removeOnAccountsChanged` | `void` | - |
 | `removeOnConnected` | `void` | - |
+| `removeOnMessageSignature` | `void` | - |
 | `removeOnStatusChanged` | `void` | - |
 | `removeOnTxChanged` | `void` | - |
+| `signMessage` | `void` | - |
 | `status` | `void` | - |
 
 <span id="class-dappsdk"></span>
@@ -271,7 +298,14 @@ Use ``DiscoveryClient`` + the wallet picker, or construct any
 
 - Kind: `Class`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/sdk.d.ts:16`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | members added: `onMessageSignature`, `removeOnMessageSignature`, `signMessage` |
 
 **Members**
 
@@ -287,6 +321,7 @@ Use ``DiscoveryClient`` + the wallet picker, or construct any
 | `listAccounts` | `void` | - |
 | `onAccountsChanged` | `void` | - |
 | `onConnected` | `void` | - |
+| `onMessageSignature` | `void` | - |
 | `onStatusChanged` | `void` | - |
 | `onTxChanged` | `void` | - |
 | `open` | `void` | - |
@@ -294,8 +329,10 @@ Use ``DiscoveryClient`` + the wallet picker, or construct any
 | `prepareExecuteAndWait` | `void` | - |
 | `removeOnAccountsChanged` | `void` | - |
 | `removeOnConnected` | `void` | - |
+| `removeOnMessageSignature` | `void` | - |
 | `removeOnStatusChanged` | `void` | - |
 | `removeOnTxChanged` | `void` | - |
+| `signMessage` | `void` | - |
 | `status` | `void` | - |
 
 <span id="class-discoveryclient"></span>
@@ -304,7 +341,14 @@ Use ``DiscoveryClient`` + the wallet picker, or construct any
 
 - Kind: `Class`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `node_modules/@canton-network/core-wallet-discovery/dist/client.d.ts:31`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 DiscoveryClient manages provider adapters and exposes a unified
 Provider&lt;DappRpcTypes&gt; regardless of the underlying wallet type.
@@ -396,36 +440,6 @@ and implements the full openrpc-dapp-api.json surface directly.
 | `name` | `string` | - |
 | `providerId` | `string` | - |
 | `target` | `string` | - |
-| `type` | `ProviderType` | - |
-| `detect` | `void` | - |
-| `getInfo` | `void` | - |
-| `provider` | `void` | - |
-| `restore` | `void` | - |
-| `teardown` | `void` | - |
-
-<span id="class-injectedadapter"></span>
-
-#### InjectedAdapter
-
-- Kind: `Class`
-- Introduced: `1.1.0`
-- Source: `dist/adapter/injected-adapter.d.ts:12`
-
-A ProviderAdapter is a thin factory that knows how to create a
-Provider&lt;DappRpcTypes&gt; for a particular wallet type, detect its
-availability, and clean up resources.
-
-All RPC methods (connect, disconnect, status, prepareExecute, etc.)
-are called directly on the provider — the adapter does not duplicate them.
-
-**Members**
-
-| Member | Type | Description |
-| --- | --- | --- |
-| `constructor` | `void` | - |
-| `icon` | `string` | - |
-| `name` | `string` | - |
-| `providerId` | `string` | - |
 | `type` | `ProviderType` | - |
 | `detect` | `void` | - |
 | `getInfo` | `void` | - |
@@ -557,7 +571,7 @@ provider() returns a provider that maps the remote API
 
 - Kind: `Class`
 - Introduced: `1.1.0`
-- Source: `dist/adapter/walletconnect-adapter.d.ts:25`
+- Source: `dist/adapter/walletconnect-adapter.d.ts:74`
 
 Single-class WalletConnect adapter that implements both ProviderAdapter
 (for discovery/wallet-picker) and Provider&lt;DappRpcTypes&gt; (for RPC calls).
@@ -629,6 +643,38 @@ Events arriving via session_event are buffered until a listener attaches.
 | `captureStackTrace` | `void` | - |
 | `prepareStackTrace` | `void` | - |
 
+<span id="class-injectedadapter"></span>
+
+#### InjectedAdapter
+
+- Kind: `Class`
+- Introduced: `1.1.0`
+- Removed in: `1.2.0`
+- Shown for historical reference.
+- Source: `dist/adapter/injected-adapter.d.ts:12`
+
+A ProviderAdapter is a thin factory that knows how to create a
+Provider&lt;DappRpcTypes&gt; for a particular wallet type, detect its
+availability, and clean up resources.
+
+All RPC methods (connect, disconnect, status, prepareExecute, etc.)
+are called directly on the provider — the adapter does not duplicate them.
+
+**Members**
+
+| Member | Type | Description |
+| --- | --- | --- |
+| `constructor` | `void` | - |
+| `icon` | `string` | - |
+| `name` | `string` | - |
+| `providerId` | `string` | - |
+| `type` | `ProviderType` | - |
+| `detect` | `void` | - |
+| `getInfo` | `void` | - |
+| `provider` | `void` | - |
+| `restore` | `void` | - |
+| `teardown` | `void` | - |
+
 ### Interfaces
 
 <span id="interface-activesession"></span>
@@ -659,7 +705,14 @@ interface ActiveSession
 
 - Kind: `Interface`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/client.d.ts:3`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | members removed: `injectGlobal` |
 
 **Signature**
 
@@ -671,7 +724,6 @@ interface DappClientOptions
 
 | Member | Type | Description |
 | --- | --- | --- |
-| `injectGlobal` | `boolean` | Inject provider into ``window.canton``. Defaults to true. |
 | `providerType` | `ProviderType` | Provider type hint — affects ``open()`` routing. Defaults to ``'remote'``. |
 | `target` | `string` | Optional routing key for extension open messages. |
 
@@ -764,7 +816,14 @@ interface DiscoveryErrorEvent
 
 - Kind: `Interface`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `node_modules/@canton-network/core-wallet-discovery/dist/types.d.ts:27`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 **Signature**
 
@@ -823,7 +882,14 @@ interface RemoteAdapterConfig extends ProviderAdapterConfig
 
 - Kind: `Interface`
 - Introduced: `1.1.0`
-- Source: `dist/adapter/walletconnect-adapter.d.ts:6`
+- Changed in: `1.2.0`
+- Source: `dist/adapter/walletconnect-adapter.d.ts:52`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | members added: `onSignInWithCanton`, `signInWithCanton` |
 
 **Signature**
 
@@ -837,8 +903,10 @@ interface WalletConnectAdapterConfig
 | --- | --- | --- |
 | `chainId` | `string` | - |
 | `metadata` | `{ description: string; icons: string[]; name: string; url: string }` | - |
+| `onSignInWithCanton` | `(result: SignInWithCantonResult) =&gt; void` | - |
 | `onUri` | `(uri: string) =&gt; void` | Called with the pairing URI so the dApp can display or forward it. |
 | `projectId` | `string` | - |
+| `signInWithCanton` | `SIWXMessageParams` | Whether to trigger a canton_signMessage request after the session is established. |
 
 <span id="interface-walletinfo"></span>
 
@@ -872,15 +940,13 @@ interface WalletInfo
 
 - Kind: `Interface`
 - Introduced: `1.1.0`
-- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:144`
+- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:150`
 
 **Signature**
 
 ```ts
 interface WalletPickerEntry
 ```
-
-Wallet picker entry and result
 
 **Members**
 
@@ -900,7 +966,7 @@ Wallet picker entry and result
 
 - Kind: `Interface`
 - Introduced: `1.1.0`
-- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:154`
+- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:166`
 
 **Signature**
 
@@ -988,7 +1054,7 @@ type DiscoveryErrorCode = "WALLET_NOT_FOUND" | "WALLET_NOT_INSTALLED" | "USER_RE
 
 - Kind: `Type Alias`
 - Introduced: `1.1.0`
-- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:137`
+- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:142`
 
 **Signature**
 
@@ -1037,7 +1103,7 @@ Canton logo (PNG) - used as the default icon for Wallet Gateway
 
 - Kind: `Variable`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:88`
+- Source: `dist/sdk.d.ts:90`
 
 **Signature**
 
@@ -1051,7 +1117,7 @@ const dappSDK: DappSDK
 
 - Kind: `Variable`
 - Introduced: `1.1.0`
-- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:137`
+- Source: `node_modules/@canton-network/core-types/dist/index.d.ts:142`
 
 **Signature**
 
@@ -1085,7 +1151,14 @@ Alias for Wallet Gateway - same as Canton logo
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:93`
+- Changed in: `1.2.0`
+- Source: `dist/sdk.d.ts:95`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 **Signature**
 
@@ -1127,7 +1200,7 @@ Returns: `Promise<ConnectResult>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:97`
+- Source: `dist/sdk.d.ts:99`
 
 **Signature**
 
@@ -1149,7 +1222,7 @@ Returns: `Promise<null>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:105`
+- Source: `dist/sdk.d.ts:107`
 
 **Signature**
 
@@ -1171,7 +1244,7 @@ Returns: `Provider<RpcTypes>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:96`
+- Source: `dist/sdk.d.ts:98`
 
 **Signature**
 
@@ -1197,7 +1270,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:98`
+- Source: `dist/sdk.d.ts:100`
 
 **Signature**
 
@@ -1219,7 +1292,7 @@ Returns: `Promise<ConnectResult>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:103`
+- Source: `dist/sdk.d.ts:105`
 
 **Signature**
 
@@ -1245,7 +1318,7 @@ Returns: `Promise<LedgerApiResult>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:100`
+- Source: `dist/sdk.d.ts:102`
 
 **Signature**
 
@@ -1267,7 +1340,7 @@ Returns: `Promise<ListAccountsResult>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:107`
+- Source: `dist/sdk.d.ts:109`
 
 **Signature**
 
@@ -1293,7 +1366,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:108`
+- Source: `dist/sdk.d.ts:110`
 
 **Signature**
 
@@ -1319,7 +1392,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:106`
+- Source: `dist/sdk.d.ts:108`
 
 **Signature**
 
@@ -1345,7 +1418,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:109`
+- Source: `dist/sdk.d.ts:111`
 
 **Signature**
 
@@ -1371,7 +1444,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:104`
+- Source: `dist/sdk.d.ts:106`
 
 **Signature**
 
@@ -1393,7 +1466,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:101`
+- Source: `dist/sdk.d.ts:103`
 
 **Signature**
 
@@ -1419,7 +1492,7 @@ Returns: `Promise<null>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:102`
+- Source: `dist/sdk.d.ts:104`
 
 **Signature**
 
@@ -1445,7 +1518,7 @@ Returns: `Promise<PrepareExecuteAndWaitResult>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:111`
+- Source: `dist/sdk.d.ts:114`
 
 **Signature**
 
@@ -1471,7 +1544,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:112`
+- Source: `dist/sdk.d.ts:115`
 
 **Signature**
 
@@ -1497,7 +1570,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:110`
+- Source: `dist/sdk.d.ts:113`
 
 **Signature**
 
@@ -1523,7 +1596,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:113`
+- Source: `dist/sdk.d.ts:116`
 
 **Signature**
 
@@ -1549,7 +1622,7 @@ Returns: `Promise<void>`
 
 - Kind: `Function`
 - Introduced: `1.1.0`
-- Source: `dist/sdk.d.ts:99`
+- Source: `dist/sdk.d.ts:101`
 
 **Signature**
 
@@ -1573,7 +1646,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-connectresult"></span>
 
@@ -1581,7 +1661,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-ledgerapiparams"></span>
 
@@ -1589,7 +1676,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-ledgerapiresult"></span>
 
@@ -1597,7 +1691,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-listaccountsresult"></span>
 
@@ -1605,7 +1706,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-network"></span>
 
@@ -1613,7 +1721,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-prepareexecuteandwaitresult"></span>
 
@@ -1621,7 +1736,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-prepareexecuteparams"></span>
 
@@ -1629,7 +1751,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-providerid"></span>
 
@@ -1637,7 +1766,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/adapter/types.d.ts:2`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-providertype"></span>
 
@@ -1645,7 +1781,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/adapter/types.d.ts:2`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-session"></span>
 
@@ -1653,7 +1796,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-signmessageparams"></span>
 
@@ -1661,7 +1811,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-signmessageresult"></span>
 
@@ -1669,7 +1826,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-statusevent"></span>
 
@@ -1677,7 +1841,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-txchangedevent"></span>
 
@@ -1685,7 +1856,14 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |
 
 <span id="reference-wallet"></span>
 
@@ -1693,4 +1871,11 @@ Returns: `Promise<StatusEvent>`
 
 - Kind: `Reference`
 - Introduced: `1.1.0`
+- Changed in: `1.2.0`
 - Source: `dist/index.d.ts:10`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `1.2.0` | details updated |

--- a/docs-main/reference/typescript/wallet-sdk.mdx
+++ b/docs-main/reference/typescript/wallet-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@canton-network/wallet-sdk"
+title: "Wallet SDK"
 description: "TypeScript client library reference for wallet integrations."
 ---
 

--- a/scripts/generated_reference_sources/typescript_bindings.py
+++ b/scripts/generated_reference_sources/typescript_bindings.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Required, TypedDict
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from generated_reference_sources.common import SourceUpdate, load_json, write_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_KEY = "typescript-bindings"
+SOURCE_LABEL = "TypeScript bindings"
+DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "x2mdx" / "typescript-bindings" / "source-artifacts.json"
+DEFAULT_TIMEOUT_SECONDS = 20.0
+USER_AGENT = "cf-docs-generated-reference-source-updater"
+
+
+class TypeScriptPackageConfigPayload(TypedDict, total=False):
+    package_name: Required[str]
+    source: str
+    version_filter: str
+    page_title: str
+    page_description: str
+    output_file: str
+    entry_point: str
+    typedoc_args: list[str]
+    typedoc_version: str
+    publish_version: Required[str]
+    versions: Required[list[str]]
+
+
+@dataclass(frozen=True)
+class TypeScriptPackageConfig:
+    raw: TypeScriptPackageConfigPayload
+    package_name: str
+    publish_version: str
+    versions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TypeScriptBindingsSourceConfig:
+    raw: dict[str, object]
+    packages: tuple[TypeScriptPackageConfig, ...]
+
+
+def parse_source_config(path: Path) -> TypeScriptBindingsSourceConfig:
+    raw_json = load_json(path)
+    packages_json = raw_json.get("packages")
+    if not isinstance(packages_json, list) or not packages_json:
+        raise ValueError(f"{path} must define a non-empty packages list")
+
+    packages: list[TypeScriptPackageConfig] = []
+    for index, package_json in enumerate(packages_json):
+        if not isinstance(package_json, dict):
+            raise ValueError(f"{path} packages[{index}] must be an object")
+        package_name = package_json.get("package_name")
+        publish_version = package_json.get("publish_version")
+        versions = package_json.get("versions")
+        if not isinstance(package_name, str) or not package_name:
+            raise ValueError(f"{path} packages[{index}] must define package_name")
+        if not isinstance(publish_version, str) or not publish_version:
+            raise ValueError(f"{path} packages[{package_name}] must define publish_version")
+        if not isinstance(versions, list) or not all(isinstance(version, str) and version for version in versions):
+            raise ValueError(f"{path} packages[{package_name}] must define a non-empty versions string list")
+
+        raw: TypeScriptPackageConfigPayload = {}
+        raw.update(package_json)
+        packages.append(
+            TypeScriptPackageConfig(
+                raw=raw,
+                package_name=package_name,
+                publish_version=publish_version,
+                versions=tuple(versions),
+            )
+        )
+    return TypeScriptBindingsSourceConfig(raw=raw_json, packages=tuple(packages))
+
+
+def latest_npm_version(package_name: str, *, timeout: float = DEFAULT_TIMEOUT_SECONDS) -> str:
+    encoded_name = quote(package_name, safe="")
+    request = Request(
+        f"https://registry.npmjs.org/{encoded_name}",
+        headers={"User-Agent": USER_AGENT},
+    )
+    with urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    latest = payload.get("dist-tags", {}).get("latest")
+    if not isinstance(latest, str) or not latest:
+        raise ValueError(f"npm package {package_name} does not define a latest dist-tag")
+    return latest
+
+
+def update_source(
+    *,
+    source_config_path: Path,
+    dry_run: bool,
+) -> list[SourceUpdate]:
+    source_config = parse_source_config(source_config_path)
+    updates: list[SourceUpdate] = []
+    updated_packages: list[dict[str, object]] = []
+
+    for package in source_config.packages:
+        current_version = latest_npm_version(package.package_name)
+        updated_package = dict(package.raw)
+        if package.publish_version != current_version:
+            updates.append(
+                SourceUpdate(
+                    source=f"{SOURCE_LABEL} {package.package_name}",
+                    path=source_config_path,
+                    field="publish_version",
+                    previous=package.publish_version,
+                    current=current_version,
+                )
+            )
+            versions = list(package.versions)
+            if current_version not in versions:
+                versions.append(current_version)
+            updated_package["publish_version"] = current_version
+            updated_package["versions"] = versions
+        updated_packages.append(updated_package)
+
+    if updates and not dry_run:
+        updated_config = dict(source_config.raw)
+        updated_config["packages"] = updated_packages
+        write_json(source_config_path, updated_config)
+    return updates

--- a/scripts/summarize_version_changes.py
+++ b/scripts/summarize_version_changes.py
@@ -141,6 +141,32 @@ def source_config_changes(before_path: Path, after_path: Path, *, label: str) ->
     return changes
 
 
+def package_source_config_changes(before_path: Path, after_path: Path, *, label: str) -> list[str]:
+    before = load_json(before_path)
+    after = load_json(after_path)
+    before_packages = {
+        package["package_name"]: package
+        for package in object_items(before.get("packages"))
+        if isinstance(package.get("package_name"), str)
+    }
+    changes: list[str] = []
+    for package in object_items(after.get("packages")):
+        package_name = package.get("package_name")
+        if not isinstance(package_name, str):
+            continue
+        before_package = before_packages.get(package_name)
+        if before_package is None:
+            continue
+        before_version = before_package.get("publish_version")
+        after_version = package.get("publish_version")
+        if before_version != after_version:
+            changes.append(
+                f"- {label} {package_name} publish_version: "
+                f"{format_value(before_version)} -> {format_value(after_version)}"
+            )
+    return changes
+
+
 def print_changes(changes: list[str]) -> None:
     if changes:
         print("\n".join(changes))
@@ -160,6 +186,13 @@ def parse_args() -> argparse.Namespace:
     source_config.add_argument("before", type=Path)
     source_config.add_argument("after", type=Path)
     source_config.add_argument("--label", required=True)
+    package_source_config = subparsers.add_parser(
+        "package-source-config",
+        help="Summarize package-based generated-reference source config changes.",
+    )
+    package_source_config.add_argument("before", type=Path)
+    package_source_config.add_argument("after", type=Path)
+    package_source_config.add_argument("--label", required=True)
     return parser.parse_args()
 
 
@@ -169,6 +202,8 @@ def main() -> int:
         print_changes(dashboard_changes(args.before, args.after))
     elif args.command == "source-config":
         print_changes(source_config_changes(args.before, args.after, label=args.label))
+    elif args.command == "package-source-config":
+        print_changes(package_source_config_changes(args.before, args.after, label=args.label))
     else:
         raise AssertionError(f"Unhandled command: {args.command}")
     return 0

--- a/scripts/update_generated_reference_prs.py
+++ b/scripts/update_generated_reference_prs.py
@@ -80,6 +80,33 @@ UPDATE_TARGETS = (
             "git diff --check",
         ),
     ),
+    UpdateTarget(
+        key="typescript-bindings",
+        title="Update TypeScript bindings reference",
+        branch="generated-references/typescript-bindings/update",
+        description=(
+            "Updates the TypeScript bindings source pins to the latest stable npm "
+            "releases and regenerates the checked-in TypeScript bindings reference pages."
+        ),
+        generate_commands=(
+            ("nix-shell", "--run", "npm run update:generated-reference-sources -- --source typescript-bindings"),
+            ("nix-shell", "--run", "npm run generate:typescript-bindings-reference"),
+        ),
+        paths=(
+            "config/x2mdx/typescript-bindings/source-artifacts.json",
+            "docs-main/docs.json",
+            "docs-main/reference/typescript.mdx",
+            "docs-main/reference/typescript",
+        ),
+        summary_kind="package-source-config",
+        summary_path="config/x2mdx/typescript-bindings/source-artifacts.json",
+        summary_label="TypeScript bindings",
+        validation=(
+            "npm run update:generated-reference-sources -- --source typescript-bindings",
+            "npm run generate:typescript-bindings-reference",
+            "git diff --check",
+        ),
+    ),
 )
 
 
@@ -120,6 +147,14 @@ def summarize_target_changes(target: UpdateTarget, before_path: Path) -> list[st
         if target.summary_label is None:
             raise ValueError(f"Update target {target.key} must define summary_label")
         return summarize_version_changes.source_config_changes(
+            before_path,
+            after_path,
+            label=target.summary_label,
+        )
+    if target.summary_kind == "package-source-config":
+        if target.summary_label is None:
+            raise ValueError(f"Update target {target.key} must define summary_label")
+        return summarize_version_changes.package_source_config_changes(
             before_path,
             after_path,
             label=target.summary_label,

--- a/scripts/update_generated_reference_sources.py
+++ b/scripts/update_generated_reference_sources.py
@@ -6,13 +6,14 @@ import argparse
 import sys
 from pathlib import Path
 
-from generated_reference_sources import splice_openapi, wallet_gateway_openrpc
+from generated_reference_sources import splice_openapi, typescript_bindings, wallet_gateway_openrpc
 from generated_reference_sources.common import SourceUpdate
 
 
 SOURCE_SPLICE_OPENAPI = splice_openapi.SOURCE_KEY
 SOURCE_WALLET_GATEWAY_OPENRPC = wallet_gateway_openrpc.SOURCE_KEY
-ALL_SOURCES = (SOURCE_SPLICE_OPENAPI, SOURCE_WALLET_GATEWAY_OPENRPC)
+SOURCE_TYPESCRIPT_BINDINGS = typescript_bindings.SOURCE_KEY
+ALL_SOURCES = (SOURCE_SPLICE_OPENAPI, SOURCE_WALLET_GATEWAY_OPENRPC, SOURCE_TYPESCRIPT_BINDINGS)
 
 
 def parse_args() -> argparse.Namespace:
@@ -32,6 +33,15 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Wallet Gateway OpenRPC source-artifacts config. "
             f"Default: {wallet_gateway_openrpc.DEFAULT_SOURCE_CONFIG}"
+        ),
+    )
+    parser.add_argument(
+        "--typescript-bindings-source-config",
+        type=Path,
+        default=typescript_bindings.DEFAULT_SOURCE_CONFIG,
+        help=(
+            "TypeScript bindings source-artifacts config. "
+            f"Default: {typescript_bindings.DEFAULT_SOURCE_CONFIG}"
         ),
     )
     parser.add_argument(
@@ -79,6 +89,13 @@ def main() -> int:
         )
         if update is not None:
             updates.append(update)
+    if SOURCE_TYPESCRIPT_BINDINGS in sources:
+        updates.extend(
+            typescript_bindings.update_source(
+                source_config_path=args.typescript_bindings_source_config.resolve(),
+                dry_run=args.dry_run or args.check,
+            )
+        )
 
     if not updates:
         print("Generated reference source pins are up to date.")

--- a/tests/test_summarize_version_changes.py
+++ b/tests/test_summarize_version_changes.py
@@ -87,3 +87,32 @@ def test_source_config_changes_summarizes_publish_version(tmp_path: Path) -> Non
     assert module.source_config_changes(before, after, label="Wallet Gateway OpenRPC") == [
         "- Wallet Gateway OpenRPC publish_version: 0.25.0 -> 1.4.0"
     ]
+
+
+def test_package_source_config_changes_summarizes_package_publish_versions(tmp_path: Path) -> None:
+    module = load_script_module()
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    write_json(
+        before,
+        {
+            "packages": [
+                {"package_name": "@daml/types", "publish_version": "3.4.11"},
+                {"package_name": "@canton-network/dapp-sdk", "publish_version": "1.1.0"},
+            ]
+        },
+    )
+    write_json(
+        after,
+        {
+            "packages": [
+                {"package_name": "@daml/types", "publish_version": "3.5.2"},
+                {"package_name": "@canton-network/dapp-sdk", "publish_version": "1.2.0"},
+            ]
+        },
+    )
+
+    assert module.package_source_config_changes(before, after, label="TypeScript bindings") == [
+        "- TypeScript bindings @daml/types publish_version: 3.4.11 -> 3.5.2",
+        "- TypeScript bindings @canton-network/dapp-sdk publish_version: 1.1.0 -> 1.2.0",
+    ]

--- a/tests/test_update_generated_reference_prs.py
+++ b/tests/test_update_generated_reference_prs.py
@@ -66,6 +66,7 @@ def test_generated_clean_paths_include_target_paths_and_internal_output() -> Non
 
     assert ".internal" in clean_paths
     assert "docs-main/reference/wallet-gateway-json-rpc" in clean_paths
+    assert "docs-main/reference/typescript" in clean_paths
     assert "docs-main/snippets/generated/version-dashboard-data.mdx" in clean_paths
 
 

--- a/tests/test_update_generated_reference_sources.py
+++ b/tests/test_update_generated_reference_sources.py
@@ -61,6 +61,42 @@ def write_wallet_gateway_source_config(path: Path, *, publish_version: str) -> N
     )
 
 
+def write_typescript_bindings_source_config(
+    path: Path,
+    *,
+    daml_types_version: str = "3.4.11",
+    wallet_sdk_version: str = "1.3.1",
+    dapp_sdk_version: str = "1.1.0",
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "typedoc_version": "0.27.9",
+                "packages": [
+                    {
+                        "package_name": "@daml/types",
+                        "publish_version": daml_types_version,
+                        "versions": ["3.4.11"],
+                    },
+                    {
+                        "package_name": "@canton-network/wallet-sdk",
+                        "publish_version": wallet_sdk_version,
+                        "versions": ["1.3.1"],
+                    },
+                    {
+                        "package_name": "@canton-network/dapp-sdk",
+                        "publish_version": dapp_sdk_version,
+                        "versions": ["1.1.0"],
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_update_splice_openapi_source_updates_stale_publish_version(tmp_path: Path) -> None:
     module = load_script_module()
     source_config_path = tmp_path / "source-artifacts.json"
@@ -193,6 +229,90 @@ def test_update_wallet_gateway_openrpc_source_dry_run_does_not_write(tmp_path: P
     assert json.loads(source_config_path.read_text(encoding="utf-8"))["publish_version"] == "0.25.0"
 
 
+def test_update_typescript_bindings_source_updates_stale_package_versions(tmp_path: Path) -> None:
+    module = load_script_module()
+    source_config_path = tmp_path / "source-artifacts.json"
+    write_typescript_bindings_source_config(source_config_path)
+    latest_versions = {
+        "@daml/types": "3.5.2",
+        "@canton-network/wallet-sdk": "1.3.1",
+        "@canton-network/dapp-sdk": "1.2.0",
+    }
+    module.typescript_bindings.latest_npm_version = lambda package_name: latest_versions[package_name]
+
+    updates = module.typescript_bindings.update_source(
+        source_config_path=source_config_path,
+        dry_run=False,
+    )
+
+    assert updates == [
+        module.SourceUpdate(
+            source="TypeScript bindings @daml/types",
+            path=source_config_path,
+            field="publish_version",
+            previous="3.4.11",
+            current="3.5.2",
+        ),
+        module.SourceUpdate(
+            source="TypeScript bindings @canton-network/dapp-sdk",
+            path=source_config_path,
+            field="publish_version",
+            previous="1.1.0",
+            current="1.2.0",
+        ),
+    ]
+    packages = json.loads(source_config_path.read_text(encoding="utf-8"))["packages"]
+    assert packages[0]["publish_version"] == "3.5.2"
+    assert packages[0]["versions"] == ["3.4.11", "3.5.2"]
+    assert packages[1]["publish_version"] == "1.3.1"
+    assert packages[1]["versions"] == ["1.3.1"]
+    assert packages[2]["publish_version"] == "1.2.0"
+    assert packages[2]["versions"] == ["1.1.0", "1.2.0"]
+
+
+def test_update_typescript_bindings_source_noops_when_current(tmp_path: Path) -> None:
+    module = load_script_module()
+    source_config_path = tmp_path / "source-artifacts.json"
+    write_typescript_bindings_source_config(
+        source_config_path,
+        daml_types_version="3.5.2",
+        wallet_sdk_version="1.3.1",
+        dapp_sdk_version="1.2.0",
+    )
+    latest_versions = {
+        "@daml/types": "3.5.2",
+        "@canton-network/wallet-sdk": "1.3.1",
+        "@canton-network/dapp-sdk": "1.2.0",
+    }
+    module.typescript_bindings.latest_npm_version = lambda package_name: latest_versions[package_name]
+
+    assert module.typescript_bindings.update_source(
+        source_config_path=source_config_path,
+        dry_run=False,
+    ) == []
+
+
+def test_update_typescript_bindings_source_dry_run_does_not_write(tmp_path: Path) -> None:
+    module = load_script_module()
+    source_config_path = tmp_path / "source-artifacts.json"
+    write_typescript_bindings_source_config(source_config_path)
+    module.typescript_bindings.latest_npm_version = lambda package_name: {
+        "@daml/types": "3.5.2",
+        "@canton-network/wallet-sdk": "1.3.1",
+        "@canton-network/dapp-sdk": "1.2.0",
+    }[package_name]
+
+    updates = module.typescript_bindings.update_source(
+        source_config_path=source_config_path,
+        dry_run=True,
+    )
+
+    assert [update.current for update in updates] == ["3.5.2", "1.2.0"]
+    packages = json.loads(source_config_path.read_text(encoding="utf-8"))["packages"]
+    assert packages[0]["publish_version"] == "3.4.11"
+    assert packages[2]["publish_version"] == "1.1.0"
+
+
 def test_requested_sources_defaults_to_all_sources() -> None:
     module = load_script_module()
 
@@ -209,9 +329,10 @@ def test_requested_sources_preserves_order_and_deduplicates() -> None:
             {
                 "sources": [
                     "wallet-gateway-openrpc",
+                    "typescript-bindings",
                     "splice-openapi",
                     "wallet-gateway-openrpc",
                 ]
             },
         )()
-    ) == ("wallet-gateway-openrpc", "splice-openapi")
+    ) == ("wallet-gateway-openrpc", "typescript-bindings", "splice-openapi")


### PR DESCRIPTION
Adds TypeScript bindings to the generated-reference source updater and PR orchestration introduced by #773.

This adds a package-aware source updater for `config/x2mdx/typescript-bindings/source-artifacts.json`, registers a `typescript-bindings` generated PR target, and includes the regenerated TypeScript bindings reference output.

Validation:
- `direnv exec . python3 -m pytest tests/test_update_generated_reference_sources.py tests/test_update_generated_reference_prs.py tests/test_summarize_version_changes.py tests/test_typescript_bindings_reference.py`
- `direnv exec . npm run update:generated-reference-sources -- --source typescript-bindings --check`
- Actual workflow dispatch: https://github.com/canton-network/cf-docs/actions/runs/27714089077

Built after #773 merged.
