### PR TITLE
Update Canton protobuf history reference

### DIFF
--- a/docs-main/appdev/reference/protobuf-history/index.mdx
+++ b/docs-main/appdev/reference/protobuf-history/index.mdx
@@ -4,57 +4,57 @@ description: "Descriptor-backed protobuf API history grouped by package."
 ---
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Reference</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Details and History</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">Operation-first gRPC pages with package-level browsing and recursive related schema sections.</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Protobuf</span>
-  
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5.1</span>
-  
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5.5</span>
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
     <dd>Canton protobuf trees from published release bundles</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Version filter</dt>
     <dd>stable Canton release bundles &gt;= 3.2.0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Latest release</dt>
-    <dd>v3.5.1</dd>
+    <dd>v3.5.5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Packages</dt>
     <dd>5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>58</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>237</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -68,447 +68,447 @@ Counts are shown as added / changed / removed within each release slice.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.0</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>55 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>227 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>12 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.2</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.3</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.4</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 1 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.5</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.6</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.7</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.8</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.9</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.10</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 1 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.11</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>1 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
@@ -549,6 +549,166 @@ Counts are shown as added / changed / removed within each release slice.
   </div>
 
 
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.2</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.3</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
 </div>
 
 
@@ -561,187 +721,187 @@ Counts are shown as added / changed / removed within each release slice.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">9 services, 22 endpoints, 120 messages, 8 enums</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>9</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>22</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>120</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>8</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-admin">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.admin</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">6 services, 28 endpoints, 79 messages, 3 enums</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>28</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>79</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>3</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-interactive">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.interactive</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">1 services, 6 endpoints, 29 messages, 1 enums</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>29</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-testing">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.testing</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">1 services, 2 endpoints, 3 messages</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>3</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -754,50 +914,50 @@ Counts are shown as added / changed / removed within each release slice.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-interactive-transaction-v1">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.interactive.transaction.v1</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">0 services, 0 endpoints, 6 messages</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus.mdx
@@ -9,60 +9,60 @@ title: "GetCommandStatus"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetCommandStatus</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetCommandStatus</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.CommandInspectionService/GetCommandStatus</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetCommandStatus"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandInspectionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetCommandStatus</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GetCommandStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetCommandStatusRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id_prefix</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "GetCommandStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetCommandStatusResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_status</code>
       <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetCommandStatus"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,156 +235,156 @@ title: "GetCommandStatus"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetCommandStatusRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id_prefix</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CommandState">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstate">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>COMMAND_STATE_UNSPECIFIED</code></li>
-    
+
     <li><code>COMMAND_STATE_PENDING</code></li>
-    
+
     <li><code>COMMAND_STATE_SUCCEEDED</code></li>
-    
+
     <li><code>COMMAND_STATE_FAILED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetCommandStatusResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_status</code>
       <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CommandStatus">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstatus">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">started</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completed</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_statistics</code>
       <span class="x2mdx-ref-type-badge">RequestStatistics</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">updates</code>
       <span class="x2mdx-ref-type-badge">CommandUpdates</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
@@ -405,116 +405,116 @@ title: "GetCommandStatus"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Completion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -526,915 +526,915 @@ title: "GetCommandStatus"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.RequestStatistics">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-requeststatistics">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">envelopes</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">recipients</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CommandUpdates">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandupdates">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetched</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">looked_up_by_key</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Contract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-contract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1475,12 +1475,12 @@ title: "GetCommandStatus"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1499,14 +1499,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1567,7 +1567,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "CreateIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>CreateIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">CreateIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/CreateIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "CreateIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>CreateIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "CreateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,45 +153,45 @@ title: "CreateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -201,12 +201,12 @@ title: "CreateIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -217,103 +217,103 @@ title: "CreateIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -323,12 +323,12 @@ title: "CreateIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -351,14 +351,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -375,7 +375,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "DeleteIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>DeleteIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">DeleteIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/DeleteIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "DeleteIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>DeleteIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "DeleteIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,32 +153,32 @@ title: "DeleteIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "DeleteIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "DeleteIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "DeleteIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -261,14 +261,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "GetIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/GetIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "GetIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,45 +153,45 @@ title: "GetIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -201,12 +201,12 @@ title: "GetIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -217,103 +217,103 @@ title: "GetIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -323,12 +323,12 @@ title: "GetIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -345,14 +345,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -369,7 +369,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs.mdx
@@ -9,60 +9,60 @@ title: "ListIdentityProviderConfigs"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListIdentityProviderConfigs</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListIdentityProviderConfigs</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/ListIdentityProviderConfigs</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListIdentityProviderConfigs"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListIdentityProviderConfigs</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "ListIdentityProviderConfigs"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListIdentityProviderConfigsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "ListIdentityProviderConfigs"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListIdentityProviderConfigsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_configs</code>
       <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "ListIdentityProviderConfigs"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,90 +204,90 @@ title: "ListIdentityProviderConfigs"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_configs</code>
       <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -297,12 +297,12 @@ title: "ListIdentityProviderConfigs"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -317,14 +317,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -343,7 +343,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "UpdateIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/UpdateIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "UpdateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "UpdateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "UpdateIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,112 +226,112 @@ title: "UpdateIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -341,12 +341,12 @@ title: "UpdateIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -370,14 +370,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -394,7 +394,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages.mdx
@@ -9,60 +9,60 @@ title: "ListKnownPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListKnownPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListKnownPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/ListKnownPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListKnownPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListKnownPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "ListKnownPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "ListKnownPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_details</code>
       <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "ListKnownPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,90 +204,90 @@ title: "ListKnownPackages"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_details</code>
       <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PackageDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-packagedetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_size</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">known_since</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -297,12 +297,12 @@ title: "ListKnownPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -317,14 +317,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -343,7 +343,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages.mdx
@@ -9,60 +9,60 @@ title: "UpdateVettedPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateVettedPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateVettedPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/UpdateVettedPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateVettedPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateVettedPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,81 +105,81 @@ title: "UpdateVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateVettedPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">changes</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dry_run</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_topology_serial</code>
       <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
       <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -189,54 +189,54 @@ title: "UpdateVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateVettedPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">past_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -246,12 +246,12 @@ title: "UpdateVettedPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -262,380 +262,380 @@ title: "UpdateVettedPackages"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">changes</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dry_run</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_topology_serial</code>
       <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
       <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vet</code>
       <span class="x2mdx-ref-type-badge">Vet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unvet</code>
       <span class="x2mdx-ref-type-badge">Unvet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesRef">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackagesref">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-vet">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PriorTopologySerial">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prior</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">no_prior</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">past_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackages">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackage">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -645,12 +645,12 @@ title: "UpdateVettedPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -689,14 +689,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -734,7 +734,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile.mdx
@@ -9,60 +9,60 @@ title: "UploadDarFile"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UploadDarFile</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UploadDarFile</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/UploadDarFile</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UploadDarFile"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UploadDarFile</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "UploadDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UploadDarFileRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_change</code>
       <span class="x2mdx-ref-type-badge">VettingChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,32 +180,32 @@ title: "UploadDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UploadDarFileResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -215,12 +215,12 @@ title: "UploadDarFile"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -231,78 +231,78 @@ title: "UploadDarFile"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_change</code>
       <span class="x2mdx-ref-type-badge">VettingChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>VETTING_CHANGE_UNSPECIFIED</code></li>
-    
+
     <li><code>VETTING_CHANGE_VET_ALL_PACKAGES</code></li>
-    
+
     <li><code>VETTING_CHANGE_DONT_VET_ANY_PACKAGES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfileresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -312,12 +312,12 @@ title: "UploadDarFile"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -337,14 +337,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -353,7 +353,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile.mdx
@@ -9,60 +9,60 @@ title: "ValidateDarFile"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ValidateDarFile</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ValidateDarFile</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/ValidateDarFile</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ValidateDarFile"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ValidateDarFile</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "ValidateDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ValidateDarFileRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "ValidateDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ValidateDarFileResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "ValidateDarFile"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "ValidateDarFile"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ValidateDarFileRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfilerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ValidateDarFileResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfileresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "ValidateDarFile"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune.mdx
@@ -9,60 +9,60 @@ title: "Prune"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>Prune</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Prune</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.ParticipantPruningService/Prune</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "Prune"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>ParticipantPruningService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>Prune</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "Prune"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PruneRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_up_to</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "Prune"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PruneResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "Prune"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "Prune"
 
 <Accordion title="com.daml.ledger.api.v2.admin.PruneRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-prunerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_up_to</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PruneResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-pruneresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "Prune"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty.mdx
@@ -9,60 +9,60 @@ title: "AllocateExternalParty"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>AllocateExternalParty</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">AllocateExternalParty</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/AllocateExternalParty</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "AllocateExternalParty"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>AllocateExternalParty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,66 +105,66 @@ title: "AllocateExternalParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocateExternalPartyRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">onboarding_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wait_for_allocation</code>
@@ -185,10 +185,10 @@ title: "AllocateExternalParty"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -198,45 +198,45 @@ title: "AllocateExternalParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocateExternalPartyResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -246,12 +246,12 @@ title: "AllocateExternalParty"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -262,46 +262,46 @@ title: "AllocateExternalParty"
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">onboarding_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wait_for_allocation</code>
@@ -322,154 +322,154 @@ title: "AllocateExternalParty"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -479,12 +479,12 @@ title: "AllocateExternalParty"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -525,14 +525,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -543,7 +543,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty.mdx
@@ -9,60 +9,60 @@ title: "AllocateParty"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>AllocateParty</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">AllocateParty</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/AllocateParty</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "AllocateParty"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>AllocateParty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,81 +105,81 @@ title: "AllocateParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocatePartyRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -189,45 +189,45 @@ title: "AllocateParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocatePartyResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -237,12 +237,12 @@ title: "AllocateParty"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -253,161 +253,161 @@ title: "AllocateParty"
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocatePartyRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocatePartyResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "AllocateParty"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -450,14 +450,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -480,7 +480,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology.mdx
@@ -9,60 +9,60 @@ title: "GenerateExternalPartyTopology"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GenerateExternalPartyTopology</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GenerateExternalPartyTopology</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GenerateExternalPartyTopology</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GenerateExternalPartyTopology"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GenerateExternalPartyTopology</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,99 +105,99 @@ title: "GenerateExternalPartyTopology"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GenerateExternalPartyTopologyRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key</code>
       <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_threshold</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observing_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -207,72 +207,72 @@ title: "GenerateExternalPartyTopology"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GenerateExternalPartyTopologyResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -282,12 +282,12 @@ title: "GenerateExternalPartyTopology"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -298,210 +298,210 @@ title: "GenerateExternalPartyTopology"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key</code>
       <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_threshold</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observing_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningPublicKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_data</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_spec</code>
       <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CryptoKeyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningKeySpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -511,12 +511,12 @@ title: "GenerateExternalPartyTopology"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -547,14 +547,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -570,7 +570,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid.mdx
@@ -9,60 +9,60 @@ title: "GetParticipantId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetParticipantId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetParticipantId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GetParticipantId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetParticipantId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetParticipantId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetParticipantId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetParticipantIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "GetParticipantId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetParticipantIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "GetParticipantId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "GetParticipantId"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetParticipantIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetParticipantIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "GetParticipantId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties.mdx
@@ -9,60 +9,60 @@ title: "GetParties"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetParties</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetParties</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GetParties</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetParties"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetParties</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPartiesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "GetParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPartiesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "GetParties"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,134 +226,134 @@ title: "GetParties"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetPartiesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetPartiesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -363,12 +363,12 @@ title: "GetParties"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -388,14 +388,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -420,7 +420,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties.mdx
@@ -9,60 +9,60 @@ title: "ListKnownParties"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListKnownParties</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListKnownParties</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/ListKnownParties</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListKnownParties"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListKnownParties</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "ListKnownParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPartiesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filter_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,54 +180,54 @@ title: "ListKnownParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPartiesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -237,12 +237,12 @@ title: "ListKnownParties"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -253,161 +253,161 @@ title: "ListKnownParties"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPartiesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filter_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPartiesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "ListKnownParties"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -442,14 +442,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -475,7 +475,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails.mdx
@@ -9,60 +9,60 @@ title: "UpdatePartyDetails"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdatePartyDetails</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdatePartyDetails</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyDetails</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdatePartyDetails"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdatePartyDetails</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "UpdatePartyDetails"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyDetailsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "UpdatePartyDetails"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyDetailsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "UpdatePartyDetails"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,134 +226,134 @@ title: "UpdatePartyDetails"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -363,12 +363,12 @@ title: "UpdatePartyDetails"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -398,14 +398,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -428,7 +428,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid.mdx
@@ -9,60 +9,60 @@ title: "UpdatePartyIdentityProviderId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdatePartyIdentityProviderId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdatePartyIdentityProviderId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyIdentityProviderId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdatePartyIdentityProviderId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdatePartyIdentityProviderId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "UpdatePartyIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyIdentityProviderIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "UpdatePartyIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyIdentityProviderIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "UpdatePartyIdentityProviderId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "UpdatePartyIdentityProviderId"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "UpdatePartyIdentityProviderId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser.mdx
@@ -9,60 +9,60 @@ title: "CreateUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>CreateUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">CreateUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/CreateUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "CreateUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>CreateUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "CreateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "CreateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "CreateUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,86 +226,86 @@ title: "CreateUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -317,239 +317,239 @@ title: "CreateUser"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -559,12 +559,12 @@ title: "CreateUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -600,14 +600,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -632,7 +632,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser.mdx
@@ -9,60 +9,60 @@ title: "DeleteUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>DeleteUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">DeleteUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/DeleteUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "DeleteUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>DeleteUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "DeleteUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,32 +162,32 @@ title: "DeleteUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -197,12 +197,12 @@ title: "DeleteUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -213,41 +213,41 @@ title: "DeleteUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -257,12 +257,12 @@ title: "DeleteUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -280,14 +280,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -296,7 +296,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser.mdx
@@ -9,60 +9,60 @@ title: "GetUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/GetUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "GetUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "GetUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,108 +226,108 @@ title: "GetUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -339,39 +339,39 @@ title: "GetUser"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -381,12 +381,12 @@ title: "GetUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -404,14 +404,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -436,7 +436,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights.mdx
@@ -9,60 +9,60 @@ title: "GrantUserRights"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GrantUserRights</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GrantUserRights</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/GrantUserRights</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GrantUserRights"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GrantUserRights</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GrantUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GrantUserRightsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "GrantUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GrantUserRightsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_granted_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GrantUserRights"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,241 +235,241 @@ title: "GrantUserRights"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GrantUserRightsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GrantUserRightsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_granted_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -479,12 +479,12 @@ title: "GrantUserRights"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -507,14 +507,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -529,7 +529,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights.mdx
@@ -9,60 +9,60 @@ title: "ListUserRights"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListUserRights</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListUserRights</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/ListUserRights</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListUserRights"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListUserRights</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "ListUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUserRightsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "ListUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUserRightsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "ListUserRights"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,232 +226,232 @@ title: "ListUserRights"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUserRightsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUserRightsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -461,12 +461,12 @@ title: "ListUserRights"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -484,14 +484,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -506,7 +506,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers.mdx
@@ -9,60 +9,60 @@ title: "ListUsers"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListUsers</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListUsers</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/ListUsers</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListUsers"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListUsers</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "ListUsers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUsersRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,54 +171,54 @@ title: "ListUsers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUsersResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">users</code>
       <span class="x2mdx-ref-type-badge">repeated User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "ListUsers"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,126 +244,126 @@ title: "ListUsers"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUsersRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUsersResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">users</code>
       <span class="x2mdx-ref-type-badge">repeated User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -375,39 +375,39 @@ title: "ListUsers"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "ListUsers"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -441,14 +441,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -476,7 +476,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights.mdx
@@ -9,60 +9,60 @@ title: "RevokeUserRights"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>RevokeUserRights</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">RevokeUserRights</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/RevokeUserRights</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "RevokeUserRights"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>RevokeUserRights</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "RevokeUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>RevokeUserRightsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "RevokeUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>RevokeUserRightsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "RevokeUserRights"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,241 +235,241 @@ title: "RevokeUserRights"
 
 <Accordion title="com.daml.ledger.api.v2.admin.RevokeUserRightsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.RevokeUserRightsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -479,12 +479,12 @@ title: "RevokeUserRights"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -507,14 +507,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -529,7 +529,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser.mdx
@@ -9,60 +9,60 @@ title: "UpdateUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/UpdateUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "UpdateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "UpdateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "UpdateUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,86 +226,86 @@ title: "UpdateUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -317,61 +317,61 @@ title: "UpdateUser"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -381,12 +381,12 @@ title: "UpdateUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -418,14 +418,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -450,7 +450,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid.mdx
@@ -9,60 +9,60 @@ title: "UpdateUserIdentityProviderId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateUserIdentityProviderId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateUserIdentityProviderId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/UpdateUserIdentityProviderId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateUserIdentityProviderId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateUserIdentityProviderId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "UpdateUserIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserIdentityProviderIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "UpdateUserIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserIdentityProviderIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "UpdateUserIdentityProviderId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "UpdateUserIdentityProviderId"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "UpdateUserIdentityProviderId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission.mdx
@@ -9,60 +9,60 @@ title: "ExecuteSubmission"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ExecuteSubmission</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ExecuteSubmission</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmission</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ExecuteSubmission"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ExecuteSubmission</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,108 +105,108 @@ title: "ExecuteSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -216,32 +216,32 @@ title: "ExecuteSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -251,12 +251,12 @@ title: "ExecuteSubmission"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -267,273 +267,273 @@ title: "ExecuteSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -545,80 +545,80 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -630,488 +630,488 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1197,82 +1197,82 @@ title: "ExecuteSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1293,143 +1293,143 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1450,30 +1450,30 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1546,411 +1546,411 @@ title: "ExecuteSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -1960,12 +1960,12 @@ title: "ExecuteSubmission"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2044,14 +2044,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2060,7 +2060,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait.mdx
@@ -9,60 +9,60 @@ title: "ExecuteSubmissionAndWait"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ExecuteSubmissionAndWait</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ExecuteSubmissionAndWait</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWait</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ExecuteSubmissionAndWait"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ExecuteSubmissionAndWait</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,108 +105,108 @@ title: "ExecuteSubmissionAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -216,54 +216,54 @@ title: "ExecuteSubmissionAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -273,12 +273,12 @@ title: "ExecuteSubmissionAndWait"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -289,273 +289,273 @@ title: "ExecuteSubmissionAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -567,80 +567,80 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -652,488 +652,488 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1219,82 +1219,82 @@ title: "ExecuteSubmissionAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1315,143 +1315,143 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1472,30 +1472,30 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1568,433 +1568,433 @@ title: "ExecuteSubmissionAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2004,12 +2004,12 @@ title: "ExecuteSubmissionAndWait"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2088,14 +2088,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2107,7 +2107,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction.mdx
@@ -9,60 +9,60 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ExecuteSubmissionAndWaitForTransaction</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ExecuteSubmissionAndWaitForTransaction</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWaitForTransaction</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ExecuteSubmissionAndWaitForTransaction</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,117 +105,117 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitForTransactionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -225,45 +225,45 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitForTransactionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -273,12 +273,12 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -289,282 +289,282 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -576,80 +576,80 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -661,488 +661,488 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1228,82 +1228,82 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1324,143 +1324,143 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1481,30 +1481,30 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1577,768 +1577,768 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -2350,102 +2350,102 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -2459,132 +2459,132 @@ title: "ExecuteSubmissionAndWaitForTransaction"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -2596,263 +2596,263 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2862,12 +2862,12 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2946,14 +2946,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2989,7 +2989,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages.mdx
@@ -9,60 +9,60 @@ title: "GetPreferredPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPreferredPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPreferredPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPreferredPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPreferredPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GetPreferredPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
       <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,54 +171,54 @@ title: "GetPreferredPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_references</code>
       <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetPreferredPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,143 +244,143 @@ title: "GetPreferredPackages"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
       <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PackageVettingRequirement">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagevettingrequirement">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_references</code>
       <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageReference">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -390,12 +390,12 @@ title: "GetPreferredPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -421,14 +421,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -446,7 +446,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion.mdx
