### PR TITLE
Update JSON Ledger API AsyncAPI reference

### DIFF
--- a/config/x2mdx/ledger-api-asyncapi/source-artifacts.json
+++ b/config/x2mdx/ledger-api-asyncapi/source-artifacts.json
@@ -11,7 +11,7 @@
     },
     {
       "version": "3.5",
-      "canton_version": "3.5.0-snapshot.20260405.18555.0.vbee160e5"
+      "canton_version": "3.5.5"
     }
   ]
 }

--- a/docs-main/reference/json-api-asyncapi-reference/operations/details.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/details.mdx
@@ -1,54 +1,50 @@
 ---
 title: "Details and history"
+description: "JSON Ledger API WebSocket AsyncAPI reference and version history."
 ---
 
-<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+<div class="x2mdx-ref-hero">
 
-<div className="x2mdx-ref-operation-shell">
-  <div className="x2mdx-ref-operation-main">
+  <p class="x2mdx-ref-eyebrow">AsyncAPI Reference</p>
 
 
-    <div class="x2mdx-ref-hero">
-      
-      <p class="x2mdx-ref-eyebrow">asyncapi reference</p>
-      
-      <h1 class="x2mdx-ref-title">JSON API AsyncAPI Reference</h1> 
-      <h2>Details and history</h2>
-      <p>JSON Ledger API WebSocket AsyncAPI reference and version history. Operation-first WebSocket reference pages built from AsyncAPI channel snapshots and lifecycle deltas.</p>
-      
-      <div class="x2mdx-ref-badges">
-      
-        <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">AsyncAPI</span>
-      
-        <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5</span>
-      
-      </div>
+  <h1 class="x2mdx-ref-title">JSON API AsyncAPI Reference</h1>
 
-    </div>
-  </div>
-  
+
+  <p class="x2mdx-ref-summary">Operation-first WebSocket reference pages built from AsyncAPI channel snapshots and lifecycle deltas.</p>
+
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">AsyncAPI</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">3.5</span>
+
+</div>
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Publish version</dt>
     <dd>3.5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>AsyncAPI version</dt>
     <dd>2.6.0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
     <dd>Canton release bundle JSON Ledger API AsyncAPI fixtures</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Version filter</dt>
     <dd>configured docs major versions from Canton release bundles</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -62,190 +58,190 @@ Use the channel page to choose a specific `publish` or `subscribe` action. Actio
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./v2-commands-completions/details">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>/v2/commands/completions</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Subscribe to command completion events.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Last seen</dt>
     <dd>3.5</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./v2-state-active-contracts/details">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>/v2/state/active-contracts</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client...</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Last seen</dt>
     <dd>3.5</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./v2-updates/details">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>/v2/updates</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Read the ledger&#x27;s filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection c...</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Last seen</dt>
     <dd>3.5</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./v2-updates-flats/details">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>/v2/updates/flats</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Get flat transactions update stream. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Last seen</dt>
     <dd>3.5</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./v2-updates-trees/details">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>/v2/updates/trees</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Get update transactions tree stream. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Last seen</dt>
     <dd>3.5</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-commands-completions/details.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-commands-completions/details.mdx
@@ -6,49 +6,49 @@ description: "Subscribe to command completion events."
 <p class="x2mdx-ref-back"><a href="../details">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">AsyncAPI Channel</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">/v2/commands/completions</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">Subscribe to command completion events.</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/commands/completions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Introduced</dt>
     <dd>3.4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Removed</dt>
     <dd>-</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -62,89 +62,89 @@ Subscribe to command completion events.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./publish">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>publish /v2/commands/completions</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Publish CompletionStreamRequest messages from the client to /v2/commands/completions.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2CommandsCompletions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./subscribe">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>subscribe /v2/commands/completions</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Receive Either_JsCantonError_CompletionStreamResponse messages from /v2/commands/completions on the subscription stream.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2CommandsCompletions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-commands-completions/publish.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-commands-completions/publish.mdx
@@ -9,55 +9,55 @@ title: "Publish completions"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/commands/completions</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>publish</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/commands/completions</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Publish completions</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--publish">PUBLISH</span>
-  
+
   <code>/v2/commands/completions</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Publish completions"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/commands/completions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>publish</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2CommandsCompletions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,47 +105,47 @@ title: "Publish completions"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CompletionStreamRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Client -&gt; Server</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>CompletionStreamRequest</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">array[string]</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -159,12 +159,12 @@ title: "Publish completions"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">channel description updated; publish description updated; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -175,25 +175,25 @@ title: "Publish completions"
 
 <Accordion title="CompletionStreamRequest">
 <div class="x2mdx-ref-schema" id="schema-v2-commands-completions-publish">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">array[string]</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -203,12 +203,12 @@ title: "Publish completions"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -220,14 +220,14 @@ npx wscat \
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -240,7 +240,7 @@ npx wscat \
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-commands-completions/subscribe.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-commands-completions/subscribe.mdx
@@ -9,55 +9,55 @@ title: "Subscribe completions"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/commands/completions</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>subscribe</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/commands/completions</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Subscribe completions</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--subscribe">SUBSCRIBE</span>
-  
+
   <code>/v2/commands/completions</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Subscribe completions"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/commands/completions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2CommandsCompletions</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
 
@@ -109,45 +109,45 @@ title: "Subscribe completions"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Either_JsCantonError_CompletionStreamResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Server -&gt; Client</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>Either_JsCantonError_CompletionStreamResponse</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completionResponse</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -157,12 +157,12 @@ title: "Subscribe completions"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">channel description updated; publish description updated; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -173,23 +173,23 @@ title: "Subscribe completions"
 
 <Accordion title="Either_JsCantonError_CompletionStreamResponse">
 <div class="x2mdx-ref-schema" id="schema-v2-commands-completions-subscribe">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completionResponse</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -199,12 +199,12 @@ title: "Subscribe completions"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -213,14 +213,14 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -243,7 +243,7 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/details.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/details.mdx
@@ -10,49 +10,49 @@ Clients SHOULD NOT assume that the set of active contracts they receive reflects
 <p class="x2mdx-ref-back"><a href="../details">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">AsyncAPI Channel</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">/v2/state/active-contracts</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client...</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/state/active-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Introduced</dt>
     <dd>3.4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Removed</dt>
     <dd>-</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -70,89 +70,89 @@ Clients SHOULD NOT assume that the set of active contracts they receive reflects
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./publish">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>publish /v2/state/active-contracts</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Publish GetActiveContractsRequest messages from the client to /v2/state/active-contracts.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2StateActive-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./subscribe">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>subscribe /v2/state/active-contracts</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Receive Either_JsCantonError_JsGetActiveContractsResponse messages from /v2/state/active-contracts on the subscription stream.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2StateActive-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/publish.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/publish.mdx
@@ -9,55 +9,55 @@ title: "Publish active contracts"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/state/active-contracts</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>publish</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/state/active-contracts</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Publish active contracts</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--publish">PUBLISH</span>
-  
+
   <code>/v2/state/active-contracts</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Publish active contracts"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/state/active-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>publish</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2StateActive-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,47 +105,47 @@ title: "Publish active contracts"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetActiveContractsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Client -&gt; Server</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>GetActiveContractsRequest</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">activeAtOffset</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -159,12 +159,12 @@ title: "Publish active contracts"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">channel description updated; publish description updated; publish required fields removed: `eventFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -175,25 +175,25 @@ title: "Publish active contracts"
 
 <Accordion title="GetActiveContractsRequest">
 <div class="x2mdx-ref-schema" id="schema-v2-state-active-contracts-publish">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">activeAtOffset</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -203,12 +203,12 @@ title: "Publish active contracts"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -220,14 +220,14 @@ npx wscat \
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -238,7 +238,7 @@ npx wscat \
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/subscribe.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/subscribe.mdx
@@ -9,55 +9,55 @@ title: "Subscribe active contracts"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/state/active-contracts</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>subscribe</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/state/active-contracts</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Subscribe active contracts</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--subscribe">SUBSCRIBE</span>
-  
+
   <code>/v2/state/active-contracts</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Subscribe active contracts"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/state/active-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2StateActive-contracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
 