@@ -9,60 +9,60 @@ title: "GetPreferredPackageVersion"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPreferredPackageVersion</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPreferredPackageVersion</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackageVersion</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPreferredPackageVersion"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPreferredPackageVersion</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "GetPreferredPackageVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackageVersionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,45 +180,45 @@ title: "GetPreferredPackageVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackageVersionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_preference</code>
       <span class="x2mdx-ref-type-badge">PackagePreference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetPreferredPackageVersion"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,143 +244,143 @@ title: "GetPreferredPackageVersion"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_preference</code>
       <span class="x2mdx-ref-type-badge">PackagePreference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PackagePreference">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagepreference">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_reference</code>
       <span class="x2mdx-ref-type-badge">PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageReference">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -390,12 +390,12 @@ title: "GetPreferredPackageVersion"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -417,14 +417,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -442,7 +442,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission.mdx
@@ -9,60 +9,60 @@ title: "PrepareSubmission"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>PrepareSubmission</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">PrepareSubmission</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/PrepareSubmission</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "PrepareSubmission"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>PrepareSubmission</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,147 +105,147 @@ title: "PrepareSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PrepareSubmissionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose_hashing</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
       <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
@@ -266,10 +266,10 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -279,81 +279,81 @@ title: "PrepareSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PrepareSubmissionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_details</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cost_estimation</code>
       <span class="x2mdx-ref-type-badge">CostEstimation</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -363,12 +363,12 @@ title: "PrepareSubmission"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -379,127 +379,127 @@ title: "PrepareSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose_hashing</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
       <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
@@ -520,822 +520,822 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1347,60 +1347,60 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.CostEstimationHints">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimationhints">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disabled</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1425,246 +1425,246 @@ title: "PrepareSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_details</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cost_estimation</code>
       <span class="x2mdx-ref-type-badge">CostEstimation</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -1676,80 +1676,80 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1841,89 +1841,89 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1944,143 +1944,143 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -2101,30 +2101,30 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2197,255 +2197,255 @@ title: "PrepareSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.CostEstimation">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimation">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimation_timestamp</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_request_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_response_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">total_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2455,12 +2455,12 @@ title: "PrepareSubmission"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2517,14 +2517,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2584,7 +2584,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-testing/timeservice/gettime.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-testing/timeservice/gettime.mdx
@@ -9,60 +9,60 @@ title: "GetTime"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-testing">com.daml.ledger.api.v2.testing</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetTime</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.testing</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetTime</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.testing.TimeService/GetTime</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetTime"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>TimeService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetTime</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetTimeRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "GetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetTimeResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "GetTime"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "GetTime"
 
 <Accordion title="com.daml.ledger.api.v2.testing.GetTimeRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimerequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.testing.GetTimeResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimeresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "GetTime"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-testing/timeservice/settime.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2-testing/timeservice/settime.mdx
@@ -9,60 +9,60 @@ title: "SetTime"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-testing">com.daml.ledger.api.v2.testing</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SetTime</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.testing</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SetTime</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.testing.TimeService/SetTime</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SetTime"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>TimeService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SetTime</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "SetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SetTimeRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.testing.SetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,27 +162,27 @@ title: "SetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Empty</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>google.protobuf.Empty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
+
+
 </div>
 
 
@@ -192,12 +192,12 @@ title: "SetTime"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -208,32 +208,32 @@ title: "SetTime"
 
 <Accordion title="com.daml.ledger.api.v2.testing.SetTimeRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-settimerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -243,12 +243,12 @@ title: "SetTime"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -266,14 +266,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -282,7 +282,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream.mdx
@@ -9,60 +9,60 @@ title: "CompletionStream"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>CompletionStream</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">CompletionStream</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandCompletionService/CompletionStream</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "CompletionStream"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandCompletionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>CompletionStream</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "CompletionStream"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CompletionStreamRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,54 +171,54 @@ title: "CompletionStream"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CompletionStreamResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "CompletionStream"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,180 +244,180 @@ title: "CompletionStream"
 
 <Accordion title="com.daml.ledger.api.v2.CompletionStreamRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CompletionStreamResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Completion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -429,101 +429,101 @@ title: "CompletionStream"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.OffsetCheckpoint">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_times</code>
       <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -533,12 +533,12 @@ title: "CompletionStream"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -560,14 +560,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -588,7 +588,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandservice/submitandwait.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandservice/submitandwait.mdx
@@ -9,60 +9,60 @@ title: "SubmitAndWait"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitAndWait</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitAndWait</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWait</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitAndWait"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitAndWait</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "SubmitAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,54 +153,54 @@ title: "SubmitAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "SubmitAndWait"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,167 +226,167 @@ title: "SubmitAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Commands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -398,791 +398,791 @@ title: "SubmitAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1194,39 +1194,39 @@ title: "SubmitAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1236,12 +1236,12 @@ title: "SubmitAndWait"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1273,14 +1273,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1292,7 +1292,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment.mdx
@@ -9,60 +9,60 @@ title: "SubmitAndWaitForReassignment"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitAndWaitForReassignment</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitAndWaitForReassignment</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWaitForReassignment</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitAndWaitForReassignment"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitAndWaitForReassignment</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "SubmitAndWaitForReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForReassignmentRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "SubmitAndWaitForReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForReassignmentResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "SubmitAndWaitForReassignment"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,548 +226,548 @@ title: "SubmitAndWaitForReassignment"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassign_command</code>
       <span class="x2mdx-ref-type-badge">UnassignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assign_command</code>
       <span class="x2mdx-ref-type-badge">AssignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -779,281 +779,281 @@ title: "SubmitAndWaitForReassignment"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -1067,572 +1067,572 @@ title: "SubmitAndWaitForReassignment"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1644,39 +1644,39 @@ title: "SubmitAndWaitForReassignment"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1686,12 +1686,12 @@ title: "SubmitAndWaitForReassignment"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1744,14 +1744,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1787,7 +1787,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction.mdx
@@ -9,60 +9,60 @@ title: "SubmitAndWaitForTransaction"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitAndWaitForTransaction</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitAndWaitForTransaction</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWaitForTransaction</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitAndWaitForTransaction"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitAndWaitForTransaction</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "SubmitAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForTransactionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "SubmitAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForTransactionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "SubmitAndWaitForTransaction"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,176 +226,176 @@ title: "SubmitAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Commands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -407,791 +407,791 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1203,374 +1203,374 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1582,102 +1582,102 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -1691,132 +1691,132 @@ title: "SubmitAndWaitForTransaction"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1828,263 +1828,263 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2094,12 +2094,12 @@ title: "SubmitAndWaitForTransaction"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2151,14 +2151,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2194,7 +2194,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit.mdx
@@ -9,60 +9,60 @@ title: "Submit"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>Submit</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Submit</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandSubmissionService/Submit</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "Submit"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>Submit</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "Submit"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,32 +153,32 @@ title: "Submit"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "Submit"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,167 +204,167 @@ title: "Submit"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Commands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -376,791 +376,791 @@ title: "Submit"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1172,17 +1172,17 @@ title: "Submit"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -1192,12 +1192,12 @@ title: "Submit"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1229,14 +1229,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1245,7 +1245,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment.mdx
@@ -9,60 +9,60 @@ title: "SubmitReassignment"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitReassignment</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitReassignment</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandSubmissionService/SubmitReassignment</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitReassignment"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitReassignment</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "SubmitReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitReassignmentRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,32 +153,32 @@ title: "SubmitReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitReassignmentResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "SubmitReassignment"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,210 +204,210 @@ title: "SubmitReassignment"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitReassignmentRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassign_command</code>
       <span class="x2mdx-ref-type-badge">UnassignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assign_command</code>
       <span class="x2mdx-ref-type-badge">AssignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitReassignmentResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "SubmitReassignment"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -454,14 +454,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -470,7 +470,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/contractservice/getcontract.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/contractservice/getcontract.mdx
@@ -9,60 +9,60 @@ title: "GetContract"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetContract</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetContract</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.11</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.ContractService/GetContract</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetContract"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>ContractService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetContract</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetContract"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetContractRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetContractRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">querying_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "GetContract"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetContractResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetContractResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "GetContract"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.11</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,108 +226,108 @@ title: "GetContract"
 
 <Accordion title="com.daml.ledger.api.v2.GetContractRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">querying_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetContractResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -341,612 +341,612 @@ title: "GetContract"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -958,8 +958,8 @@ title: "GetContract"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -969,12 +969,12 @@ title: "GetContract"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -994,14 +994,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1039,7 +1039,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid.mdx
@@ -9,60 +9,60 @@ title: "GetEventsByContractId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetEventsByContractId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetEventsByContractId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.EventQueryService/GetEventsByContractId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetEventsByContractId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>EventQueryService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetEventsByContractId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetEventsByContractId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetEventsByContractIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,54 +162,54 @@ title: "GetEventsByContractId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetEventsByContractIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">Created</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">Archived</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetEventsByContractId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,383 +235,383 @@ title: "GetEventsByContractId"
 
 <Accordion title="com.daml.ledger.api.v2.GetEventsByContractIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetEventsByContractIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">Created</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">Archived</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Created">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-created">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -625,572 +625,572 @@ title: "GetEventsByContractId"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1202,115 +1202,115 @@ title: "GetEventsByContractId"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Archived">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archived">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived_event</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1320,12 +1320,12 @@ title: "GetEventsByContractId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1363,14 +1363,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1428,7 +1428,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/getpackage.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/getpackage.mdx
@@ -9,60 +9,60 @@ title: "GetPackage"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPackage</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPackage</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/GetPackage</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPackage"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPackage</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "GetPackage"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,63 +153,63 @@ title: "GetPackage"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash_function</code>
       <span class="x2mdx-ref-type-badge">HashFunction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archive_payload</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetPackage"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,78 +235,78 @@ title: "GetPackage"
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackageresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash_function</code>
       <span class="x2mdx-ref-type-badge">HashFunction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archive_payload</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.HashFunction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-hashfunction">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASH_FUNCTION_SHA256</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -316,12 +316,12 @@ title: "GetPackage"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -338,14 +338,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -358,7 +358,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus.mdx
@@ -9,60 +9,60 @@ title: "GetPackageStatus"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPackageStatus</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPackageStatus</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/GetPackageStatus</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPackageStatus"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPackageStatus</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "GetPackageStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageStatusRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,45 +153,45 @@ title: "GetPackageStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageStatusResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_status</code>
       <span class="x2mdx-ref-type-badge">PackageStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -201,12 +201,12 @@ title: "GetPackageStatus"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -217,62 +217,62 @@ title: "GetPackageStatus"
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageStatusRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageStatusResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_status</code>
       <span class="x2mdx-ref-type-badge">PackageStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageStatus">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagestatus">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PACKAGE_STATUS_UNSPECIFIED</code></li>
-    
+
     <li><code>PACKAGE_STATUS_REGISTERED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -282,12 +282,12 @@ title: "GetPackageStatus"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -304,14 +304,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -322,7 +322,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/listpackages.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/listpackages.mdx
@@ -9,60 +9,60 @@ title: "ListPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/ListPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "ListPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "ListPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "ListPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "ListPackages"
 
 <Accordion title="com.daml.ledger.api.v2.ListPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ListPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "ListPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -279,7 +279,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages.mdx
@@ -9,60 +9,60 @@ title: "ListVettedPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListVettedPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListVettedPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/ListVettedPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListVettedPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListVettedPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "ListVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListVettedPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_metadata_filter</code>
       <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_state_filter</code>
       <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,54 +180,54 @@ title: "ListVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListVettedPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetted_packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -237,12 +237,12 @@ title: "ListVettedPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -253,250 +253,250 @@ title: "ListVettedPackages"
 
 <Accordion title="com.daml.ledger.api.v2.ListVettedPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_metadata_filter</code>
       <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_state_filter</code>
       <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageMetadataFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagemetadatafilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name_prefixes</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyStateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologystatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ListVettedPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetted_packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackages">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackage">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -506,12 +506,12 @@ title: "ListVettedPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -545,14 +545,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -579,7 +579,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts.mdx
@@ -9,60 +9,60 @@ title: "GetActiveContracts"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetActiveContracts</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetActiveContracts</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetActiveContracts</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetActiveContracts"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetActiveContracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,48 +105,48 @@ title: "GetActiveContracts"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetActiveContractsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -158,10 +158,10 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,66 +171,66 @@ title: "GetActiveContracts"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetActiveContractsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_contract</code>
       <span class="x2mdx-ref-type-badge">ActiveContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_assigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -242,10 +242,10 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -255,12 +255,12 @@ title: "GetActiveContracts"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -271,28 +271,28 @@ title: "GetActiveContracts"
 
 <Accordion title="com.daml.ledger.api.v2.GetActiveContractsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -304,288 +304,288 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetActiveContractsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_contract</code>
       <span class="x2mdx-ref-type-badge">ActiveContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_assigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -597,102 +597,102 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ActiveContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-activecontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -706,572 +706,572 @@ title: "GetActiveContracts"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1283,249 +1283,249 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.IncompleteUnassigned">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteunassigned">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned_event</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.IncompleteAssigned">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteassigned">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned_event</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1535,12 +1535,12 @@ title: "GetActiveContracts"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1580,14 +1580,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1624,7 +1624,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers.mdx
@@ -9,60 +9,60 @@ title: "GetConnectedSynchronizers"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetConnectedSynchronizers</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetConnectedSynchronizers</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetConnectedSynchronizers</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetConnectedSynchronizers"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetConnectedSynchronizers</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GetConnectedSynchronizers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetConnectedSynchronizersRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "GetConnectedSynchronizers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetConnectedSynchronizersResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">connected_synchronizers</code>
       <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetConnectedSynchronizers"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,124 +235,124 @@ title: "GetConnectedSynchronizers"
 
 <Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">connected_synchronizers</code>
       <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_alias</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -362,12 +362,12 @@ title: "GetConnectedSynchronizers"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -386,14 +386,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -410,7 +410,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets.mdx
@@ -9,60 +9,60 @@ title: "GetLatestPrunedOffsets"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetLatestPrunedOffsets</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetLatestPrunedOffsets</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetLatestPrunedOffsets</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetLatestPrunedOffsets"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetLatestPrunedOffsets</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetLatestPrunedOffsets"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLatestPrunedOffsetsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,54 +140,54 @@ title: "GetLatestPrunedOffsets"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLatestPrunedOffsetsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -197,12 +197,12 @@ title: "GetLatestPrunedOffsets"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -213,41 +213,41 @@ title: "GetLatestPrunedOffsets"
 
 <Accordion title="com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -257,12 +257,12 @@ title: "GetLatestPrunedOffsets"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -277,14 +277,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -296,7 +296,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getledgerend.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/stateservice/getledgerend.mdx
@@ -9,60 +9,60 @@ title: "GetLedgerEnd"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetLedgerEnd</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetLedgerEnd</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetLedgerEnd</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetLedgerEnd"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetLedgerEnd</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetLedgerEnd"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerEndRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "GetLedgerEnd"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerEndResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "GetLedgerEnd"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "GetLedgerEnd"
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerEndRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerEndResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "GetLedgerEnd"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid.mdx
@@ -9,60 +9,60 @@ title: "GetUpdateById"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUpdateById</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUpdateById</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.UpdateService/GetUpdateById</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUpdateById"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UpdateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUpdateById</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetUpdateById"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateByIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,63 +162,63 @@ title: "GetUpdateById"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetUpdateById"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,540 +244,540 @@ title: "GetUpdateById"
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateByIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyidrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UpdateFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -789,102 +789,102 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -898,572 +898,572 @@ title: "GetUpdateById"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1475,344 +1475,344 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1824,330 +1824,330 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -2159,140 +2159,140 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2342,12 +2342,12 @@ title: "GetUpdateById"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2402,14 +2402,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2445,7 +2445,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset.mdx
@@ -9,60 +9,60 @@ title: "GetUpdateByOffset"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUpdateByOffset</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUpdateByOffset</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.UpdateService/GetUpdateByOffset</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUpdateByOffset"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UpdateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUpdateByOffset</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetUpdateByOffset"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateByOffsetRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,63 +162,63 @@ title: "GetUpdateByOffset"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetUpdateByOffset"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,540 +244,540 @@ title: "GetUpdateByOffset"
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateByOffsetRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyoffsetrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UpdateFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -789,102 +789,102 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -898,572 +898,572 @@ title: "GetUpdateByOffset"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1475,344 +1475,344 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1824,330 +1824,330 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -2159,140 +2159,140 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2342,12 +2342,12 @@ title: "GetUpdateByOffset"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2402,14 +2402,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2445,7 +2445,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/updateservice/getupdates.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/updateservice/getupdates.mdx
@@ -9,60 +9,60 @@ title: "GetUpdates"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUpdates</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUpdates</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.UpdateService/GetUpdates</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUpdates"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UpdateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUpdates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,57 +105,57 @@ title: "GetUpdates"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">end_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">descending_order</code>
@@ -167,10 +167,10 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,72 +180,72 @@ title: "GetUpdates"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -255,12 +255,12 @@ title: "GetUpdates"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -271,37 +271,37 @@ title: "GetUpdates"
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdatesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">end_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">descending_order</code>
@@ -313,525 +313,525 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UpdateFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdatesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -843,102 +843,102 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -952,572 +952,572 @@ title: "GetUpdates"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1529,344 +1529,344 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1878,392 +1878,392 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.OffsetCheckpoint">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_times</code>
       <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -2275,140 +2275,140 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2458,12 +2458,12 @@ title: "GetUpdates"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2521,14 +2521,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2564,7 +2564,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion.mdx