@@ -109,72 +109,72 @@ title: "Subscribe active contracts"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Either_JsCantonError_JsGetActiveContractsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Server -&gt; Client</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>Either_JsCantonError_JsGetActiveContractsResponse</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -184,12 +184,12 @@ title: "Subscribe active contracts"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">channel description updated; publish description updated; publish required fields removed: `eventFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -200,50 +200,50 @@ title: "Subscribe active contracts"
 
 <Accordion title="Either_JsCantonError_JsGetActiveContractsResponse">
 <div class="x2mdx-ref-schema" id="schema-v2-state-active-contracts-subscribe">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -253,12 +253,12 @@ title: "Subscribe active contracts"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -267,14 +267,14 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -288,7 +288,7 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-flats/details.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-flats/details.mdx
@@ -6,49 +6,49 @@ description: "Get flat transactions update stream. Provided for backwards compat
 <p class="x2mdx-ref-back"><a href="../details">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">AsyncAPI Channel</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">/v2/updates/flats</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">Get flat transactions update stream. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates/flats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Introduced</dt>
     <dd>3.4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Removed</dt>
     <dd>-</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -62,89 +62,89 @@ Get flat transactions update stream. Provided for backwards compatibility, it wi
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./publish">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>publish /v2/updates/flats</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Publish GetUpdatesRequest messages from the client to /v2/updates/flats.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2UpdatesFlats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./subscribe">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>subscribe /v2/updates/flats</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Receive Either_JsCantonError_JsGetUpdatesResponse messages from /v2/updates/flats on the subscription stream.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2UpdatesFlats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-flats/publish.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-flats/publish.mdx
@@ -9,55 +9,55 @@ title: "Publish flats"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/updates/flats</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>publish</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/updates/flats</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Publish flats</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--publish">PUBLISH</span>
-  
+
   <code>/v2/updates/flats</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Publish flats"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates/flats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>publish</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2UpdatesFlats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,47 +105,47 @@ title: "Publish flats"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Client -&gt; Server</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>GetUpdatesRequest</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">beginExclusive</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -159,12 +159,12 @@ title: "Publish flats"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">publish description updated; publish required fields added: `beginExclusive`; publish required fields removed: `updateFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -175,25 +175,25 @@ title: "Publish flats"
 
 <Accordion title="GetUpdatesRequest">
 <div class="x2mdx-ref-schema" id="schema-v2-updates-flats-publish">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">beginExclusive</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -203,12 +203,12 @@ title: "Publish flats"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -220,14 +220,14 @@ npx wscat \
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -238,7 +238,7 @@ npx wscat \
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-flats/subscribe.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-flats/subscribe.mdx
@@ -9,55 +9,55 @@ title: "Subscribe flats"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/updates/flats</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>subscribe</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/updates/flats</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Subscribe flats</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--subscribe">SUBSCRIBE</span>
-  
+
   <code>/v2/updates/flats</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Subscribe flats"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates/flats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2UpdatesFlats</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
 
@@ -109,72 +109,72 @@ title: "Subscribe flats"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Either_JsCantonError_JsGetUpdatesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Server -&gt; Client</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>Either_JsCantonError_JsGetUpdatesResponse</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -184,12 +184,12 @@ title: "Subscribe flats"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">publish description updated; publish required fields added: `beginExclusive`; publish required fields removed: `updateFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -200,50 +200,50 @@ title: "Subscribe flats"
 
 <Accordion title="Either_JsCantonError_JsGetUpdatesResponse">
 <div class="x2mdx-ref-schema" id="schema-v2-updates-flats-subscribe">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -253,12 +253,12 @@ title: "Subscribe flats"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -267,14 +267,14 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -288,7 +288,7 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-trees/details.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-trees/details.mdx