+++ b/docs-main/appdev/reference/protobuf-history/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion.mdx
@@ -9,60 +9,60 @@ title: "GetLedgerApiVersion"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetLedgerApiVersion</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetLedgerApiVersion</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.VersionService/GetLedgerApiVersion</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetLedgerApiVersion"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>VersionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetLedgerApiVersion</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetLedgerApiVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerApiVersionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,54 +140,54 @@ title: "GetLedgerApiVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerApiVersionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">features</code>
       <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -197,12 +197,12 @@ title: "GetLedgerApiVersion"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -213,280 +213,280 @@ title: "GetLedgerApiVersion"
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerApiVersionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerApiVersionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">features</code>
       <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.FeaturesDescriptor">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-featuresdescriptor">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">experimental</code>
       <span class="x2mdx-ref-type-badge">ExperimentalFeatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_management</code>
       <span class="x2mdx-ref-type-badge">UserManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_management</code>
       <span class="x2mdx-ref-type-badge">PartyManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpointFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_feature</code>
       <span class="x2mdx-ref-type-badge">PackageFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExperimentalFeatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalfeatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">static_time</code>
       <span class="x2mdx-ref-type-badge">ExperimentalStaticTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_inspection_service</code>
       <span class="x2mdx-ref-type-badge">ExperimentalCommandInspectionService</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExperimentalStaticTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalstatictime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExperimentalCommandInspectionService">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalcommandinspectionservice">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UserManagementFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-usermanagementfeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_rights_per_user</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_users_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PartyManagementFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-partymanagementfeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_parties_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.OffsetCheckpointFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpointfeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_offset_checkpoint_emission_delay</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagefeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_vetted_packages_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -496,12 +496,12 @@ title: "GetLedgerApiVersion"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -516,14 +516,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -558,7 +558,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-admin.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-admin.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.admin</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">6 services, 28 endpoints, 79 messages, 3 enums</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>28</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>79</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>3</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,280 +61,280 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>11</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>11</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>17</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>20</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -346,69 +346,69 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandInspectionService.GetCommandStatus</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandInspectionService.GetCommandStatus(com.daml.ledger.api.v2.admin.GetCommandStatusRequest) returns (com.daml.ledger.api.v2.admin.GetCommandStatusResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -420,257 +420,257 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>5</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.CreateIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.CreateIdentityProviderConfig(com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.CreateIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.DeleteIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.DeleteIdentityProviderConfig(com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.DeleteIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.GetIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.GetIdentityProviderConfig(com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.GetIdentityProvi...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.ListIdentityProviderConfigs</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.ListIdentityProviderConfigs(com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest) returns (com.daml.ledger.api.v2.admin.ListIdentity...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.UpdateIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.UpdateIdentityProviderConfig(com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.UpdateIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -682,210 +682,210 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>4</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.ListKnownPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.ListKnownPackages(com.daml.ledger.api.v2.admin.ListKnownPackagesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.UpdateVettedPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.UpdateVettedPackages(com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest) returns (com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.UploadDarFile</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.UploadDarFile(com.daml.ledger.api.v2.admin.UploadDarFileRequest) returns (com.daml.ledger.api.v2.admin.UploadDarFileResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.ValidateDarFile</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.ValidateDarFile(com.daml.ledger.api.v2.admin.ValidateDarFileRequest) returns (com.daml.ledger.api.v2.admin.ValidateDarFileResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -897,69 +897,69 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>ParticipantPruningService.Prune</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc ParticipantPruningService.Prune(com.daml.ledger.api.v2.admin.PruneRequest) returns (com.daml.ledger.api.v2.admin.PruneResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -971,398 +971,398 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>8</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.AllocateExternalParty</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.AllocateExternalParty(com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest) returns (com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.AllocateParty</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.AllocateParty(com.daml.ledger.api.v2.admin.AllocatePartyRequest) returns (com.daml.ledger.api.v2.admin.AllocatePartyResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.GenerateExternalPartyTopology</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GenerateExternalPartyTopology(com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest) returns (com.daml.ledger.api.v2.admin.GenerateExterna...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.GetParticipantId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GetParticipantId(com.daml.ledger.api.v2.admin.GetParticipantIdRequest) returns (com.daml.ledger.api.v2.admin.GetParticipantIdResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.GetParties</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GetParties(com.daml.ledger.api.v2.admin.GetPartiesRequest) returns (com.daml.ledger.api.v2.admin.GetPartiesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.ListKnownParties</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.ListKnownParties(com.daml.ledger.api.v2.admin.ListKnownPartiesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPartiesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.UpdatePartyDetails</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.UpdatePartyDetails(com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.UpdatePartyIdentityProviderId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.UpdatePartyIdentityProviderId(com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1374,445 +1374,445 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>9</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.CreateUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.CreateUser(com.daml.ledger.api.v2.admin.CreateUserRequest) returns (com.daml.ledger.api.v2.admin.CreateUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.DeleteUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.DeleteUser(com.daml.ledger.api.v2.admin.DeleteUserRequest) returns (com.daml.ledger.api.v2.admin.DeleteUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.GetUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.GetUser(com.daml.ledger.api.v2.admin.GetUserRequest) returns (com.daml.ledger.api.v2.admin.GetUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.GrantUserRights</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.GrantUserRights(com.daml.ledger.api.v2.admin.GrantUserRightsRequest) returns (com.daml.ledger.api.v2.admin.GrantUserRightsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.ListUserRights</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.ListUserRights(com.daml.ledger.api.v2.admin.ListUserRightsRequest) returns (com.daml.ledger.api.v2.admin.ListUserRightsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.ListUsers</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.ListUsers(com.daml.ledger.api.v2.admin.ListUsersRequest) returns (com.daml.ledger.api.v2.admin.ListUsersResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.RevokeUserRights</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.RevokeUserRights(com.daml.ledger.api.v2.admin.RevokeUserRightsRequest) returns (com.daml.ledger.api.v2.admin.RevokeUserRightsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.UpdateUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.UpdateUser(com.daml.ledger.api.v2.admin.UpdateUserRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.UpdateUserIdentityProviderId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.UpdateUserIdentityProviderId(com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserIdentity...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1830,50 +1830,50 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">onboarding_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wait_for_allocation</code>
@@ -1894,426 +1894,426 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Signature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocatePartyRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ObjectMeta</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocatePartyResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PartyDetails</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstatus">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CommandStatus</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">9 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">started</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completed</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_statistics</code>
       <span class="x2mdx-ref-type-badge">RequestStatistics</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">updates</code>
       <span class="x2mdx-ref-type-badge">CommandUpdates</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
@@ -2334,120 +2334,120 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Completion</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">12 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -2459,1028 +2459,1028 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TraceContext</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SynchronizerTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstate">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CommandState</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>COMMAND_STATE_UNSPECIFIED</code></li>
-    
+
     <li><code>COMMAND_STATE_PENDING</code></li>
-    
+
     <li><code>COMMAND_STATE_SUCCEEDED</code></li>
-    
+
     <li><code>COMMAND_STATE_FAILED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Command</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-requeststatistics">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.RequestStatistics</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">envelopes</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">recipients</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandupdates">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CommandUpdates</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetched</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">looked_up_by_key</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-contract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Contract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-timing">
@@ -3521,208 +3521,208 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.IdentityProviderConfig</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.User</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -3734,2268 +3734,2268 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.ParticipantAdmin</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanActAs</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanReadAs</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanExecuteAs</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key</code>
       <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_threshold</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observing_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningPublicKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_data</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_spec</code>
       <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CryptoKeyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningKeySpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id_prefix</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_status</code>
       <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetPartiesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetPartiesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_granted_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_configs</code>
       <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_details</code>
       <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-packagedetails">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PackageDetails</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_size</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">known_since</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filter_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUserRightsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUserRightsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUsersRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUsersResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">users</code>
       <span class="x2mdx-ref-type-badge">repeated User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-prunerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PruneRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_up_to</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-pruneresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PruneResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">changes</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dry_run</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_topology_serial</code>
       <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
       <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vet</code>
       <span class="x2mdx-ref-type-badge">Vet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unvet</code>
       <span class="x2mdx-ref-type-badge">Unvet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackagesref">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesRef</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-vet">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PriorTopologySerial</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prior</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">no_prior</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">past_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackages</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackage</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UploadDarFileRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_change</code>
       <span class="x2mdx-ref-type-badge">VettingChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>VETTING_CHANGE_UNSPECIFIED</code></li>
-    
+
     <li><code>VETTING_CHANGE_VET_ALL_PACKAGES</code></li>
-    
+
     <li><code>VETTING_CHANGE_DONT_VET_ANY_PACKAGES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfileresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UploadDarFileResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfilerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfileresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive.tran
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.interactive.transaction.v1</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">0 services, 0 endpoints, 6 messages</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,46 +61,46 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive.tran
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -118,77 +118,77 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Create</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -200,536 +200,536 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkeywithmaintainers">
@@ -823,140 +823,140 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Exercise</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -977,93 +977,93 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Fetch</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">10 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1084,57 +1084,57 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Node</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -1146,34 +1146,34 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Rollback</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-querybykey">

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.interactive</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">1 services, 6 endpoints, 29 messages, 1 enums</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>29</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,85 +61,85 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>22</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -151,304 +151,304 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>6</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.ExecuteSubmission</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmission(com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionResp...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.ExecuteSubmissionAndWait</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmissionAndWait(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest) returns (com.daml.ledger.api.v2.interactive.Execute...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest) returns (com.daml.ledge...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.GetPreferredPackageVersion</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.GetPreferredPackageVersion(com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest) returns (com.daml.ledger.api.v2.interactive.Get...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.GetPreferredPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.GetPreferredPackages(com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPac...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.PrepareSubmission</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.PrepareSubmission(com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.PrepareSubmissionResp...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -466,286 +466,286 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimation">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.CostEstimation</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimation_timestamp</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_request_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_response_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">total_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimationhints">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.CostEstimationHints</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disabled</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.DamlTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.DamlTransaction.Node</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Node</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -757,84 +757,84 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Create</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -846,536 +846,536 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkeywithmaintainers">
@@ -1469,86 +1469,86 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Fetch</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">10 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1569,147 +1569,147 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Exercise</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1730,34 +1730,34 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Rollback</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-querybykey">
@@ -1834,960 +1834,960 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">9 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PreparedTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">10 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata.InputContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PartySignatures</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.SinglePartySignatures</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Signature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.HashingSchemeVersion</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.MinLedgerTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.EventFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Filters</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CumulativeFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.WildcardFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TemplateFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionShape</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Transaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">11 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -2799,110 +2799,110 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Event</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreatedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -2916,136 +2916,136 @@ These are the package-level message and enum shapes in the publish-version snaps
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceView</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -3057,903 +3057,903 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ArchivedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExercisedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">15 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TraceContext</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_preference</code>
       <span class="x2mdx-ref-type-badge">PackagePreference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagepreference">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PackagePreference</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_reference</code>
       <span class="x2mdx-ref-type-badge">PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageReference</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
       <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagevettingrequirement">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PackageVettingRequirement</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_references</code>
       <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">15 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose_hashing</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
       <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
@@ -3974,339 +3974,339 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Command</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.DisclosedContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PrefetchContractKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -4318,68 +4318,68 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_details</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cost_estimation</code>
       <span class="x2mdx-ref-type-badge">CostEstimation</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-testing.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-testing.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.testing."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.testing</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">1 services, 2 endpoints, 3 messages</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>3</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,46 +61,46 @@ description: "Package-level overview for com.daml.ledger.api.v2.testing."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>3</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -112,116 +112,116 @@ description: "Package-level overview for com.daml.ledger.api.v2.testing."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>2</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-testing/timeservice/gettime">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>TimeService.GetTime</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc TimeService.GetTime(com.daml.ledger.api.v2.testing.GetTimeRequest) returns (com.daml.ledger.api.v2.testing.GetTimeResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-testing/timeservice/settime">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>TimeService.SetTime</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc TimeService.SetTime(com.daml.ledger.api.v2.testing.SetTimeRequest) returns (google.protobuf.Empty);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.testing.SetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>google.protobuf.Empty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -239,73 +239,73 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.testing.GetTimeRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimeresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.testing.GetTimeResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-settimerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.testing.SetTimeRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">9 services, 22 endpoints, 120 messages, 8 enums</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>23</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>9</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>22</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>120</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>8</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,10 +61,10 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto</h3>
 
@@ -92,7 +92,7 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto">community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto">community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto</a></dd>
   </div>
 
 </dl>
@@ -106,859 +106,859 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>8</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>10</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>13</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>10</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -970,69 +970,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandCompletionService.CompletionStream</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandCompletionService.CompletionStream(com.daml.ledger.api.v2.CompletionStreamRequest) returns (stream com.daml.ledger.api.v2.CompletionStreamResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1044,163 +1044,163 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>3</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwait">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandService.SubmitAndWait</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWait(com.daml.ledger.api.v2.SubmitAndWaitRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandService.SubmitAndWaitForReassignment</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWaitForReassignment(com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandService.SubmitAndWaitForTransaction</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWaitForTransaction(com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1212,116 +1212,116 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>2</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandsubmissionservice/submit">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandSubmissionService.Submit</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandSubmissionService.Submit(com.daml.ledger.api.v2.SubmitRequest) returns (com.daml.ledger.api.v2.SubmitResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandSubmissionService.SubmitReassignment</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandSubmissionService.SubmitReassignment(com.daml.ledger.api.v2.SubmitReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitReassignmentResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1333,69 +1333,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/contractservice/getcontract">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>ContractService.GetContract</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.11</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc ContractService.GetContract(com.daml.ledger.api.v2.GetContractRequest) returns (com.daml.ledger.api.v2.GetContractResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetContractRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetContractResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1407,69 +1407,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>EventQueryService.GetEventsByContractId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc EventQueryService.GetEventsByContractId(com.daml.ledger.api.v2.GetEventsByContractIdRequest) returns (com.daml.ledger.api.v2.GetEventsByContractIdResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1481,210 +1481,210 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>4</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/getpackage">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.GetPackage</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.GetPackage(com.daml.ledger.api.v2.GetPackageRequest) returns (com.daml.ledger.api.v2.GetPackageResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetPackageRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetPackageResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/getpackagestatus">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.GetPackageStatus</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.GetPackageStatus(com.daml.ledger.api.v2.GetPackageStatusRequest) returns (com.daml.ledger.api.v2.GetPackageStatusResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/listpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.ListPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.ListPackages(com.daml.ledger.api.v2.ListPackagesRequest) returns (com.daml.ledger.api.v2.ListPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/listvettedpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.ListVettedPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.ListVettedPackages(com.daml.ledger.api.v2.ListVettedPackagesRequest) returns (com.daml.ledger.api.v2.ListVettedPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1696,70 +1696,70 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>5</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getactivecontracts">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetActiveContracts</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetActiveContracts(com.daml.ledger.api.v2.GetActiveContractsRequest) returns (stream com.daml.ledger.api.v2.GetActiveContractsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getactivecontractspage">
 
     <div class="x2mdx-ref-card-head">
@@ -1808,145 +1808,145 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetConnectedSynchronizers</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetConnectedSynchronizers(com.daml.ledger.api.v2.GetConnectedSynchronizersRequest) returns (com.daml.ledger.api.v2.GetConnectedSynchronizersResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetLatestPrunedOffsets</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetLatestPrunedOffsets(com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest) returns (com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getledgerend">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetLedgerEnd</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetLedgerEnd(com.daml.ledger.api.v2.GetLedgerEndRequest) returns (com.daml.ledger.api.v2.GetLedgerEndResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1958,163 +1958,163 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>4</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatebyid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UpdateService.GetUpdateById</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdateById(com.daml.ledger.api.v2.GetUpdateByIdRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UpdateService.GetUpdateByOffset</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdateByOffset(com.daml.ledger.api.v2.GetUpdateByOffsetRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdates">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UpdateService.GetUpdates</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdates(com.daml.ledger.api.v2.GetUpdatesRequest) returns (stream com.daml.ledger.api.v2.GetUpdatesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatespage">
 
@@ -2173,69 +2173,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>VersionService.GetLedgerApiVersion</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc VersionService.GetLedgerApiVersion(com.daml.ledger.api.v2.GetLedgerApiVersionRequest) returns (com.daml.ledger.api.v2.GetLedgerApiVersionResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -2253,103 +2253,103 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-activecontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ActiveContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreatedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -2363,664 +2363,664 @@ These are the package-level message and enum shapes in the publish-version snaps
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceView</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -3032,633 +3032,633 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archived">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Archived</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived_event</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ArchivedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.AssignCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.AssignedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Command</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Commands</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -3670,92 +3670,92 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.DisclosedContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PrefetchContractKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -3767,120 +3767,120 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Completion</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">12 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -3892,970 +3892,970 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TraceContext</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SynchronizerTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CompletionStreamRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CompletionStreamResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.OffsetCheckpoint</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_times</code>
       <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-created">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Created</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CumulativeFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.WildcardFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TemplateFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Event</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExercisedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">15 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.EventFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Filters</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalcommandinspectionservice">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalCommandInspectionService</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalfeatures">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalFeatures</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">static_time</code>
       <span class="x2mdx-ref-type-badge">ExperimentalStaticTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_inspection_service</code>
       <span class="x2mdx-ref-type-badge">ExperimentalCommandInspectionService</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalstatictime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalStaticTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalpartytopologyevents">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalPartyTopologyEvents</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-featuresdescriptor">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.FeaturesDescriptor</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">experimental</code>
       <span class="x2mdx-ref-type-badge">ExperimentalFeatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_management</code>
       <span class="x2mdx-ref-type-badge">UserManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_management</code>
       <span class="x2mdx-ref-type-badge">PartyManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpointFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_feature</code>
       <span class="x2mdx-ref-type-badge">PackageFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-usermanagementfeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UserManagementFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_rights_per_user</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_users_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-partymanagementfeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PartyManagementFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_parties_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpointfeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.OffsetCheckpointFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_offset_checkpoint_emission_delay</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagefeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_vetted_packages_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractspagerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetActiveContractsPageRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_page_size</code>
@@ -4876,48 +4876,48 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractspageresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetActiveContractsPageResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated GetActiveContractsResponse</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
 
@@ -4979,197 +4979,197 @@ These are the package-level message and enum shapes in the publish-version snaps
     </div>
 
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteunassigned">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.IncompleteUnassigned</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned_event</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UnassignedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">12 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteassigned">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.IncompleteAssigned</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned_event</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsrequest">
@@ -5219,939 +5219,939 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">connected_synchronizers</code>
       <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_alias</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantPermission</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetContractRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">querying_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetContractResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetEventsByContractIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetEventsByContractIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">Created</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">Archived</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">features</code>
       <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerEndRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerEndResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackageresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash_function</code>
       <span class="x2mdx-ref-type-badge">HashFunction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archive_payload</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-hashfunction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.HashFunction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASH_FUNCTION_SHA256</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageStatusRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageStatusResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_status</code>
       <span class="x2mdx-ref-type-badge">PackageStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagestatus">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageStatus</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PACKAGE_STATUS_UNSPECIFIED</code></li>
-    
+
     <li><code>PACKAGE_STATUS_REGISTERED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyidrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdateByIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UpdateFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionShape</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyoffsetrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdateResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Transaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">11 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -6163,93 +6163,93 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Reassignment</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">9 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -6261,154 +6261,154 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ReassignmentEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -6420,131 +6420,131 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationChanged</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationRevoked</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationAdded</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationonboarding">
@@ -6718,41 +6718,41 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdatesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">end_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">descending_order</code>
@@ -6764,1062 +6764,1062 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdatesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListVettedPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_metadata_filter</code>
       <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_state_filter</code>
       <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagemetadatafilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageMetadataFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name_prefixes</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologystatefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyStateFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListVettedPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetted_packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackages</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackage</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageReference</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PriorTopologySerial</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prior</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">no_prior</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ReassignmentCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassign_command</code>
       <span class="x2mdx-ref-type-badge">UnassignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assign_command</code>
       <span class="x2mdx-ref-type-badge">AssignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UnassignCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ReassignmentCommands</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Signature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningPublicKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_data</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_spec</code>
       <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CryptoKeyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningKeySpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitReassignmentRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitReassignmentResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2210,6 +2210,12 @@
                         ]
                       },
                       {
+                        "group": "com.digitalasset.canton.admin.topology.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-topology-v30"
+                        ]
+                      },
+                      {
                         "group": "com.digitalasset.canton.crypto.admin.v30",
                         "pages": [
                           "reference/admin-api/protobuf/packages/com-digitalasset-canton-crypto-admin-v30",

--- a/docs-main/reference/admin-api/protobuf/index.mdx
+++ b/docs-main/reference/admin-api/protobuf/index.mdx
@@ -18,7 +18,7 @@ description: "Descriptor-backed protobuf API history grouped by package."
 
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Protobuf</span>
 
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5.5</span>
 
 </div>
 
@@ -37,12 +37,12 @@ description: "Descriptor-backed protobuf API history grouped by package."
 
   <div class="x2mdx-ref-meta-item">
     <dt>Latest release</dt>
-    <dd>v3.5.1</dd>
+    <dd>v3.5.5</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
     <dt>Packages</dt>
-    <dd>11</dd>
+    <dd>12</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -52,7 +52,7 @@ description: "Descriptor-backed protobuf API history grouped by package."
 
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
-    <dd>368</dd>
+    <dd>370</dd>
   </div>
 
 </dl>
@@ -549,6 +549,166 @@ Counts are shown as added / changed / removed within each release slice.
   </div>
 
 
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.2</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.3</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2 / 2 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
 </div>
 
 
@@ -576,7 +736,7 @@ Counts are shown as added / changed / removed within each release slice.
 
     </div>
 
-    <p class="x2mdx-ref-card-summary">11 services, 70 endpoints, 171 messages, 7 enums</p>
+    <p class="x2mdx-ref-card-summary">11 services, 70 endpoints, 171 messages, 8 enums</p>
 
 
 <dl class="x2mdx-ref-meta-grid">
@@ -598,7 +758,7 @@ Counts are shown as added / changed / removed within each release slice.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
-    <dd>7</dd>
+    <dd>8</dd>
   </div>
 
 </dl>
@@ -885,7 +1045,7 @@ Counts are shown as added / changed / removed within each release slice.
 
     </div>
 
-    <p class="x2mdx-ref-card-summary">4 services, 36 endpoints, 105 messages, 1 enums</p>
+    <p class="x2mdx-ref-card-summary">4 services, 36 endpoints, 106 messages, 1 enums</p>
 
 
 <dl class="x2mdx-ref-meta-grid">
@@ -902,7 +1062,7 @@ Counts are shown as added / changed / removed within each release slice.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
-    <dd>105</dd>
+    <dd>106</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -1096,6 +1256,51 @@ Counts are shown as added / changed / removed within each release slice.
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="./packages/com-digitalasset-canton-admin-topology-v30">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>com.digitalasset.canton.admin.topology.v30</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">0 services, 0 endpoints, 1 messages</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>1</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">

--- a/docs-main/reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/listregisteredsynchronizers.mdx
+++ b/docs-main/reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/listregisteredsynchronizers.mdx
@@ -129,6 +129,19 @@ title: "ListRegisteredSynchronizers"
 
 
 
+<div class="x2mdx-ref-fields">
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">all_statuses</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+
+    </div>
+
+  </div>
+
+</div>
+
 
 
 
@@ -213,6 +226,19 @@ title: "ListRegisteredSynchronizers"
 <div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-participant-v30-listregisteredsynchronizersrequest">
 
 
+<div class="x2mdx-ref-fields">
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">all_statuses</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+
+    </div>
+
+  </div>
+
+</div>
+
 
 
 </div>
@@ -235,6 +261,33 @@ title: "ListRegisteredSynchronizers"
 
 </div>
 
+
+
+</div>
+</Accordion>
+
+<Accordion title="com.digitalasset.canton.admin.participant.v30.ListRegisteredSynchronizersResponse.Status">
+<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-participant-v30-listregisteredsynchronizersresponse-status">
+
+
+
+  <ul class="x2mdx-ref-enum-list">
+
+    <li><code>STATUS_UNSPECIFIED</code></li>
+
+    <li><code>STATUS_ACTIVE</code></li>
+
+    <li><code>STATUS_HARD_MIGRATING_SOURCE</code></li>
+
+    <li><code>STATUS_HARD_MIGRATING_TARGET</code></li>
+
+    <li><code>STATUS_LSU_SOURCE</code></li>
+
+    <li><code>STATUS_LSU_TARGET</code></li>
+
+    <li><code>STATUS_INACTIVE</code></li>
+
+  </ul>
 
 
 </div>
@@ -268,6 +321,24 @@ title: "ListRegisteredSynchronizers"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">physical_synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_predecessor</code>
+      <span class="x2mdx-ref-type-badge">SynchronizerPredecessor</span>
 
     </div>
 
@@ -699,6 +770,46 @@ title: "ListRegisteredSynchronizers"
 </div>
 </Accordion>
 
+<Accordion title="com.digitalasset.canton.admin.topology.v30.SynchronizerPredecessor">
+<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-topology-v30-synchronizerpredecessor">
+
+
+<div class="x2mdx-ref-fields">
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">predecessor_physical_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">upgrade_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_late_upgrade</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+
+    </div>
+
+  </div>
+
+</div>
+
+
+
+</div>
+</Accordion>
+
 </AccordionGroup>
 
 
@@ -719,7 +830,9 @@ grpcurl \
   -d @ \
   <HOST:PORT> \
   com.digitalasset.canton.admin.participant.v30.SynchronizerConnectivityService/ListRegisteredSynchronizers <<'EOF'
-{}
+{
+  "allStatuses": true
+}
 EOF
 ```
 
@@ -763,7 +876,13 @@ EOF
         }
       },
       "connected": true,
-      "physicalSynchronizerId": "string"
+      "physicalSynchronizerId": "string",
+      "status": "STATUS_UNSPECIFIED",
+      "synchronizerPredecessor": {
+        "predecessorPhysicalId": "string",
+        "upgradeTime": "string",
+        "isLateUpgrade": true
+      }
     }
   ]
 }

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-health-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-health-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.health.v3
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto</a></dd>
   </div>
 
 </dl>
@@ -115,7 +115,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.health.v3
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-mediator-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-mediator-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.mediator.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto</a></dd>
   </div>
 
 </dl>
@@ -115,7 +115,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.mediator.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/mediator/v30/mediator_status_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-participant-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-participant-v30.mdx
@@ -13,7 +13,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
   <h1 class="x2mdx-ref-title">com.digitalasset.canton.admin.participant.v30</h1>
 
 
-  <p class="x2mdx-ref-summary">11 services, 70 endpoints, 171 messages, 7 enums</p>
+  <p class="x2mdx-ref-summary">11 services, 70 endpoints, 171 messages, 8 enums</p>
 
 
 <div class="x2mdx-ref-badges">
@@ -47,7 +47,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
-    <dd>7</dd>
+    <dd>8</dd>
   </div>
 
 </dl>
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/acs_import.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/acs_import.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/acs_import.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/acs_import.proto</a></dd>
   </div>
 
 </dl>
@@ -131,7 +131,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/active_contract.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/active_contract.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/active_contract.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/active_contract.proto</a></dd>
   </div>
 
 </dl>
@@ -170,7 +170,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto</a></dd>
   </div>
 
 </dl>
@@ -209,7 +209,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto</a></dd>
   </div>
 
 </dl>
@@ -248,7 +248,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto</a></dd>
   </div>
 
 </dl>
@@ -287,7 +287,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto</a></dd>
   </div>
 
 </dl>
@@ -326,7 +326,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto</a></dd>
   </div>
 
 </dl>
@@ -365,7 +365,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto</a></dd>
   </div>
 
 </dl>
@@ -404,7 +404,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto</a></dd>
   </div>
 
 </dl>
@@ -443,7 +443,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto</a></dd>
   </div>
 
 </dl>
@@ -482,7 +482,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/reassignment_id.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/reassignment_id.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/reassignment_id.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/reassignment_id.proto</a></dd>
   </div>
 
 </dl>
@@ -521,7 +521,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto</a></dd>
   </div>
 
 </dl>
@@ -560,7 +560,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto</a></dd>
   </div>
 
 </dl>
@@ -599,7 +599,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto</a></dd>
   </div>
 
 </dl>
@@ -622,7 +622,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/package_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -1213,7 +1213,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_inspection_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -1663,7 +1663,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_repair_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -2207,7 +2207,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_replication_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -2281,7 +2281,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/participant_status_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -2355,7 +2355,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -2711,7 +2711,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/ping_pong_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -2785,7 +2785,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/pruning_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -3423,7 +3423,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/resource_management_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -3544,7 +3544,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -4157,7 +4157,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.participa
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/traffic_control_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -7988,10 +7988,23 @@ These are the package-level message and enum shapes in the publish-version snaps
   <div class="x2mdx-ref-schema-head">
     <h3>com.digitalasset.canton.admin.participant.v30.ListRegisteredSynchronizersRequest</h3>
 
-    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
 
   </div>
 
+
+<div class="x2mdx-ref-fields">
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">all_statuses</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+
+    </div>
+
+  </div>
+
+</div>
 
 
 
@@ -8023,11 +8036,42 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
+<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-participant-v30-listregisteredsynchronizersresponse-status">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.digitalasset.canton.admin.participant.v30.ListRegisteredSynchronizersResponse.Status</h3>
+
+    <p class="x2mdx-ref-schema-summary">7 values</p>
+
+  </div>
+
+
+
+  <ul class="x2mdx-ref-enum-list">
+
+    <li><code>STATUS_UNSPECIFIED</code></li>
+
+    <li><code>STATUS_ACTIVE</code></li>
+
+    <li><code>STATUS_HARD_MIGRATING_SOURCE</code></li>
+
+    <li><code>STATUS_HARD_MIGRATING_TARGET</code></li>
+
+    <li><code>STATUS_LSU_SOURCE</code></li>
+
+    <li><code>STATUS_LSU_TARGET</code></li>
+
+    <li><code>STATUS_INACTIVE</code></li>
+
+  </ul>
+
+
+</div>
+
 <div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-participant-v30-listregisteredsynchronizersresponse-result">
   <div class="x2mdx-ref-schema-head">
     <h3>com.digitalasset.canton.admin.participant.v30.ListRegisteredSynchronizersResponse.Result</h3>
 
-    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
 
   </div>
 
@@ -8056,6 +8100,68 @@ These are the package-level message and enum shapes in the publish-version snaps
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">physical_synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_predecessor</code>
+      <span class="x2mdx-ref-type-badge">SynchronizerPredecessor</span>
+
+    </div>
+
+  </div>
+
+</div>
+
+
+
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-topology-v30-synchronizerpredecessor">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.digitalasset.canton.admin.topology.v30.SynchronizerPredecessor</h3>
+
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+
+  </div>
+
+
+<div class="x2mdx-ref-fields">
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">predecessor_physical_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">upgrade_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_late_upgrade</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
 
     </div>
 

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-pruning-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-pruning-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.pruning.v
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/pruning/v30/pruning.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/pruning/v30/pruning.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/pruning/v30/pruning.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/pruning/v30/pruning.proto</a></dd>
   </div>
 
 </dl>

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-sequencer-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-sequencer-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.sequencer
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_connection.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_connection.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_connection.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_connection.proto</a></dd>
   </div>
 
 </dl>
@@ -131,7 +131,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.sequencer
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto</a></dd>
   </div>
 
 </dl>
@@ -154,7 +154,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.sequencer
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-time-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-time-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.time.v30.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/time/v30/time_tracker_config.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/time/v30/time_tracker_config.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/time/v30/time_tracker_config.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/time/v30/time_tracker_config.proto</a></dd>
   </div>
 
 </dl>

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-topology-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-topology-v30.mdx
@@ -1,6 +1,6 @@
 ---
-title: "com.digitalasset.canton.admin.crypto.v30"
-description: "Package-level overview for com.digitalasset.canton.admin.crypto.v30."
+title: "com.digitalasset.canton.admin.topology.v30"
+description: "Package-level overview for com.digitalasset.canton.admin.topology.v30."
 ---
 
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
@@ -10,10 +10,10 @@ description: "Package-level overview for com.digitalasset.canton.admin.crypto.v3
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
 
 
-  <h1 class="x2mdx-ref-title">com.digitalasset.canton.admin.crypto.v30</h1>
+  <h1 class="x2mdx-ref-title">com.digitalasset.canton.admin.topology.v30</h1>
 
 
-  <p class="x2mdx-ref-summary">0 services, 0 endpoints, 1 messages, 1 enums</p>
+  <p class="x2mdx-ref-summary">0 services, 0 endpoints, 1 messages</p>
 
 
 <div class="x2mdx-ref-badges">
@@ -47,7 +47,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.crypto.v3
 
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
-    <dd>1</dd>
+    <dd>0</dd>
   </div>
 
 </dl>
@@ -66,7 +66,7 @@ description: "Package-level overview for com.digitalasset.canton.admin.crypto.v3
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
     <div class="x2mdx-ref-card-head">
-      <h3>community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/crypto/v30/crypto.proto</h3>
+      <h3>community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/topology/v30/common.proto</h3>
 
     </div>
 
@@ -87,12 +87,12 @@ description: "Package-level overview for com.digitalasset.canton.admin.crypto.v3
 
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
-    <dd>1</dd>
+    <dd>0</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/crypto/v30/crypto.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/crypto/v30/crypto.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/topology/v30/common.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/topology/v30/common.proto</a></dd>
   </div>
 
 </dl>
@@ -115,11 +115,11 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 
 
-<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-crypto-v30-salt">
+<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-topology-v30-synchronizerpredecessor">
   <div class="x2mdx-ref-schema-head">
-    <h3>com.digitalasset.canton.admin.crypto.v30.Salt</h3>
+    <h3>com.digitalasset.canton.admin.topology.v30.SynchronizerPredecessor</h3>
 
-    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
 
   </div>
 
@@ -128,8 +128,8 @@ These are the package-level message and enum shapes in the publish-version snaps
 
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
-      <code class="x2mdx-ref-field-name">hmac</code>
-      <span class="x2mdx-ref-type-badge">HmacAlgorithm</span>
+      <code class="x2mdx-ref-field-name">predecessor_physical_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
 
     </div>
 
@@ -137,8 +137,17 @@ These are the package-level message and enum shapes in the publish-version snaps
 
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
-      <code class="x2mdx-ref-field-name">salt</code>
-      <span class="x2mdx-ref-type-badge">bytes</span>
+      <code class="x2mdx-ref-field-name">upgrade_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_late_upgrade</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
 
     </div>
 
@@ -146,27 +155,6 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-
-
-</div>
-
-<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-admin-crypto-v30-hmacalgorithm">
-  <div class="x2mdx-ref-schema-head">
-    <h3>com.digitalasset.canton.admin.crypto.v30.HmacAlgorithm</h3>
-
-    <p class="x2mdx-ref-schema-summary">2 values</p>
-
-  </div>
-
-
-
-  <ul class="x2mdx-ref-enum-list">
-
-    <li><code>HMAC_ALGORITHM_UNSPECIFIED</code></li>
-
-    <li><code>HMAC_ALGORITHM_HMAC_SHA256</code></li>
-
-  </ul>
 
 
 </div>

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-admin.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.admin."
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/scalapb/package.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/scalapb/package.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/scalapb/package.proto">community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/scalapb/package.proto</a></dd>
   </div>
 
 </dl>

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-crypto-admin-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-crypto-admin-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.crypto.admin.v3
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto</a></dd>
   </div>
 
 </dl>
@@ -115,7 +115,7 @@ description: "Package-level overview for com.digitalasset.canton.crypto.admin.v3
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/crypto/admin/v30/vault_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-time-admin-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-time-admin-v30.mdx
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.time.admin.v30.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto</a></dd>
   </div>
 
 </dl>
@@ -115,7 +115,7 @@ description: "Package-level overview for com.digitalasset.canton.time.admin.v30.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/time/admin/v30/synchronizer_time_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">

--- a/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-topology-admin-v30.mdx
+++ b/docs-main/reference/admin-api/protobuf/packages/com-digitalasset-canton-topology-admin-v30.mdx
@@ -13,7 +13,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
   <h1 class="x2mdx-ref-title">com.digitalasset.canton.topology.admin.v30</h1>
 
 
-  <p class="x2mdx-ref-summary">4 services, 36 endpoints, 105 messages, 1 enums</p>
+  <p class="x2mdx-ref-summary">4 services, 36 endpoints, 106 messages, 1 enums</p>
 
 
 <div class="x2mdx-ref-badges">
@@ -42,7 +42,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
-    <dd>105</dd>
+    <dd>106</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -82,7 +82,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
-    <dd>3</dd>
+    <dd>4</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -92,7 +92,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/common.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/common.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/common.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/common.proto</a></dd>
   </div>
 
 </dl>
@@ -131,7 +131,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto</a></dd>
   </div>
 
 </dl>
@@ -170,7 +170,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto</a></dd>
   </div>
 
 </dl>
@@ -209,7 +209,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto</a></dd>
   </div>
 
 </dl>
@@ -248,7 +248,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto</a></dd>
   </div>
 
 </dl>
@@ -271,7 +271,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/initialization_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -439,7 +439,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -560,7 +560,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -1668,7 +1668,7 @@ description: "Package-level overview for com.digitalasset.canton.topology.admin.
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto">community/base/src/main/protobuf/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service.proto</a></dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -5684,6 +5684,50 @@ These are the package-level message and enum shapes in the publish-version snaps
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTopologyTransaction</span>
+
+    </div>
+
+  </div>
+
+</div>
+
+
+
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-digitalasset-canton-topology-admin-v30-synchronizerpredecessor">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.digitalasset.canton.topology.admin.v30.SynchronizerPredecessor</h3>
+
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+
+  </div>
+
+
+<div class="x2mdx-ref-fields">
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">predecessor_physical_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">upgrade_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+
+    </div>
+
+  </div>
+
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_late_upgrade</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
 
     </div>
 

--- a/docs-main/reference/protobuf/index.mdx
+++ b/docs-main/reference/protobuf/index.mdx
@@ -18,43 +18,43 @@ description: "Descriptor-backed protobuf API history grouped by package."
 
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Protobuf</span>
 
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.5.5</span>
 
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
     <dd>Canton protobuf trees from published release bundles</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Version filter</dt>
     <dd>stable Canton release bundles &gt;= 3.2.0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Latest release</dt>
-    <dd>v3.5.1</dd>
+    <dd>v3.5.5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Packages</dt>
     <dd>5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>58</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>237</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -68,447 +68,447 @@ Counts are shown as added / changed / removed within each release slice.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.0</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>55 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>227 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>12 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.2</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.3</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.4</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 1 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.5</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.6</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.7</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.8</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.9</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.10</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>0 / 1 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>3.4.11</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>1 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2 / 0 / 0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0 / 0 / 0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
@@ -549,6 +549,166 @@ Counts are shown as added / changed / removed within each release slice.
   </div>
 
 
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.2</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.3</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
 </div>
 
 
@@ -561,187 +721,187 @@ Counts are shown as added / changed / removed within each release slice.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">9 services, 22 endpoints, 120 messages, 8 enums</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>9</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>22</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>120</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>8</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-admin">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.admin</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">6 services, 28 endpoints, 79 messages, 3 enums</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>28</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>79</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>3</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-interactive">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.interactive</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">1 services, 6 endpoints, 29 messages, 1 enums</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>29</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-testing">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.testing</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">1 services, 2 endpoints, 3 messages</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>3</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -754,50 +914,50 @@ Counts are shown as added / changed / removed within each release slice.
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="./packages/com-daml-ledger-api-v2-interactive-transaction-v1">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>com.daml.ledger.api.v2.interactive.transaction.v1</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">0 services, 0 endpoints, 6 messages</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus.mdx
@@ -9,60 +9,60 @@ title: "GetCommandStatus"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetCommandStatus</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetCommandStatus</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.CommandInspectionService/GetCommandStatus</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetCommandStatus"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandInspectionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetCommandStatus</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GetCommandStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetCommandStatusRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id_prefix</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "GetCommandStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetCommandStatusResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_status</code>
       <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetCommandStatus"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,156 +235,156 @@ title: "GetCommandStatus"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetCommandStatusRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id_prefix</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CommandState">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstate">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>COMMAND_STATE_UNSPECIFIED</code></li>
-    
+
     <li><code>COMMAND_STATE_PENDING</code></li>
-    
+
     <li><code>COMMAND_STATE_SUCCEEDED</code></li>
-    
+
     <li><code>COMMAND_STATE_FAILED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetCommandStatusResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_status</code>
       <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CommandStatus">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstatus">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">started</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completed</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_statistics</code>
       <span class="x2mdx-ref-type-badge">RequestStatistics</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">updates</code>
       <span class="x2mdx-ref-type-badge">CommandUpdates</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
@@ -405,116 +405,116 @@ title: "GetCommandStatus"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Completion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -526,915 +526,915 @@ title: "GetCommandStatus"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.RequestStatistics">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-requeststatistics">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">envelopes</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">recipients</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CommandUpdates">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandupdates">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetched</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">looked_up_by_key</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Contract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-contract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1475,12 +1475,12 @@ title: "GetCommandStatus"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1499,14 +1499,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1567,7 +1567,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "CreateIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>CreateIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">CreateIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/CreateIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "CreateIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>CreateIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "CreateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,45 +153,45 @@ title: "CreateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -201,12 +201,12 @@ title: "CreateIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -217,103 +217,103 @@ title: "CreateIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -323,12 +323,12 @@ title: "CreateIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -351,14 +351,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -375,7 +375,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "DeleteIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>DeleteIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">DeleteIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/DeleteIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "DeleteIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>DeleteIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "DeleteIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,32 +153,32 @@ title: "DeleteIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "DeleteIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "DeleteIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "DeleteIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -261,14 +261,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "GetIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/GetIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "GetIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,45 +153,45 @@ title: "GetIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -201,12 +201,12 @@ title: "GetIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -217,103 +217,103 @@ title: "GetIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -323,12 +323,12 @@ title: "GetIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -345,14 +345,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -369,7 +369,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs.mdx
@@ -9,60 +9,60 @@ title: "ListIdentityProviderConfigs"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListIdentityProviderConfigs</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListIdentityProviderConfigs</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/ListIdentityProviderConfigs</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListIdentityProviderConfigs"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListIdentityProviderConfigs</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "ListIdentityProviderConfigs"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListIdentityProviderConfigsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "ListIdentityProviderConfigs"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListIdentityProviderConfigsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_configs</code>
       <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "ListIdentityProviderConfigs"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,90 +204,90 @@ title: "ListIdentityProviderConfigs"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_configs</code>
       <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -297,12 +297,12 @@ title: "ListIdentityProviderConfigs"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -317,14 +317,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -343,7 +343,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig.mdx
@@ -9,60 +9,60 @@ title: "UpdateIdentityProviderConfig"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateIdentityProviderConfig</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateIdentityProviderConfig</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/UpdateIdentityProviderConfig</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateIdentityProviderConfig"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>IdentityProviderConfigService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateIdentityProviderConfig</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "UpdateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateIdentityProviderConfigRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "UpdateIdentityProviderConfig"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateIdentityProviderConfigResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "UpdateIdentityProviderConfig"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,112 +226,112 @@ title: "UpdateIdentityProviderConfig"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -341,12 +341,12 @@ title: "UpdateIdentityProviderConfig"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -370,14 +370,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -394,7 +394,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages.mdx
@@ -9,60 +9,60 @@ title: "ListKnownPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListKnownPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListKnownPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/ListKnownPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListKnownPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListKnownPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "ListKnownPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "ListKnownPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_details</code>
       <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "ListKnownPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,90 +204,90 @@ title: "ListKnownPackages"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_details</code>
       <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PackageDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-packagedetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_size</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">known_since</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -297,12 +297,12 @@ title: "ListKnownPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -317,14 +317,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -343,7 +343,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages.mdx
@@ -9,60 +9,60 @@ title: "UpdateVettedPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateVettedPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateVettedPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/UpdateVettedPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateVettedPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateVettedPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,81 +105,81 @@ title: "UpdateVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateVettedPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">changes</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dry_run</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_topology_serial</code>
       <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
       <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -189,54 +189,54 @@ title: "UpdateVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateVettedPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">past_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -246,12 +246,12 @@ title: "UpdateVettedPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -262,380 +262,380 @@ title: "UpdateVettedPackages"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">changes</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dry_run</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_topology_serial</code>
       <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
       <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vet</code>
       <span class="x2mdx-ref-type-badge">Vet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unvet</code>
       <span class="x2mdx-ref-type-badge">Unvet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesRef">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackagesref">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-vet">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PriorTopologySerial">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prior</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">no_prior</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">past_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackages">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackage">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -645,12 +645,12 @@ title: "UpdateVettedPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -689,14 +689,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -734,7 +734,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile.mdx
@@ -9,60 +9,60 @@ title: "UploadDarFile"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UploadDarFile</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UploadDarFile</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/UploadDarFile</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UploadDarFile"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UploadDarFile</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "UploadDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UploadDarFileRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_change</code>
       <span class="x2mdx-ref-type-badge">VettingChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,32 +180,32 @@ title: "UploadDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UploadDarFileResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -215,12 +215,12 @@ title: "UploadDarFile"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -231,78 +231,78 @@ title: "UploadDarFile"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_change</code>
       <span class="x2mdx-ref-type-badge">VettingChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>VETTING_CHANGE_UNSPECIFIED</code></li>
-    
+
     <li><code>VETTING_CHANGE_VET_ALL_PACKAGES</code></li>
-    
+
     <li><code>VETTING_CHANGE_DONT_VET_ANY_PACKAGES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfileresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -312,12 +312,12 @@ title: "UploadDarFile"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -337,14 +337,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -353,7 +353,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile.mdx
@@ -9,60 +9,60 @@ title: "ValidateDarFile"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ValidateDarFile</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ValidateDarFile</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PackageManagementService/ValidateDarFile</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ValidateDarFile"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ValidateDarFile</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "ValidateDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ValidateDarFileRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "ValidateDarFile"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ValidateDarFileResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "ValidateDarFile"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "ValidateDarFile"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ValidateDarFileRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfilerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ValidateDarFileResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfileresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "ValidateDarFile"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune.mdx
@@ -9,60 +9,60 @@ title: "Prune"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>Prune</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Prune</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.ParticipantPruningService/Prune</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "Prune"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>ParticipantPruningService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>Prune</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "Prune"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PruneRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_up_to</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "Prune"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PruneResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "Prune"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "Prune"
 
 <Accordion title="com.daml.ledger.api.v2.admin.PruneRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-prunerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_up_to</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PruneResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-pruneresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "Prune"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty.mdx
@@ -9,60 +9,60 @@ title: "AllocateExternalParty"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>AllocateExternalParty</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">AllocateExternalParty</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/AllocateExternalParty</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "AllocateExternalParty"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>AllocateExternalParty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,66 +105,66 @@ title: "AllocateExternalParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocateExternalPartyRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">onboarding_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wait_for_allocation</code>
@@ -185,10 +185,10 @@ title: "AllocateExternalParty"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -198,45 +198,45 @@ title: "AllocateExternalParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocateExternalPartyResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -246,12 +246,12 @@ title: "AllocateExternalParty"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -262,46 +262,46 @@ title: "AllocateExternalParty"
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">onboarding_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wait_for_allocation</code>
@@ -322,154 +322,154 @@ title: "AllocateExternalParty"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -479,12 +479,12 @@ title: "AllocateExternalParty"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -525,14 +525,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -543,7 +543,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty.mdx
@@ -9,60 +9,60 @@ title: "AllocateParty"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>AllocateParty</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">AllocateParty</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/AllocateParty</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "AllocateParty"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>AllocateParty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,81 +105,81 @@ title: "AllocateParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocatePartyRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -189,45 +189,45 @@ title: "AllocateParty"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>AllocatePartyResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -237,12 +237,12 @@ title: "AllocateParty"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -253,161 +253,161 @@ title: "AllocateParty"
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocatePartyRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.AllocatePartyResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "AllocateParty"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -450,14 +450,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -480,7 +480,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology.mdx
@@ -9,60 +9,60 @@ title: "GenerateExternalPartyTopology"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GenerateExternalPartyTopology</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GenerateExternalPartyTopology</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GenerateExternalPartyTopology</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GenerateExternalPartyTopology"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GenerateExternalPartyTopology</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,99 +105,99 @@ title: "GenerateExternalPartyTopology"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GenerateExternalPartyTopologyRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key</code>
       <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_threshold</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observing_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -207,72 +207,72 @@ title: "GenerateExternalPartyTopology"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GenerateExternalPartyTopologyResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -282,12 +282,12 @@ title: "GenerateExternalPartyTopology"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -298,210 +298,210 @@ title: "GenerateExternalPartyTopology"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key</code>
       <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_threshold</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observing_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningPublicKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_data</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_spec</code>
       <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CryptoKeyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningKeySpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -511,12 +511,12 @@ title: "GenerateExternalPartyTopology"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -547,14 +547,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -570,7 +570,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid.mdx
@@ -9,60 +9,60 @@ title: "GetParticipantId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetParticipantId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetParticipantId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GetParticipantId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetParticipantId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetParticipantId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetParticipantId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetParticipantIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "GetParticipantId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetParticipantIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "GetParticipantId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "GetParticipantId"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetParticipantIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetParticipantIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "GetParticipantId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties.mdx
@@ -9,60 +9,60 @@ title: "GetParties"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetParties</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetParties</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GetParties</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetParties"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetParties</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPartiesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "GetParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPartiesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "GetParties"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,134 +226,134 @@ title: "GetParties"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetPartiesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetPartiesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -363,12 +363,12 @@ title: "GetParties"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -388,14 +388,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -420,7 +420,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties.mdx
@@ -9,60 +9,60 @@ title: "ListKnownParties"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListKnownParties</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListKnownParties</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/ListKnownParties</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListKnownParties"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListKnownParties</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "ListKnownParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPartiesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filter_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,54 +180,54 @@ title: "ListKnownParties"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListKnownPartiesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -237,12 +237,12 @@ title: "ListKnownParties"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -253,161 +253,161 @@ title: "ListKnownParties"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPartiesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filter_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListKnownPartiesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "ListKnownParties"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -442,14 +442,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -475,7 +475,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails.mdx
@@ -9,60 +9,60 @@ title: "UpdatePartyDetails"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdatePartyDetails</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdatePartyDetails</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyDetails</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdatePartyDetails"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdatePartyDetails</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "UpdatePartyDetails"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyDetailsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "UpdatePartyDetails"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyDetailsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "UpdatePartyDetails"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,134 +226,134 @@ title: "UpdatePartyDetails"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -363,12 +363,12 @@ title: "UpdatePartyDetails"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -398,14 +398,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -428,7 +428,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid.mdx
@@ -9,60 +9,60 @@ title: "UpdatePartyIdentityProviderId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdatePartyIdentityProviderId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdatePartyIdentityProviderId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyIdentityProviderId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdatePartyIdentityProviderId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PartyManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdatePartyIdentityProviderId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "UpdatePartyIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyIdentityProviderIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "UpdatePartyIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdatePartyIdentityProviderIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "UpdatePartyIdentityProviderId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "UpdatePartyIdentityProviderId"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "UpdatePartyIdentityProviderId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser.mdx
@@ -9,60 +9,60 @@ title: "CreateUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>CreateUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">CreateUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/CreateUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "CreateUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>CreateUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "CreateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "CreateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CreateUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "CreateUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,86 +226,86 @@ title: "CreateUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -317,239 +317,239 @@ title: "CreateUser"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.CreateUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -559,12 +559,12 @@ title: "CreateUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -600,14 +600,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -632,7 +632,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser.mdx
@@ -9,60 +9,60 @@ title: "DeleteUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>DeleteUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">DeleteUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/DeleteUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "DeleteUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>DeleteUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "DeleteUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,32 +162,32 @@ title: "DeleteUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>DeleteUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -197,12 +197,12 @@ title: "DeleteUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -213,41 +213,41 @@ title: "DeleteUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.DeleteUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -257,12 +257,12 @@ title: "DeleteUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -280,14 +280,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -296,7 +296,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser.mdx
@@ -9,60 +9,60 @@ title: "GetUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/GetUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "GetUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "GetUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,108 +226,108 @@ title: "GetUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GetUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -339,39 +339,39 @@ title: "GetUser"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -381,12 +381,12 @@ title: "GetUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -404,14 +404,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -436,7 +436,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights.mdx
@@ -9,60 +9,60 @@ title: "GrantUserRights"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GrantUserRights</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GrantUserRights</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/GrantUserRights</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GrantUserRights"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GrantUserRights</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GrantUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GrantUserRightsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "GrantUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GrantUserRightsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_granted_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GrantUserRights"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,241 +235,241 @@ title: "GrantUserRights"
 
 <Accordion title="com.daml.ledger.api.v2.admin.GrantUserRightsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.GrantUserRightsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_granted_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -479,12 +479,12 @@ title: "GrantUserRights"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -507,14 +507,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -529,7 +529,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights.mdx
@@ -9,60 +9,60 @@ title: "ListUserRights"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListUserRights</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListUserRights</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/ListUserRights</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListUserRights"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListUserRights</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "ListUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUserRightsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "ListUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUserRightsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "ListUserRights"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,232 +226,232 @@ title: "ListUserRights"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUserRightsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUserRightsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -461,12 +461,12 @@ title: "ListUserRights"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -484,14 +484,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -506,7 +506,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers.mdx
@@ -9,60 +9,60 @@ title: "ListUsers"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListUsers</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListUsers</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/ListUsers</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListUsers"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListUsers</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "ListUsers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUsersRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,54 +171,54 @@ title: "ListUsers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListUsersResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">users</code>
       <span class="x2mdx-ref-type-badge">repeated User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "ListUsers"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,126 +244,126 @@ title: "ListUsers"
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUsersRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ListUsersResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">users</code>
       <span class="x2mdx-ref-type-badge">repeated User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -375,39 +375,39 @@ title: "ListUsers"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "ListUsers"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -441,14 +441,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -476,7 +476,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights.mdx
@@ -9,60 +9,60 @@ title: "RevokeUserRights"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>RevokeUserRights</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">RevokeUserRights</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/RevokeUserRights</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "RevokeUserRights"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>RevokeUserRights</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "RevokeUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>RevokeUserRightsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "RevokeUserRights"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>RevokeUserRightsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "RevokeUserRights"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,241 +235,241 @@ title: "RevokeUserRights"
 
 <Accordion title="com.daml.ledger.api.v2.admin.RevokeUserRightsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.RevokeUserRightsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -479,12 +479,12 @@ title: "RevokeUserRights"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -507,14 +507,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -529,7 +529,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser.mdx
@@ -9,60 +9,60 @@ title: "UpdateUser"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateUser</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateUser</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/UpdateUser</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateUser"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateUser</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "UpdateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "UpdateUser"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "UpdateUser"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,86 +226,86 @@ title: "UpdateUser"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.User">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -317,61 +317,61 @@ title: "UpdateUser"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -381,12 +381,12 @@ title: "UpdateUser"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -418,14 +418,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -450,7 +450,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid.mdx
@@ -9,60 +9,60 @@ title: "UpdateUserIdentityProviderId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>UpdateUserIdentityProviderId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">UpdateUserIdentityProviderId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.admin.UserManagementService/UpdateUserIdentityProviderId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "UpdateUserIdentityProviderId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UserManagementService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>UpdateUserIdentityProviderId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "UpdateUserIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserIdentityProviderIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,32 +171,32 @@ title: "UpdateUserIdentityProviderId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>UpdateUserIdentityProviderIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -206,12 +206,12 @@ title: "UpdateUserIdentityProviderId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -222,50 +222,50 @@ title: "UpdateUserIdentityProviderId"
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -275,12 +275,12 @@ title: "UpdateUserIdentityProviderId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -299,14 +299,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -315,7 +315,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission.mdx
@@ -9,60 +9,60 @@ title: "ExecuteSubmission"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ExecuteSubmission</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ExecuteSubmission</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmission</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ExecuteSubmission"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ExecuteSubmission</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,108 +105,108 @@ title: "ExecuteSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -216,32 +216,32 @@ title: "ExecuteSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -251,12 +251,12 @@ title: "ExecuteSubmission"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -267,273 +267,273 @@ title: "ExecuteSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -545,80 +545,80 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -630,488 +630,488 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1197,82 +1197,82 @@ title: "ExecuteSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1293,143 +1293,143 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1450,30 +1450,30 @@ title: "ExecuteSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1546,411 +1546,411 @@ title: "ExecuteSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -1960,12 +1960,12 @@ title: "ExecuteSubmission"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2044,14 +2044,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2060,7 +2060,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait.mdx
@@ -9,60 +9,60 @@ title: "ExecuteSubmissionAndWait"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ExecuteSubmissionAndWait</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ExecuteSubmissionAndWait</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWait</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ExecuteSubmissionAndWait"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ExecuteSubmissionAndWait</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,108 +105,108 @@ title: "ExecuteSubmissionAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -216,54 +216,54 @@ title: "ExecuteSubmissionAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -273,12 +273,12 @@ title: "ExecuteSubmissionAndWait"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -289,273 +289,273 @@ title: "ExecuteSubmissionAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -567,80 +567,80 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -652,488 +652,488 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1219,82 +1219,82 @@ title: "ExecuteSubmissionAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1315,143 +1315,143 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1472,30 +1472,30 @@ title: "ExecuteSubmissionAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1568,433 +1568,433 @@ title: "ExecuteSubmissionAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2004,12 +2004,12 @@ title: "ExecuteSubmissionAndWait"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2088,14 +2088,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2107,7 +2107,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction.mdx
@@ -9,60 +9,60 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ExecuteSubmissionAndWaitForTransaction</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ExecuteSubmissionAndWaitForTransaction</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWaitForTransaction</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ExecuteSubmissionAndWaitForTransaction</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,117 +105,117 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitForTransactionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -225,45 +225,45 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ExecuteSubmissionAndWaitForTransactionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -273,12 +273,12 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -289,282 +289,282 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -576,80 +576,80 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -661,488 +661,488 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1228,82 +1228,82 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1324,143 +1324,143 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1481,30 +1481,30 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1577,768 +1577,768 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Signature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SignatureFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -2350,102 +2350,102 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -2459,132 +2459,132 @@ title: "ExecuteSubmissionAndWaitForTransaction"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -2596,263 +2596,263 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2862,12 +2862,12 @@ title: "ExecuteSubmissionAndWaitForTransaction"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2946,14 +2946,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2989,7 +2989,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages.mdx
@@ -9,60 +9,60 @@ title: "GetPreferredPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPreferredPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPreferredPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPreferredPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPreferredPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GetPreferredPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
       <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,54 +171,54 @@ title: "GetPreferredPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_references</code>
       <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetPreferredPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,143 +244,143 @@ title: "GetPreferredPackages"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
       <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PackageVettingRequirement">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagevettingrequirement">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_references</code>
       <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageReference">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -390,12 +390,12 @@ title: "GetPreferredPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -421,14 +421,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -446,7 +446,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion.mdx
@@ -9,60 +9,60 @@ title: "GetPreferredPackageVersion"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPreferredPackageVersion</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPreferredPackageVersion</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackageVersion</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPreferredPackageVersion"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPreferredPackageVersion</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "GetPreferredPackageVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackageVersionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,45 +180,45 @@ title: "GetPreferredPackageVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPreferredPackageVersionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_preference</code>
       <span class="x2mdx-ref-type-badge">PackagePreference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetPreferredPackageVersion"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,143 +244,143 @@ title: "GetPreferredPackageVersion"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_preference</code>
       <span class="x2mdx-ref-type-badge">PackagePreference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PackagePreference">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagepreference">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_reference</code>
       <span class="x2mdx-ref-type-badge">PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageReference">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -390,12 +390,12 @@ title: "GetPreferredPackageVersion"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -417,14 +417,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -442,7 +442,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission.mdx
@@ -9,60 +9,60 @@ title: "PrepareSubmission"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>PrepareSubmission</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">PrepareSubmission</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/PrepareSubmission</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "PrepareSubmission"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>InteractiveSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>PrepareSubmission</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,147 +105,147 @@ title: "PrepareSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PrepareSubmissionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose_hashing</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
       <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
@@ -266,10 +266,10 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -279,81 +279,81 @@ title: "PrepareSubmission"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>PrepareSubmissionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_details</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cost_estimation</code>
       <span class="x2mdx-ref-type-badge">CostEstimation</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -363,12 +363,12 @@ title: "PrepareSubmission"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -379,127 +379,127 @@ title: "PrepareSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose_hashing</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
       <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
@@ -520,822 +520,822 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1347,60 +1347,60 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.CostEstimationHints">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimationhints">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disabled</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1425,246 +1425,246 @@ title: "PrepareSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_details</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cost_estimation</code>
       <span class="x2mdx-ref-type-badge">CostEstimation</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -1676,80 +1676,80 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1841,89 +1841,89 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1944,143 +1944,143 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -2101,30 +2101,30 @@ title: "PrepareSubmission"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2197,255 +2197,255 @@ title: "PrepareSubmission"
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.interactive.CostEstimation">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimation">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimation_timestamp</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_request_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_response_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">total_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2455,12 +2455,12 @@ title: "PrepareSubmission"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2517,14 +2517,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2584,7 +2584,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/gettime.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/gettime.mdx
@@ -9,60 +9,60 @@ title: "GetTime"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-testing">com.daml.ledger.api.v2.testing</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetTime</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.testing</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetTime</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.testing.TimeService/GetTime</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetTime"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>TimeService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetTime</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetTimeRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "GetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetTimeResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "GetTime"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "GetTime"
 
 <Accordion title="com.daml.ledger.api.v2.testing.GetTimeRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimerequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.testing.GetTimeResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimeresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "GetTime"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/settime.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/settime.mdx
@@ -9,60 +9,60 @@ title: "SetTime"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2-testing">com.daml.ledger.api.v2.testing</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SetTime</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.testing</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SetTime</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.testing.TimeService/SetTime</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SetTime"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>TimeService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SetTime</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "SetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SetTimeRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.testing.SetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,27 +162,27 @@ title: "SetTime"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>Empty</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>google.protobuf.Empty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
+
+
 </div>
 
 
@@ -192,12 +192,12 @@ title: "SetTime"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -208,32 +208,32 @@ title: "SetTime"
 
 <Accordion title="com.daml.ledger.api.v2.testing.SetTimeRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-settimerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -243,12 +243,12 @@ title: "SetTime"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -266,14 +266,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -282,7 +282,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream.mdx
@@ -9,60 +9,60 @@ title: "CompletionStream"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>CompletionStream</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">CompletionStream</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandCompletionService/CompletionStream</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "CompletionStream"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandCompletionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>CompletionStream</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "CompletionStream"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CompletionStreamRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,54 +171,54 @@ title: "CompletionStream"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>CompletionStreamResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "CompletionStream"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,180 +244,180 @@ title: "CompletionStream"
 
 <Accordion title="com.daml.ledger.api.v2.CompletionStreamRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CompletionStreamResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Completion">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -429,101 +429,101 @@ title: "CompletionStream"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.OffsetCheckpoint">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_times</code>
       <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -533,12 +533,12 @@ title: "CompletionStream"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -560,14 +560,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -588,7 +588,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwait.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwait.mdx
@@ -9,60 +9,60 @@ title: "SubmitAndWait"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitAndWait</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitAndWait</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWait</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitAndWait"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitAndWait</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "SubmitAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,54 +153,54 @@ title: "SubmitAndWait"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "SubmitAndWait"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,167 +226,167 @@ title: "SubmitAndWait"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Commands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -398,791 +398,791 @@ title: "SubmitAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1194,39 +1194,39 @@ title: "SubmitAndWait"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1236,12 +1236,12 @@ title: "SubmitAndWait"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1273,14 +1273,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1292,7 +1292,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment.mdx
@@ -9,60 +9,60 @@ title: "SubmitAndWaitForReassignment"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitAndWaitForReassignment</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitAndWaitForReassignment</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWaitForReassignment</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitAndWaitForReassignment"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitAndWaitForReassignment</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "SubmitAndWaitForReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForReassignmentRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "SubmitAndWaitForReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForReassignmentResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "SubmitAndWaitForReassignment"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,548 +226,548 @@ title: "SubmitAndWaitForReassignment"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassign_command</code>
       <span class="x2mdx-ref-type-badge">UnassignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assign_command</code>
       <span class="x2mdx-ref-type-badge">AssignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -779,281 +779,281 @@ title: "SubmitAndWaitForReassignment"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -1067,572 +1067,572 @@ title: "SubmitAndWaitForReassignment"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1644,39 +1644,39 @@ title: "SubmitAndWaitForReassignment"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1686,12 +1686,12 @@ title: "SubmitAndWaitForReassignment"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1744,14 +1744,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1787,7 +1787,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction.mdx
@@ -9,60 +9,60 @@ title: "SubmitAndWaitForTransaction"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitAndWaitForTransaction</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitAndWaitForTransaction</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWaitForTransaction</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitAndWaitForTransaction"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitAndWaitForTransaction</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "SubmitAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForTransactionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "SubmitAndWaitForTransaction"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitAndWaitForTransactionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "SubmitAndWaitForTransaction"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,176 +226,176 @@ title: "SubmitAndWaitForTransaction"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Commands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -407,791 +407,791 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1203,374 +1203,374 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1582,102 +1582,102 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -1691,132 +1691,132 @@ title: "SubmitAndWaitForTransaction"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1828,263 +1828,263 @@ title: "SubmitAndWaitForTransaction"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2094,12 +2094,12 @@ title: "SubmitAndWaitForTransaction"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2151,14 +2151,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2194,7 +2194,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit.mdx
@@ -9,60 +9,60 @@ title: "Submit"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>Submit</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">Submit</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandSubmissionService/Submit</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "Submit"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>Submit</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "Submit"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,32 +153,32 @@ title: "Submit"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "Submit"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,167 +204,167 @@ title: "Submit"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Commands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -376,791 +376,791 @@ title: "Submit"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Command">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.DisclosedContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -1172,17 +1172,17 @@ title: "Submit"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -1192,12 +1192,12 @@ title: "Submit"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1229,14 +1229,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1245,7 +1245,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment.mdx
@@ -9,60 +9,60 @@ title: "SubmitReassignment"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>SubmitReassignment</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">SubmitReassignment</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.CommandSubmissionService/SubmitReassignment</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "SubmitReassignment"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>CommandSubmissionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>SubmitReassignment</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "SubmitReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitReassignmentRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,32 +153,32 @@ title: "SubmitReassignment"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>SubmitReassignmentResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "SubmitReassignment"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,210 +204,210 @@ title: "SubmitReassignment"
 
 <Accordion title="com.daml.ledger.api.v2.SubmitReassignmentRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommands">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassign_command</code>
       <span class="x2mdx-ref-type-badge">UnassignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assign_command</code>
       <span class="x2mdx-ref-type-badge">AssignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignCommand">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SubmitReassignmentResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentresponse">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
@@ -417,12 +417,12 @@ title: "SubmitReassignment"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -454,14 +454,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -470,7 +470,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/contractservice/getcontract.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/contractservice/getcontract.mdx
@@ -9,60 +9,60 @@ title: "GetContract"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetContract</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetContract</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.11</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.ContractService/GetContract</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetContract"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>ContractService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetContract</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetContract"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetContractRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetContractRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">querying_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,45 +162,45 @@ title: "GetContract"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetContractResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetContractResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -210,12 +210,12 @@ title: "GetContract"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.11</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -226,108 +226,108 @@ title: "GetContract"
 
 <Accordion title="com.daml.ledger.api.v2.GetContractRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">querying_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetContractResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -341,612 +341,612 @@ title: "GetContract"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -958,8 +958,8 @@ title: "GetContract"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -969,12 +969,12 @@ title: "GetContract"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -994,14 +994,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1039,7 +1039,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid.mdx
@@ -9,60 +9,60 @@ title: "GetEventsByContractId"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetEventsByContractId</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetEventsByContractId</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.EventQueryService/GetEventsByContractId</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetEventsByContractId"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>EventQueryService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetEventsByContractId</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetEventsByContractId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetEventsByContractIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,54 +162,54 @@ title: "GetEventsByContractId"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetEventsByContractIdResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">Created</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">Archived</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetEventsByContractId"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,383 +235,383 @@ title: "GetEventsByContractId"
 
 <Accordion title="com.daml.ledger.api.v2.GetEventsByContractIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetEventsByContractIdResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">Created</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">Archived</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Created">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-created">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -625,572 +625,572 @@ title: "GetEventsByContractId"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1202,115 +1202,115 @@ title: "GetEventsByContractId"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Archived">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archived">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived_event</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1320,12 +1320,12 @@ title: "GetEventsByContractId"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1363,14 +1363,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1428,7 +1428,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackage.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackage.mdx
@@ -9,60 +9,60 @@ title: "GetPackage"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPackage</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPackage</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/GetPackage</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPackage"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPackage</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "GetPackage"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,63 +153,63 @@ title: "GetPackage"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash_function</code>
       <span class="x2mdx-ref-type-badge">HashFunction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archive_payload</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetPackage"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,78 +235,78 @@ title: "GetPackage"
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagerequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackageresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash_function</code>
       <span class="x2mdx-ref-type-badge">HashFunction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archive_payload</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.HashFunction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-hashfunction">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASH_FUNCTION_SHA256</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -316,12 +316,12 @@ title: "GetPackage"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -338,14 +338,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -358,7 +358,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus.mdx
@@ -9,60 +9,60 @@ title: "GetPackageStatus"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetPackageStatus</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetPackageStatus</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/GetPackageStatus</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetPackageStatus"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetPackageStatus</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,45 +105,45 @@ title: "GetPackageStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageStatusRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -153,45 +153,45 @@ title: "GetPackageStatus"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetPackageStatusResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_status</code>
       <span class="x2mdx-ref-type-badge">PackageStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -201,12 +201,12 @@ title: "GetPackageStatus"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -217,62 +217,62 @@ title: "GetPackageStatus"
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageStatusRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetPackageStatusResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_status</code>
       <span class="x2mdx-ref-type-badge">PackageStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageStatus">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagestatus">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PACKAGE_STATUS_UNSPECIFIED</code></li>
-    
+
     <li><code>PACKAGE_STATUS_REGISTERED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -282,12 +282,12 @@ title: "GetPackageStatus"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -304,14 +304,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -322,7 +322,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listpackages.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listpackages.mdx
@@ -9,60 +9,60 @@ title: "ListPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/ListPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "ListPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "ListPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "ListPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "ListPackages"
 
 <Accordion title="com.daml.ledger.api.v2.ListPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ListPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "ListPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -279,7 +279,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages.mdx
@@ -9,60 +9,60 @@ title: "ListVettedPackages"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>ListVettedPackages</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">ListVettedPackages</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.PackageService/ListVettedPackages</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "ListVettedPackages"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>PackageService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>ListVettedPackages</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,72 +105,72 @@ title: "ListVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListVettedPackagesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_metadata_filter</code>
       <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_state_filter</code>
       <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,54 +180,54 @@ title: "ListVettedPackages"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>ListVettedPackagesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetted_packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -237,12 +237,12 @@ title: "ListVettedPackages"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -253,250 +253,250 @@ title: "ListVettedPackages"
 
 <Accordion title="com.daml.ledger.api.v2.ListVettedPackagesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_metadata_filter</code>
       <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_state_filter</code>
       <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageMetadataFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagemetadatafilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name_prefixes</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyStateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologystatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ListVettedPackagesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetted_packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackages">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.VettedPackage">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -506,12 +506,12 @@ title: "ListVettedPackages"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -545,14 +545,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -579,7 +579,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts.mdx
@@ -9,60 +9,60 @@ title: "GetActiveContracts"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetActiveContracts</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetActiveContracts</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetActiveContracts</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetActiveContracts"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetActiveContracts</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,48 +105,48 @@ title: "GetActiveContracts"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetActiveContractsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -158,10 +158,10 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,66 +171,66 @@ title: "GetActiveContracts"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetActiveContractsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_contract</code>
       <span class="x2mdx-ref-type-badge">ActiveContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_assigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -242,10 +242,10 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -255,12 +255,12 @@ title: "GetActiveContracts"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -271,28 +271,28 @@ title: "GetActiveContracts"
 
 <Accordion title="com.daml.ledger.api.v2.GetActiveContractsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -304,288 +304,288 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetActiveContractsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_contract</code>
       <span class="x2mdx-ref-type-badge">ActiveContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">incomplete_assigned</code>
       <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stream_continuation_token</code>
@@ -597,102 +597,102 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ActiveContract">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-activecontract">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -706,572 +706,572 @@ title: "GetActiveContracts"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1283,249 +1283,249 @@ title: "GetActiveContracts"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.IncompleteUnassigned">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteunassigned">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned_event</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.IncompleteAssigned">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteassigned">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned_event</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -1535,12 +1535,12 @@ title: "GetActiveContracts"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -1580,14 +1580,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -1624,7 +1624,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers.mdx
@@ -9,60 +9,60 @@ title: "GetConnectedSynchronizers"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetConnectedSynchronizers</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetConnectedSynchronizers</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetConnectedSynchronizers</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetConnectedSynchronizers"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetConnectedSynchronizers</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,63 +105,63 @@ title: "GetConnectedSynchronizers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetConnectedSynchronizersRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -171,45 +171,45 @@ title: "GetConnectedSynchronizers"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetConnectedSynchronizersResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">connected_synchronizers</code>
       <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -219,12 +219,12 @@ title: "GetConnectedSynchronizers"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -235,124 +235,124 @@ title: "GetConnectedSynchronizers"
 
 <Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">connected_synchronizers</code>
       <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_alias</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -362,12 +362,12 @@ title: "GetConnectedSynchronizers"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -386,14 +386,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -410,7 +410,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets.mdx
@@ -9,60 +9,60 @@ title: "GetLatestPrunedOffsets"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetLatestPrunedOffsets</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetLatestPrunedOffsets</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetLatestPrunedOffsets</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetLatestPrunedOffsets"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetLatestPrunedOffsets</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetLatestPrunedOffsets"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLatestPrunedOffsetsRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,54 +140,54 @@ title: "GetLatestPrunedOffsets"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLatestPrunedOffsetsResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -197,12 +197,12 @@ title: "GetLatestPrunedOffsets"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -213,41 +213,41 @@ title: "GetLatestPrunedOffsets"
 
 <Accordion title="com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -257,12 +257,12 @@ title: "GetLatestPrunedOffsets"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -277,14 +277,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -296,7 +296,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getledgerend.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getledgerend.mdx
@@ -9,60 +9,60 @@ title: "GetLedgerEnd"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetLedgerEnd</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetLedgerEnd</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.StateService/GetLedgerEnd</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetLedgerEnd"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>StateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetLedgerEnd</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetLedgerEnd"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerEndRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,45 +140,45 @@ title: "GetLedgerEnd"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerEndResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -188,12 +188,12 @@ title: "GetLedgerEnd"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -204,32 +204,32 @@ title: "GetLedgerEnd"
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerEndRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerEndResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -239,12 +239,12 @@ title: "GetLedgerEnd"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -259,14 +259,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -277,7 +277,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid.mdx
@@ -9,60 +9,60 @@ title: "GetUpdateById"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUpdateById</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUpdateById</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.UpdateService/GetUpdateById</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUpdateById"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UpdateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUpdateById</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetUpdateById"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateByIdRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,63 +162,63 @@ title: "GetUpdateById"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetUpdateById"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,540 +244,540 @@ title: "GetUpdateById"
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateByIdRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyidrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UpdateFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -789,102 +789,102 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -898,572 +898,572 @@ title: "GetUpdateById"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1475,344 +1475,344 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1824,330 +1824,330 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -2159,140 +2159,140 @@ title: "GetUpdateById"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2342,12 +2342,12 @@ title: "GetUpdateById"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2402,14 +2402,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2445,7 +2445,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset.mdx
@@ -9,60 +9,60 @@ title: "GetUpdateByOffset"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUpdateByOffset</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUpdateByOffset</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.UpdateService/GetUpdateByOffset</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUpdateByOffset"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UpdateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUpdateByOffset</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,54 +105,54 @@ title: "GetUpdateByOffset"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateByOffsetRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -162,63 +162,63 @@ title: "GetUpdateByOffset"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdateResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -228,12 +228,12 @@ title: "GetUpdateByOffset"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -244,540 +244,540 @@ title: "GetUpdateByOffset"
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateByOffsetRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyoffsetrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UpdateFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdateResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -789,102 +789,102 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -898,572 +898,572 @@ title: "GetUpdateByOffset"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1475,344 +1475,344 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1824,330 +1824,330 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -2159,140 +2159,140 @@ title: "GetUpdateByOffset"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2342,12 +2342,12 @@ title: "GetUpdateByOffset"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2402,14 +2402,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2445,7 +2445,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdates.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdates.mdx
@@ -9,60 +9,60 @@ title: "GetUpdates"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetUpdates</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetUpdates</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.UpdateService/GetUpdates</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetUpdates"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>UpdateService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetUpdates</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,57 +105,57 @@ title: "GetUpdates"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">end_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">descending_order</code>
@@ -167,10 +167,10 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -180,72 +180,72 @@ title: "GetUpdates"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetUpdatesResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -255,12 +255,12 @@ title: "GetUpdates"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -271,37 +271,37 @@ title: "GetUpdates"
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdatesRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesrequest">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">end_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">descending_order</code>
@@ -313,525 +313,525 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UpdateFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.EventFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Filters">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.WildcardFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Identifier">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TemplateFilter">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TransactionShape">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetUpdatesResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Transaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -843,102 +843,102 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Event">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.CreatedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -952,572 +952,572 @@ title: "GetUpdates"
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Value">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Optional">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.List">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Record">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.RecordField">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Variant">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Enum">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.InterfaceView">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -1529,344 +1529,344 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TraceContext">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.Reassignment">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -1878,392 +1878,392 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.AssignedEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.OffsetCheckpoint">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_times</code>
       <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.TopologyEvent">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -2275,140 +2275,140 @@ title: "GetUpdates"
 
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -2458,12 +2458,12 @@ title: "GetUpdates"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -2521,14 +2521,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -2564,7 +2564,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion.mdx
+++ b/docs-main/reference/protobuf/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion.mdx
@@ -9,60 +9,60 @@ title: "GetLedgerApiVersion"
 
 
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
-  
-  
+
+
   <span>Ledger API</span>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../index">Protobuf</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
-  
-  
+
+
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
-  
-  
-  
+
+
+
   <span>GetLedgerApiVersion</span>
-  
-  
-  
+
+
+
 </div>
 
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">GetLedgerApiVersion</h1>
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
-  
+
 </div>
 
 <div class="x2mdx-ref-operation-bar">
-  
+
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
-  
+
   <code>/com.daml.ledger.api.v2.VersionService/GetLedgerApiVersion</code>
 </div>
 
@@ -70,32 +70,32 @@ title: "GetLedgerApiVersion"
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Protocol</dt>
     <dd>gRPC</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Service</dt>
     <dd>VersionService</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>RPC</dt>
     <dd>GetLedgerApiVersion</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
 
@@ -105,32 +105,32 @@ title: "GetLedgerApiVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerApiVersionRequest</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
 </div>
 
 
@@ -140,54 +140,54 @@ title: "GetLedgerApiVersion"
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
     <h3>GetLedgerApiVersionResponse</h3>
-    
+
   </div>
-  
-  
-  
+
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Message</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
-  
-  
+
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">features</code>
       <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
-  
-  
+
+
+
+
 </div>
 
 
@@ -197,12 +197,12 @@ title: "GetLedgerApiVersion"
 ## Lifecycle Changes
 
 <div class="x2mdx-ref-change-list">
-  
+
   <div class="x2mdx-ref-change-item">
     <span class="x2mdx-ref-change-version">3.4.0</span>
     <span class="x2mdx-ref-change-detail">introduced</span>
   </div>
-  
+
 </div>
 
 
@@ -213,280 +213,280 @@ title: "GetLedgerApiVersion"
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerApiVersionRequest">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionrequest">
-  
-  
-  
-  
+
+
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.GetLedgerApiVersionResponse">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionresponse">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">features</code>
       <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.FeaturesDescriptor">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-featuresdescriptor">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">experimental</code>
       <span class="x2mdx-ref-type-badge">ExperimentalFeatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_management</code>
       <span class="x2mdx-ref-type-badge">UserManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_management</code>
       <span class="x2mdx-ref-type-badge">PartyManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpointFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_feature</code>
       <span class="x2mdx-ref-type-badge">PackageFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExperimentalFeatures">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalfeatures">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">static_time</code>
       <span class="x2mdx-ref-type-badge">ExperimentalStaticTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_inspection_service</code>
       <span class="x2mdx-ref-type-badge">ExperimentalCommandInspectionService</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExperimentalStaticTime">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalstatictime">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.ExperimentalCommandInspectionService">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalcommandinspectionservice">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.UserManagementFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-usermanagementfeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_rights_per_user</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_users_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PartyManagementFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-partymanagementfeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_parties_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.OffsetCheckpointFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpointfeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_offset_checkpoint_emission_delay</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
 <Accordion title="com.daml.ledger.api.v2.PackageFeature">
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagefeature">
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_vetted_packages_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 </Accordion>
 
@@ -496,12 +496,12 @@ title: "GetLedgerApiVersion"
 </div>
 
 <div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">grpcurl</span>
-  
+
 </div>
 
 ```bash grpcurl
@@ -516,14 +516,14 @@ EOF
 
 </div>
   </div>
-  
+
   <div className="x2mdx-ref-rail-panel">
   <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
 <div className="x2mdx-ref-rail-head">
   <span className="x2mdx-ref-rail-heading">OK</span>
-  
+
   <span className="x2mdx-ref-response-label">application/json</span>
-  
+
 </div>
 
 ```json OK
@@ -558,7 +558,7 @@ EOF
 
 </div>
   </div>
-  
+
 </div>
 
 </div>

--- a/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-admin.mdx
+++ b/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-admin.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.admin</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">6 services, 28 endpoints, 79 messages, 3 enums</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>28</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>79</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>3</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,280 +61,280 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>11</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>11</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>17</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>20</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -346,69 +346,69 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandInspectionService.GetCommandStatus</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandInspectionService.GetCommandStatus(com.daml.ledger.api.v2.admin.GetCommandStatusRequest) returns (com.daml.ledger.api.v2.admin.GetCommandStatusResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -420,257 +420,257 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>5</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.CreateIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.CreateIdentityProviderConfig(com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.CreateIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.DeleteIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.DeleteIdentityProviderConfig(com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.DeleteIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.GetIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.GetIdentityProviderConfig(com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.GetIdentityProvi...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.ListIdentityProviderConfigs</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.ListIdentityProviderConfigs(com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest) returns (com.daml.ledger.api.v2.admin.ListIdentity...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>IdentityProviderConfigService.UpdateIdentityProviderConfig</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.UpdateIdentityProviderConfig(com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.UpdateIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -682,210 +682,210 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>4</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.ListKnownPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.ListKnownPackages(com.daml.ledger.api.v2.admin.ListKnownPackagesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.UpdateVettedPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.UpdateVettedPackages(com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest) returns (com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.UploadDarFile</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.UploadDarFile(com.daml.ledger.api.v2.admin.UploadDarFileRequest) returns (com.daml.ledger.api.v2.admin.UploadDarFileResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UploadDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageManagementService.ValidateDarFile</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageManagementService.ValidateDarFile(com.daml.ledger.api.v2.admin.ValidateDarFileRequest) returns (com.daml.ledger.api.v2.admin.ValidateDarFileResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -897,69 +897,69 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>ParticipantPruningService.Prune</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc ParticipantPruningService.Prune(com.daml.ledger.api.v2.admin.PruneRequest) returns (com.daml.ledger.api.v2.admin.PruneResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.PruneResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -971,398 +971,398 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>8</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.AllocateExternalParty</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.AllocateExternalParty(com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest) returns (com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.AllocateParty</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.AllocateParty(com.daml.ledger.api.v2.admin.AllocatePartyRequest) returns (com.daml.ledger.api.v2.admin.AllocatePartyResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.AllocatePartyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.GenerateExternalPartyTopology</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GenerateExternalPartyTopology(com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest) returns (com.daml.ledger.api.v2.admin.GenerateExterna...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.GetParticipantId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GetParticipantId(com.daml.ledger.api.v2.admin.GetParticipantIdRequest) returns (com.daml.ledger.api.v2.admin.GetParticipantIdResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.GetParties</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GetParties(com.daml.ledger.api.v2.admin.GetPartiesRequest) returns (com.daml.ledger.api.v2.admin.GetPartiesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.ListKnownParties</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.ListKnownParties(com.daml.ledger.api.v2.admin.ListKnownPartiesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPartiesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.UpdatePartyDetails</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.UpdatePartyDetails(com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PartyManagementService.UpdatePartyIdentityProviderId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PartyManagementService.UpdatePartyIdentityProviderId(com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyIden...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1374,445 +1374,445 @@ description: "Package-level overview for com.daml.ledger.api.v2.admin."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>9</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.CreateUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.CreateUser(com.daml.ledger.api.v2.admin.CreateUserRequest) returns (com.daml.ledger.api.v2.admin.CreateUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.CreateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.DeleteUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.DeleteUser(com.daml.ledger.api.v2.admin.DeleteUserRequest) returns (com.daml.ledger.api.v2.admin.DeleteUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.DeleteUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.GetUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.GetUser(com.daml.ledger.api.v2.admin.GetUserRequest) returns (com.daml.ledger.api.v2.admin.GetUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GetUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.GrantUserRights</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.GrantUserRights(com.daml.ledger.api.v2.admin.GrantUserRightsRequest) returns (com.daml.ledger.api.v2.admin.GrantUserRightsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.ListUserRights</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.ListUserRights(com.daml.ledger.api.v2.admin.ListUserRightsRequest) returns (com.daml.ledger.api.v2.admin.ListUserRightsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.ListUsers</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.ListUsers(com.daml.ledger.api.v2.admin.ListUsersRequest) returns (com.daml.ledger.api.v2.admin.ListUsersResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.ListUsersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.RevokeUserRights</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.RevokeUserRights(com.daml.ledger.api.v2.admin.RevokeUserRightsRequest) returns (com.daml.ledger.api.v2.admin.RevokeUserRightsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.UpdateUser</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.UpdateUser(com.daml.ledger.api.v2.admin.UpdateUserRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UserManagementService.UpdateUserIdentityProviderId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UserManagementService.UpdateUserIdentityProviderId(com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserIdentity...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1830,50 +1830,50 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">onboarding_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wait_for_allocation</code>
@@ -1894,426 +1894,426 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Signature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocatePartyRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ObjectMeta</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">resource_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">annotations</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.AllocatePartyResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PartyDetails</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_local</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstatus">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CommandStatus</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">9 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">started</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completed</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_statistics</code>
       <span class="x2mdx-ref-type-badge">RequestStatistics</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">updates</code>
       <span class="x2mdx-ref-type-badge">CommandUpdates</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
@@ -2334,120 +2334,120 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Completion</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">12 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -2459,1028 +2459,1028 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TraceContext</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SynchronizerTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstate">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CommandState</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>COMMAND_STATE_UNSPECIFIED</code></li>
-    
+
     <li><code>COMMAND_STATE_PENDING</code></li>
-    
+
     <li><code>COMMAND_STATE_SUCCEEDED</code></li>
-    
+
     <li><code>COMMAND_STATE_FAILED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Command</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-requeststatistics">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.RequestStatistics</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">envelopes</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">request_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">recipients</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandupdates">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CommandUpdates</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">repeated Contract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetched</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">looked_up_by_key</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-contract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Contract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-timing">
@@ -3521,208 +3521,208 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.IdentityProviderConfig</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">issuer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">jwks_url</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">audience</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.User</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">is_deactivated</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">ObjectMeta</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">primary_party_authentication</code>
@@ -3734,2268 +3734,2268 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_admin</code>
       <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_act_as</code>
       <span class="x2mdx-ref-type-badge">CanActAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as</code>
       <span class="x2mdx-ref-type-badge">CanReadAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_admin</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
       <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.ParticipantAdmin</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanActAs</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanReadAs</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanExecuteAs</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.CreateUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.DeleteUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_hint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key</code>
       <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_threshold</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observing_participant_uids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningPublicKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_data</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_spec</code>
       <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CryptoKeyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningKeySpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transactions</code>
       <span class="x2mdx-ref-type-badge">repeated bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">multi_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id_prefix</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">state</code>
       <span class="x2mdx-ref-type-badge">CommandState</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_status</code>
       <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetPartiesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetPartiesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GetUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_granted_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_configs</code>
       <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_details</code>
       <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-packagedetails">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PackageDetails</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_size</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">known_since</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filter_party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUserRightsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUserRightsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUsersRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ListUsersResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">users</code>
       <span class="x2mdx-ref-type-badge">repeated User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-prunerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PruneRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_up_to</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-pruneresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.PruneResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
       <span class="x2mdx-ref-type-badge">repeated Right</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_config</code>
       <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_details</code>
       <span class="x2mdx-ref-type-badge">PartyDetails</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_mask</code>
       <span class="x2mdx-ref-type-badge">FieldMask</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateUserResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user</code>
       <span class="x2mdx-ref-type-badge">User</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">changes</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dry_run</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_topology_serial</code>
       <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
       <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vet</code>
       <span class="x2mdx-ref-type-badge">Vet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unvet</code>
       <span class="x2mdx-ref-type-badge">Unvet</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackagesref">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesRef</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-vet">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PriorTopologySerial</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prior</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">no_prior</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES</code></li>
-    
+
     <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">past_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_vetted_packages</code>
       <span class="x2mdx-ref-type-badge">VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackages</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackage</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UploadDarFileRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_change</code>
       <span class="x2mdx-ref-type-badge">VettingChange</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>VETTING_CHANGE_UNSPECIFIED</code></li>
-    
+
     <li><code>VETTING_CHANGE_VET_ALL_PACKAGES</code></li>
-    
+
     <li><code>VETTING_CHANGE_DONT_VET_ANY_PACKAGES</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfileresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.UploadDarFileResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfilerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">dar_file</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfileresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>

--- a/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
+++ b/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive.tran
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.interactive.transaction.v1</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">0 services, 0 endpoints, 6 messages</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,46 +61,46 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive.tran
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -118,77 +118,77 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Create</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -200,536 +200,536 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkeywithmaintainers">
@@ -823,140 +823,140 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Exercise</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -977,93 +977,93 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Fetch</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">10 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1084,57 +1084,57 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Node</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -1146,34 +1146,34 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Rollback</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-querybykey">

--- a/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-interactive.mdx
+++ b/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-interactive.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.interactive</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">1 services, 6 endpoints, 29 messages, 1 enums</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>29</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,85 +61,85 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>22</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -151,304 +151,304 @@ description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>6</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.ExecuteSubmission</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmission(com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionResp...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.ExecuteSubmissionAndWait</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmissionAndWait(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest) returns (com.daml.ledger.api.v2.interactive.Execute...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest) returns (com.daml.ledge...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.GetPreferredPackageVersion</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.GetPreferredPackageVersion(com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest) returns (com.daml.ledger.api.v2.interactive.Get...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.GetPreferredPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.GetPreferredPackages(com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPac...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>InteractiveSubmissionService.PrepareSubmission</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.PrepareSubmission(com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.PrepareSubmissionResp...</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -466,286 +466,286 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimation">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.CostEstimation</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimation_timestamp</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_request_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">confirmation_response_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">total_traffic_cost_estimation</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimationhints">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.CostEstimationHints</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disabled</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">expected_signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.DamlTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">roots</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">nodes</code>
       <span class="x2mdx-ref-type-badge">repeated Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_seeds</code>
       <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">seed</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.DamlTransaction.Node</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Node</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Node</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fetch</code>
       <span class="x2mdx-ref-type-badge">Fetch</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">Exercise</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">rollback</code>
       <span class="x2mdx-ref-type-badge">Rollback</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">query_by_key</code>
@@ -757,84 +757,84 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Create</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -846,536 +846,536 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkeywithmaintainers">
@@ -1469,86 +1469,86 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Fetch</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">10 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1569,147 +1569,147 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Exercise</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">lf_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">stakeholders</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">chosen_value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
@@ -1730,34 +1730,34 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Rollback</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">children</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-querybykey">
@@ -1834,960 +1834,960 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">9 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PreparedTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">DamlTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">metadata</code>
       <span class="x2mdx-ref-type-badge">Metadata</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">10 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter_info</code>
       <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">mediator_group</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_uuid</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">preparation_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">input_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated InputContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">global_key_mapping</code>
       <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">GlobalKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.Metadata.InputContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">v1</code>
       <span class="x2mdx-ref-type-badge">Create</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PartySignatures</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.SinglePartySignatures</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatures</code>
       <span class="x2mdx-ref-type-badge">repeated Signature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Signature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.HashingSchemeVersion</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V2</code></li>
-    
+
     <li><code>HASHING_SCHEME_VERSION_V3</code></li>
 
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.MinLedgerTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.EventFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Filters</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CumulativeFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.WildcardFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TemplateFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionShape</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Transaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">11 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -2799,110 +2799,110 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Event</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreatedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -2916,136 +2916,136 @@ These are the package-level message and enum shapes in the publish-version snaps
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceView</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -3057,903 +3057,903 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ArchivedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExercisedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">15 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TraceContext</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">8 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_signatures</code>
       <span class="x2mdx-ref-type-badge">PartySignatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_preference</code>
       <span class="x2mdx-ref-type-badge">PackagePreference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagepreference">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PackagePreference</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_reference</code>
       <span class="x2mdx-ref-type-badge">PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageReference</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
       <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetting_valid_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagevettingrequirement">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PackageVettingRequirement</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_references</code>
       <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">15 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time</code>
       <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose_hashing</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
       <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
@@ -3974,339 +3974,339 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Command</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.DisclosedContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PrefetchContractKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -4318,68 +4318,68 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction</code>
       <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
       <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hashing_details</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cost_estimation</code>
       <span class="x2mdx-ref-type-badge">CostEstimation</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>

--- a/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-testing.mdx
+++ b/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2-testing.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2.testing."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.testing</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">1 services, 2 endpoints, 3 messages</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>3</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,46 +61,46 @@ description: "Package-level overview for com.daml.ledger.api.v2.testing."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>3</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -112,116 +112,116 @@ description: "Package-level overview for com.daml.ledger.api.v2.testing."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>2</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-testing/timeservice/gettime">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>TimeService.GetTime</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc TimeService.GetTime(com.daml.ledger.api.v2.testing.GetTimeRequest) returns (com.daml.ledger.api.v2.testing.GetTimeResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.testing.GetTimeResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-testing/timeservice/settime">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>TimeService.SetTime</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc TimeService.SetTime(com.daml.ledger.api.v2.testing.SetTimeRequest) returns (google.protobuf.Empty);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.testing.SetTimeRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>google.protobuf.Empty</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -239,73 +239,73 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.testing.GetTimeRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimeresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.testing.GetTimeResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-settimerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.testing.SetTimeRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">current_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">new_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>

--- a/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2.mdx
+++ b/docs-main/reference/protobuf/packages/com-daml-ledger-api-v2.mdx
@@ -6,50 +6,50 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 <p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
 <div class="x2mdx-ref-hero">
-  
+
   <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
-  
-  
+
+
   <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2</h1>
-  
-  
+
+
   <p class="x2mdx-ref-summary">9 services, 22 endpoints, 120 messages, 8 enums</p>
-  
-  
+
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
 </div>
 
-  
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Files</dt>
     <dd>23</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>9</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Endpoints</dt>
     <dd>22</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>120</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>8</dd>
   </div>
-  
+
 </dl>
 
 </div>
@@ -61,10 +61,10 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto</h3>
 
@@ -92,7 +92,7 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto">community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto">community/daml-lf/ledger-api-value-proto/src/main/protobuf/com/daml/ledger/api/v2/value.proto</a></dd>
   </div>
 
 </dl>
@@ -106,859 +106,859 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>8</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>5</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>10</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>2</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>4</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>13</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>6</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>10</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
-  
+
+
+
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</h3>
-      
+
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Services</dt>
     <dd>1</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Messages</dt>
     <dd>7</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Enums</dt>
     <dd>0</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
   </div>
-  
+
 </dl>
 
-  
+
   </div>
-  
-  
+
+
 </div>
 
 
@@ -970,69 +970,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandCompletionService.CompletionStream</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandCompletionService.CompletionStream(com.daml.ledger.api.v2.CompletionStreamRequest) returns (stream com.daml.ledger.api.v2.CompletionStreamResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.CompletionStreamResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1044,163 +1044,163 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>3</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwait">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandService.SubmitAndWait</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWait(com.daml.ledger.api.v2.SubmitAndWaitRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandService.SubmitAndWaitForReassignment</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWaitForReassignment(com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandService.SubmitAndWaitForTransaction</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWaitForTransaction(com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1212,116 +1212,116 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>2</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandsubmissionservice/submit">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandSubmissionService.Submit</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandSubmissionService.Submit(com.daml.ledger.api.v2.SubmitRequest) returns (com.daml.ledger.api.v2.SubmitResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>CommandSubmissionService.SubmitReassignment</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc CommandSubmissionService.SubmitReassignment(com.daml.ledger.api.v2.SubmitReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitReassignmentResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.SubmitReassignmentResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1333,69 +1333,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/contractservice/getcontract">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>ContractService.GetContract</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.11</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc ContractService.GetContract(com.daml.ledger.api.v2.GetContractRequest) returns (com.daml.ledger.api.v2.GetContractResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetContractRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetContractResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1407,69 +1407,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>EventQueryService.GetEventsByContractId</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc EventQueryService.GetEventsByContractId(com.daml.ledger.api.v2.GetEventsByContractIdRequest) returns (com.daml.ledger.api.v2.GetEventsByContractIdResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetEventsByContractIdResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1481,210 +1481,210 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>4</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/getpackage">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.GetPackage</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.GetPackage(com.daml.ledger.api.v2.GetPackageRequest) returns (com.daml.ledger.api.v2.GetPackageResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetPackageRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetPackageResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/getpackagestatus">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.GetPackageStatus</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.GetPackageStatus(com.daml.ledger.api.v2.GetPackageStatusRequest) returns (com.daml.ledger.api.v2.GetPackageStatusResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetPackageStatusResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/listpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.ListPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.ListPackages(com.daml.ledger.api.v2.ListPackagesRequest) returns (com.daml.ledger.api.v2.ListPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.ListPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/listvettedpackages">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>PackageService.ListVettedPackages</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc PackageService.ListVettedPackages(com.daml.ledger.api.v2.ListVettedPackagesRequest) returns (com.daml.ledger.api.v2.ListVettedPackagesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.ListVettedPackagesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1696,70 +1696,70 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>5</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getactivecontracts">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetActiveContracts</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetActiveContracts(com.daml.ledger.api.v2.GetActiveContractsRequest) returns (stream com.daml.ledger.api.v2.GetActiveContractsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetActiveContractsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getactivecontractspage">
 
     <div class="x2mdx-ref-card-head">
@@ -1808,145 +1808,145 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetConnectedSynchronizers</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetConnectedSynchronizers(com.daml.ledger.api.v2.GetConnectedSynchronizersRequest) returns (com.daml.ledger.api.v2.GetConnectedSynchronizersResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetLatestPrunedOffsets</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetLatestPrunedOffsets(com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest) returns (com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getledgerend">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>StateService.GetLedgerEnd</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc StateService.GetLedgerEnd(com.daml.ledger.api.v2.GetLedgerEndRequest) returns (com.daml.ledger.api.v2.GetLedgerEndResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerEndResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -1958,163 +1958,163 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>4</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatebyid">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UpdateService.GetUpdateById</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdateById(com.daml.ledger.api.v2.GetUpdateByIdRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByIdRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UpdateService.GetUpdateByOffset</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdateByOffset(com.daml.ledger.api.v2.GetUpdateByOffsetRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
-  
+
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdates">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>UpdateService.GetUpdates</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdates(com.daml.ledger.api.v2.GetUpdatesRequest) returns (stream com.daml.ledger.api.v2.GetUpdatesResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetUpdatesResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>Yes</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatespage">
 
@@ -2173,69 +2173,69 @@ description: "Package-level overview for com.daml.ledger.api.v2."
 
 
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Source file</dt>
-    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.1/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.5.5/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Operations</dt>
     <dd>1</dd>
   </div>
-  
+
 </dl>
 
 
 <div class="x2mdx-ref-card-grid">
-  
-  
+
+
   <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion">
-  
+
     <div class="x2mdx-ref-card-head">
       <h3>VersionService.GetLedgerApiVersion</h3>
-      
+
 <div class="x2mdx-ref-badges">
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
-  
+
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.0</span>
-  
+
 </div>
 
     </div>
-    
+
     <p class="x2mdx-ref-card-summary">rpc VersionService.GetLedgerApiVersion(com.daml.ledger.api.v2.GetLedgerApiVersionRequest) returns (com.daml.ledger.api.v2.GetLedgerApiVersionResponse);</p>
-    
-    
+
+
 <dl class="x2mdx-ref-meta-grid">
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Request</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Response</dt>
     <dd>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Client stream</dt>
     <dd>No</dd>
   </div>
-  
+
   <div class="x2mdx-ref-meta-item">
     <dt>Server stream</dt>
     <dd>No</dd>
   </div>
-  
+
 </dl>
 
-  
+
   </a>
-  
-  
+
+
 </div>
 
 
@@ -2253,103 +2253,103 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-activecontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ActiveContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreatedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key_hash</code>
@@ -2363,664 +2363,664 @@ These are the package-level message and enum shapes in the publish-version snaps
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_views</code>
       <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signatories</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">observers</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">representative_package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Identifier</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">module_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entity_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Value</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unit</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">bool</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">int64</code>
       <span class="x2mdx-ref-type-badge">sint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">date</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">timestamp</code>
       <span class="x2mdx-ref-type-badge">sfixed64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">numeric</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">optional</code>
       <span class="x2mdx-ref-type-badge">Optional</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">list</code>
       <span class="x2mdx-ref-type-badge">List</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">text_map</code>
       <span class="x2mdx-ref-type-badge">TextMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">gen_map</code>
       <span class="x2mdx-ref-type-badge">GenMap</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant</code>
       <span class="x2mdx-ref-type-badge">Variant</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum</code>
       <span class="x2mdx-ref-type-badge">Enum</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Optional</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.List</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">elements</code>
       <span class="x2mdx-ref-type-badge">repeated Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">entries</code>
       <span class="x2mdx-ref-type-badge">repeated Entry</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Record</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">fields</code>
       <span class="x2mdx-ref-type-badge">repeated RecordField</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.RecordField</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">label</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Variant</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">variant_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">value</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Enum</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">enum_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">constructor</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceView</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">view_value</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implementation_package_id</code>
@@ -3032,633 +3032,633 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archived">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Archived</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived_event</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ArchivedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">7 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.AssignCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.AssignedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Command</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create</code>
       <span class="x2mdx-ref-type-badge">CreateCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise</code>
       <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_by_key</code>
       <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_and_exercise</code>
       <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">create_arguments</code>
       <span class="x2mdx-ref-type-badge">Record</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Commands</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">16 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated Command</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">read_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">disclosed_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
       <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">taps_max_passes</code>
@@ -3670,92 +3670,92 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.DisclosedContract</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PrefetchContractKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_key</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">limit</code>
@@ -3767,120 +3767,120 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Completion</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">12 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">status</code>
       <span class="x2mdx-ref-type-badge">Status</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">act_as</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">deduplication_duration</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_time</code>
       <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -3892,970 +3892,970 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TraceContext</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">traceparent</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">tracestate</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SynchronizerTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CompletionStreamRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CompletionStreamResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion</code>
       <span class="x2mdx-ref-type-badge">Completion</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.OffsetCheckpoint</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_times</code>
       <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-created">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Created</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CumulativeFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">wildcard_filter</code>
       <span class="x2mdx-ref-type-badge">WildcardFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_filter</code>
       <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_filter</code>
       <span class="x2mdx-ref-type-badge">TemplateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.WildcardFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.InterfaceFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_interface_view</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TemplateFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_created_event_blob</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Event</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercised</code>
       <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExercisedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">15 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">interface_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">choice_argument</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acting_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">consuming</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">exercise_result</code>
       <span class="x2mdx-ref-type-badge">Value</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">implemented_interfaces</code>
       <span class="x2mdx-ref-type-badge">repeated Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">acs_delta</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.EventFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_by_party</code>
       <span class="x2mdx-ref-type-badge">repeated map</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">filters_for_any_party</code>
       <span class="x2mdx-ref-type-badge">Filters</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">verbose</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Filters</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">cumulative</code>
       <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalcommandinspectionservice">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalCommandInspectionService</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalfeatures">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalFeatures</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">static_time</code>
       <span class="x2mdx-ref-type-badge">ExperimentalStaticTime</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_inspection_service</code>
       <span class="x2mdx-ref-type-badge">ExperimentalCommandInspectionService</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalstatictime">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalStaticTime</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalpartytopologyevents">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ExperimentalPartyTopologyEvents</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-featuresdescriptor">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.FeaturesDescriptor</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">experimental</code>
       <span class="x2mdx-ref-type-badge">ExperimentalFeatures</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_management</code>
       <span class="x2mdx-ref-type-badge">UserManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_management</code>
       <span class="x2mdx-ref-type-badge">PartyManagementFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpointFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_feature</code>
       <span class="x2mdx-ref-type-badge">PackageFeature</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-usermanagementfeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UserManagementFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">supported</code>
       <span class="x2mdx-ref-type-badge">bool</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_rights_per_user</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_users_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-partymanagementfeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PartyManagementFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_parties_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpointfeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.OffsetCheckpointFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_offset_checkpoint_emission_delay</code>
       <span class="x2mdx-ref-type-badge">Duration</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagefeature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageFeature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_vetted_packages_page_size</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractspagerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetActiveContractsPageRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">max_page_size</code>
@@ -4876,48 +4876,48 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractspageresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetActiveContractsPageResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_contracts</code>
       <span class="x2mdx-ref-type-badge">repeated GetActiveContractsResponse</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">active_at_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
 
@@ -4979,197 +4979,197 @@ These are the package-level message and enum shapes in the publish-version snaps
     </div>
 
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteunassigned">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.IncompleteUnassigned</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned_event</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UnassignedEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">12 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">template_id</code>
       <span class="x2mdx-ref-type-badge">Identifier</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_counter</code>
       <span class="x2mdx-ref-type-badge">uint64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">witness_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">node_id</code>
       <span class="x2mdx-ref-type-badge">int32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteassigned">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.IncompleteAssigned</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned_event</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsrequest">
@@ -5219,939 +5219,939 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">identity_provider_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">connected_synchronizers</code>
       <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_alias</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantPermission</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
-    
+
     <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetContractRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">querying_parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetContractResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created_event</code>
       <span class="x2mdx-ref-type-badge">CreatedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetEventsByContractIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetEventsByContractIdResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">created</code>
       <span class="x2mdx-ref-type-badge">Created</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archived</code>
       <span class="x2mdx-ref-type-badge">Archived</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">features</code>
       <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerEndRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetLedgerEndResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagerequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackageresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash_function</code>
       <span class="x2mdx-ref-type-badge">HashFunction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">archive_payload</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">hash</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-hashfunction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.HashFunction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>HASH_FUNCTION_SHA256</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageStatusRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetPackageStatusResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_status</code>
       <span class="x2mdx-ref-type-badge">PackageStatus</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagestatus">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageStatus</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>PACKAGE_STATUS_UNSPECIFIED</code></li>
-    
+
     <li><code>PACKAGE_STATUS_REGISTERED</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyidrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdateByIdRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UpdateFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_transactions</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_reassignments</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_topology_events</code>
       <span class="x2mdx-ref-type-badge">TopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_shape</code>
       <span class="x2mdx-ref-type-badge">TransactionShape</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TransactionShape</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
-    
+
     <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">parties</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyoffsetrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdateResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Transaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">11 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">effective_at</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated Event</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">external_transaction_hash</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -6163,93 +6163,93 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Reassignment</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">9 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">paid_traffic_cost</code>
@@ -6261,154 +6261,154 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ReassignmentEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassigned</code>
       <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assigned</code>
       <span class="x2mdx-ref-type-badge">AssignedEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyTransaction</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">record_time</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">events</code>
       <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">trace_context</code>
       <span class="x2mdx-ref-type-badge">TraceContext</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyEvent</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_added</code>
       <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_authorization_onboarding</code>
@@ -6420,131 +6420,131 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationChanged</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationRevoked</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ParticipantAuthorizationAdded</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">party_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_permission</code>
       <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationonboarding">
@@ -6718,41 +6718,41 @@ These are the package-level message and enum shapes in the publish-version snaps
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdatesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">begin_exclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">end_inclusive</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_format</code>
       <span class="x2mdx-ref-type-badge">UpdateFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">descending_order</code>
@@ -6764,1062 +6764,1062 @@ These are the package-level message and enum shapes in the publish-version snaps
 
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.GetUpdatesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">offset_checkpoint</code>
       <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_transaction</code>
       <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListVettedPackagesRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_metadata_filter</code>
       <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_state_filter</code>
       <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">page_size</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagemetadatafilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageMetadataFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name_prefixes</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologystatefilter">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.TopologyStateFilter</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_ids</code>
       <span class="x2mdx-ref-type-badge">repeated string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ListVettedPackagesResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">vetted_packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">next_page_token</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackages</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">packages</code>
       <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">participant_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">synchronizer_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">topology_serial</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.VettedPackage</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
       <span class="x2mdx-ref-type-badge">Timestamp</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PackageReference</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_name</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">package_version</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.PriorTopologySerial</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">prior</code>
       <span class="x2mdx-ref-type-badge">uint32</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">no_prior</code>
       <span class="x2mdx-ref-type-badge">Empty</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ReassignmentCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">unassign_command</code>
       <span class="x2mdx-ref-type-badge">UnassignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">assign_command</code>
       <span class="x2mdx-ref-type-badge">AssignCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.UnassignCommand</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">contract_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">source</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">target</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.ReassignmentCommands</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">6 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">workflow_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">user_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">command_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submitter</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">submission_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.Signature</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">SignatureFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signature</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signed_by</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
       <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_RAW</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_DER</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
-    
+
     <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
-    
+
     <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningPublicKey</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">3 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">format</code>
       <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_data</code>
       <span class="x2mdx-ref-type-badge">bytes</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">key_spec</code>
       <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.CryptoKeyFormat</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">4 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
-    
+
     <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SigningKeySpec</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">5 values</p>
-    
+
   </div>
-  
-  
-  
+
+
+
   <ul class="x2mdx-ref-enum-list">
-    
+
     <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
-    
+
     <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
-    
+
   </ul>
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">event_format</code>
       <span class="x2mdx-ref-type-badge">EventFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment</code>
       <span class="x2mdx-ref-type-badge">Reassignment</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction_format</code>
       <span class="x2mdx-ref-type-badge">TransactionFormat</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">transaction</code>
       <span class="x2mdx-ref-type-badge">Transaction</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitAndWaitResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">2 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">update_id</code>
       <span class="x2mdx-ref-type-badge">string</span>
-      
+
     </div>
-    
+
   </div>
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">completion_offset</code>
       <span class="x2mdx-ref-type-badge">int64</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitReassignmentRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">reassignment_commands</code>
       <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitReassignmentResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitrequest">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitRequest</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">1 fields</p>
-    
+
   </div>
-  
-  
+
+
 <div class="x2mdx-ref-fields">
-  
+
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
       <code class="x2mdx-ref-field-name">commands</code>
       <span class="x2mdx-ref-type-badge">Commands</span>
-      
+
     </div>
-    
+
   </div>
-  
+
 </div>
 
-  
-  
+
+
 </div>
 
 <div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitresponse">
   <div class="x2mdx-ref-schema-head">
     <h3>com.daml.ledger.api.v2.SubmitResponse</h3>
-    
+
     <p class="x2mdx-ref-schema-summary">0 fields</p>
-    
+
   </div>
-  
-  
-  
-  
+
+
+
+
 </div>


### PR DESCRIPTION
Regenerates the checked-in Canton protobuf history references from the latest stable Canton protobuf release bundles selected by the existing source config.

Version changes:
- No version values changed.

Validation run by the workflow:
- `npm run generate:canton-protobuf-history`
- `git diff --check`