@@ -6,49 +6,49 @@ description: "Get update transactions tree stream. Provided for backwards compat
 <p class="x2mdx-ref-back"><a href="../details">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">AsyncAPI Channel</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">/v2/updates/trees</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">Get update transactions tree stream. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates/trees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Introduced</dt>
     <dd>3.4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Removed</dt>
     <dd>-</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -62,89 +62,89 @@ Get update transactions tree stream. Provided for backwards compatibility, it wi
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./publish">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>publish /v2/updates/trees</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Publish GetUpdatesRequest messages from the client to /v2/updates/trees.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2UpdatesTrees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./subscribe">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>subscribe /v2/updates/trees</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Receive Either_JsCantonError_JsGetUpdateTreesResponse messages from /v2/updates/trees on the subscription stream.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2UpdatesTrees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-trees/publish.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-trees/publish.mdx
@@ -9,55 +9,55 @@ title: "Publish trees"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/updates/trees</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>publish</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/updates/trees</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Publish trees</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--publish">PUBLISH</span>
-  
+
   <code>/v2/updates/trees</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Publish trees"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates/trees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>publish</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2UpdatesTrees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,47 +105,47 @@ title: "Publish trees"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Client -&gt; Server</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>GetUpdatesRequest</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">beginExclusive</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -159,12 +159,12 @@ title: "Publish trees"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">publish description updated; publish required fields added: `beginExclusive`; publish required fields removed: `updateFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -175,25 +175,25 @@ title: "Publish trees"
 
 <Accordion title="GetUpdatesRequest">
 <div class="x2mdx-ref-schema" id="schema-v2-updates-trees-publish">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">beginExclusive</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -203,12 +203,12 @@ title: "Publish trees"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -220,14 +220,14 @@ npx wscat \
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -238,7 +238,7 @@ npx wscat \
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-trees/subscribe.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates-trees/subscribe.mdx
@@ -9,55 +9,55 @@ title: "Subscribe trees"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/updates/trees</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>subscribe</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/updates/trees</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Subscribe trees</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--subscribe">SUBSCRIBE</span>
-  
+
   <code>/v2/updates/trees</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Subscribe trees"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates/trees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2UpdatesTrees</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
 
@@ -109,72 +109,72 @@ title: "Subscribe trees"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Either_JsCantonError_JsGetUpdateTreesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Server -&gt; Client</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>Either_JsCantonError_JsGetUpdateTreesResponse</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -184,12 +184,12 @@ title: "Subscribe trees"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">publish description updated; publish required fields added: `beginExclusive`; publish required fields removed: `updateFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -200,50 +200,50 @@ title: "Subscribe trees"
 
 <Accordion title="Either_JsCantonError_JsGetUpdateTreesResponse">
 <div class="x2mdx-ref-schema" id="schema-v2-updates-trees-subscribe">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -253,12 +253,12 @@ title: "Subscribe trees"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -267,14 +267,14 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -288,7 +288,7 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates/details.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates/details.mdx
@@ -11,49 +11,49 @@ for individual events depends on the transaction shape chosen.
 <p class="x2mdx-ref-back"><a href="../details">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">AsyncAPI Channel</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">/v2/updates</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">Read the ledger&#x27;s filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection c...</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Actions</dt>
     <dd>publish, subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Introduced</dt>
     <dd>3.4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Removed</dt>
     <dd>-</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -72,89 +72,89 @@ for individual events depends on the transaction shape chosen.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./publish">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>publish /v2/updates</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Publish GetUpdatesRequest messages from the client to /v2/updates.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2Updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./subscribe">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>subscribe /v2/updates</h3>
     </div>
     <p class="x2mdx-ref-card-summary">Receive Either_JsCantonError_JsGetUpdatesResponse messages from /v2/updates on the subscription stream.</p>
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2Updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Method</dt>
     <dd>-</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates/publish.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates/publish.mdx
@@ -9,55 +9,55 @@ title: "Publish updates"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/updates</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>publish</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/updates</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Publish updates</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--publish">PUBLISH</span>
-  
+
   <code>/v2/updates</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Publish updates"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>publish</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>sendV2Updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>object</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,47 +105,47 @@ title: "Publish updates"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Client -&gt; Server</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>GetUpdatesRequest</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">beginExclusive</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -159,12 +159,12 @@ title: "Publish updates"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">channel description updated; publish description updated; publish required fields added: `beginExclusive`; publish required fields removed: `updateFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -175,25 +175,25 @@ title: "Publish updates"
 
 <Accordion title="GetUpdatesRequest">
 <div class="x2mdx-ref-schema" id="schema-v2-updates-publish">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">beginExclusive</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
       <span class="x2mdx-ref-required-badge">required</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -203,12 +203,12 @@ title: "Publish updates"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -220,14 +220,14 @@ npx wscat \
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -238,7 +238,7 @@ npx wscat \
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates/subscribe.mdx
+++ b/docs-main/reference/json-api-asyncapi-reference/operations/v2-updates/subscribe.mdx
@@ -9,55 +9,55 @@ title: "Subscribe updates"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <a href="../details">JSON API AsyncAPI</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="./details">/v2/updates</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>subscribe</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">/v2/updates</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Subscribe updates</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">WebSocket</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--subscribe">SUBSCRIBE</span>
-  
+
   <code>/v2/updates</code>
 </div>
 
@@ -65,37 +65,37 @@ title: "Subscribe updates"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>WebSocket</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Channel</dt>
     <dd>/v2/updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Action</dt>
     <dd>subscribe</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operation ID</dt>
     <dd>onV2Updates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Content type</dt>
     <dd>application/json</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Payload</dt>
     <dd>oneOf</dd>
   </div>
-  
+
 </dl>
 
 
@@ -109,72 +109,72 @@ title: "Subscribe updates"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Either_JsCantonError_JsGetUpdatesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Direction</dt>
     <dd>Server -&gt; Client</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>Either_JsCantonError_JsGetUpdatesResponse</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -184,12 +184,12 @@ title: "Subscribe updates"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.5</span>
     <span class="x2mdx-ref-change-detail">channel description updated; publish description updated; publish required fields added: `beginExclusive`; publish required fields removed: `updateFormat`; subscribe description updated</span>
   </div>
-  
+
 </div>
 
 
@@ -200,50 +200,50 @@ title: "Subscribe updates"
 
 <Accordion title="Either_JsCantonError_JsGetUpdatesResponse">
 <div class="x2mdx-ref-schema" id="schema-v2-updates-subscribe">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">code</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cause</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">context</code>
       <span class="x2mdx-ref-type-badge">object</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">errorCategory</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -253,12 +253,12 @@ title: "Subscribe updates"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">wscat</span>
-  
+
 </div>
 
 ```bash wscat
@@ -267,14 +267,14 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">message</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json message
@@ -288,7 +288,7 @@ npx wscat -c <WEBSOCKET_URL>
 
 </div>
   </div>
-  
+
 </div>
 
 </div>


### PR DESCRIPTION
Updates the JSON Ledger API AsyncAPI source pin to the latest public Canton release bundle for the published docs version and regenerates the checked-in AsyncAPI reference.

Version changes:
- JSON Ledger API AsyncAPI 3.5 canton_version: 3.5.0-snapshot.20260405.18555.0.vbee160e5 -> 3.5.5

Validation run by the workflow:
- `npm run update:generated-reference-sources -- --source ledger-api-asyncapi`
- `npm run generate:json-api-asyncapi-reference`
- `git diff --check`
