### PR TITLE
Update Daml Standard Library reference

### DIFF
--- a/config/x2mdx/daml-standard-library/source-artifacts.json
+++ b/config/x2mdx/daml-standard-library/source-artifacts.json
@@ -1,12 +1,12 @@
 {
   "source": "Published Daml Standard Library docs JSON from local SDK artifacts",
-  "publish_version": "3.4.11",
+  "publish_version": "3.5.1",
   "package_set": "base",
   "sdk_source": "dpm",
   "versions": [
     "3.4.9",
     "3.4.10",
-    "3.4.11"
+    "3.4.11",
+    "3.5.1"
   ]
 }
-

--- a/docs-main/appdev/reference/daml-standard-library/da-action-state.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-action-state.mdx
@@ -79,7 +79,7 @@ Instances:
 
 ### `evalState`
 
-```haskell
+```daml
 evalState : State s a -> s -> a
 ```
 
@@ -89,7 +89,7 @@ Special case of `runState` that does not return the final state.
 
 ### `execState`
 
-```haskell
+```daml
 execState : State s a -> s -> s
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-action.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-action.mdx
@@ -31,7 +31,7 @@ Deprecated since: `-`
 
 ### `when`
 
-```haskell
+```daml
 when : Applicative f => Bool -> f () -> f ()
 ```
 
@@ -50,7 +50,7 @@ is not evaluated at all.
 
 ### `unless`
 
-```haskell
+```daml
 unless : Applicative f => Bool -> f () -> f ()
 ```
 
@@ -64,7 +64,7 @@ is not evaluated at all.
 
 ### `foldrA`
 
-```haskell
+```daml
 foldrA : Action m => (a -> b -> m b) -> b -> [a] -> m b
 ```
 
@@ -76,7 +76,7 @@ over the list arguments.
 
 ### `foldr1A`
 
-```haskell
+```daml
 foldr1A : Action m => (a -> a -> m a) -> [a] -> m a
 ```
 
@@ -87,7 +87,7 @@ with an empty list argument.
 
 ### `foldlA`
 
-```haskell
+```daml
 foldlA : Action m => (b -> a -> m b) -> b -> [a] -> m b
 ```
 
@@ -99,7 +99,7 @@ left-to-right over the list arguments.
 
 ### `foldl1A`
 
-```haskell
+```daml
 foldl1A : Action m => (a -> a -> m a) -> [a] -> m a
 ```
 
@@ -110,7 +110,7 @@ presented with an empty list argument.
 
 ### `filterA`
 
-```haskell
+```daml
 filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
 ```
 
@@ -125,7 +125,7 @@ filterA (fmap (\iou -> iou.currency == "GBP") . fetch) iouCids
 
 ### `replicateA`
 
-```haskell
+```daml
 replicateA : Applicative m => Int -> m a -> m [a]
 ```
 
@@ -136,7 +136,7 @@ results.
 
 ### `replicateA_`
 
-```haskell
+```daml
 replicateA_ : Applicative m => Int -> m a -> m ()
 ```
 
@@ -146,7 +146,7 @@ Like `replicateA`, but discards the result.
 
 ### `>=>`
 
-```haskell
+```daml
 >=> : Action m => (a -> m b) -> (b -> m c) -> a -> m c
 ```
 
@@ -156,7 +156,7 @@ Left-to-right composition of Kleisli arrows.
 
 ### `<=<`
 
-```haskell
+```daml
 <=< : Action m => (b -> m c) -> (a -> m b) -> a -> m c
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-assert.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-assert.mdx
@@ -29,7 +29,7 @@ Deprecated since: `-`
 
 ### `assertEq`
 
-```haskell
+```daml
 assertEq : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 ```
 
@@ -40,7 +40,7 @@ fail with a message.
 
 ### `===`
 
-```haskell
+```daml
 === : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 ```
 
@@ -50,7 +50,7 @@ Infix version of `assertEq`.
 
 ### `assertNotEq`
 
-```haskell
+```daml
 assertNotEq : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 ```
 
@@ -61,7 +61,7 @@ fail with a message.
 
 ### `=/=`
 
-```haskell
+```daml
 =/= : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 ```
 
@@ -71,7 +71,7 @@ Infix version of `assertNotEq`.
 
 ### `assertAfterMsg`
 
-```haskell
+```daml
 assertAfterMsg : (CanAssert m, HasTime m) => Text -> Time -> m ()
 ```
 
@@ -82,7 +82,7 @@ abort with a message.
 
 ### `assertBeforeMsg`
 
-```haskell
+```daml
 assertBeforeMsg : (CanAssert m, HasTime m) => Text -> Time -> m ()
 ```
 
@@ -93,7 +93,7 @@ abort with a message.
 
 ### `assertWithinDeadline`
 
-```haskell
+```daml
 assertWithinDeadline : Text -> Time -> Update ()
 ```
 
@@ -104,7 +104,7 @@ If it's not, abort with a message.
 
 ### `assertDeadlineExceeded`
 
-```haskell
+```daml
 assertDeadlineExceeded : Text -> Time -> Update ()
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-bifunctor.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-bifunctor.mdx
@@ -45,13 +45,13 @@ defining both first and second.
 
 If you supply bimap, you should ensure that:
 
-```haskell-force
+```daml-force
 `bimap identity identity` ≡ `identity`
 ```
 
 If you supply first and second, ensure:
 
-```haskell-force
+```daml-force
 first identity ≡ identity
 second identity ≡ identity
 
@@ -59,13 +59,13 @@ second identity ≡ identity
 
 If you supply both, you should also ensure:
 
-```haskell-force
+```daml-force
 bimap f g ≡ first f . second g
 ```
 
 By parametricity, these will ensure that:
 
-```haskell-force
+```daml-force
 
 bimap  (f . g) (h . i) ≡ bimap f h . bimap g i
 first  (f . g) ≡ first  f . first  g
@@ -77,52 +77,52 @@ Methods:
 
 - `bimap : (a -> b) -> (c -> d) -> p a c -> p b d`
   Map over both arguments at the same time.
-  
-  ```haskell-force
+
+  ```daml-force
   bimap f g ≡ first f . second g
   ```
-  
+
   Examples:
-  
+
   ```
   >>> bimap not (+1) (True, 3)
   (False,4)
-  
+
   >>> bimap not (+1) (Left True)
   Left False
-  
+
   >>> bimap not (+1) (Right 3)
   Right 4
   ```
 - `first : (a -> b) -> p a c -> p b c`
   Map covariantly over the first argument.
-  
-  ```haskell-force
+
+  ```daml-force
   first f ≡ bimap f identity
   ```
-  
+
   Examples:
-  
+
   ```
   >>> first not (True, 3)
   (False,3)
-  
+
   >>> first not (Left True : Either Bool Int)
   Left False
   ```
 - `second : (b -> c) -> p a b -> p a c`
   Map covariantly over the second argument.
-  
-  ```haskell-force
+
+  ```daml-force
   second ≡ bimap identity
   ```
-  
+
   Examples:
-  
+
   ```
   >>> second (+1) (True, 3)
   (True,4)
-  
+
   >>> second (+1) (Right 3 : Either Bool Int)
   Right 4
   ```

--- a/docs-main/appdev/reference/daml-standard-library/da-contractkeys.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-contractkeys.mdx
@@ -1,0 +1,55 @@
+---
+title: "DA.ContractKeys"
+description: "Reference documentation for Daml module DA.ContractKeys."
+---
+
+<span id="module-da-contractkeys-19667"></span>
+
+# DA.ContractKeys
+
+Note: Docs TODO (https://github.com/digital-asset/daml/issues/22673)
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.5.1`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<span id="function-da-internal-template-functions-lookupnbykey-93090"></span>
+
+### `lookupNByKey`
+
+```daml
+lookupNByKey : HasLookupNByKey t k => Int -> k -> Update [(ContractId t, t)]
+```
+
+Look up up to n contracts associated with the passed key. Contracts created
+within a transaction are returned first (in recency order), then disclosed
+contracts, then nonlocal contracts.
+
+You must pass the `t` using an explicit type application. For instance, if
+you want to query 3 contracts of template `Account` given by its key `k`, you
+must call `lookupNByKey @Account 3 k.
+
+<span id="function-da-internal-template-functions-lookupallbykey-2641"></span>
+
+### `lookupAllByKey`
+
+```daml
+lookupAllByKey : HasLookupNByKey t k => k -> Update [(ContractId t, t)]
+```
+
+Shorthand for `lookupNByKey` with n larger than the amount of contracts that
+can exist for a key (1000000), therefore returning all contracts

--- a/docs-main/appdev/reference/daml-standard-library/da-crypto-text.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-crypto-text.mdx
@@ -15,28 +15,17 @@ For example, as used to implement CCTP functionality.
 
 <CardGroup cols={2}>
 <Card title="Lifecycle">
-Alpha (experimental).
+Stable.
 </Card>
 <Card title="Notices">
 Status: `active`
 Introduced in: `3.4.9`
 Removed in: `-`
-Warnings: `2`
+Warnings: `0`
 Deprecations: `0`
 Deprecated since: `-`
 </Card>
 </CardGroup>
-
-<Warning>
-DA.Crypto.Text is an alpha feature. It can change without notice.
-</Warning>
-
-<AccordionGroup>
-<Accordion title="All warnings (2)">
-- DA.Crypto.Text is an alpha feature. It can change without notice.
-- use -Wno-crypto-text-is-alpha in build-options to disable this warning
-</Accordion>
-</AccordionGroup>
 
 ## Data Types
 
@@ -94,7 +83,7 @@ Instances:
 
 ### `isHex`
 
-```haskell
+```daml
 isHex : Text -> Bool
 ```
 
@@ -105,7 +94,7 @@ hex or hexadecimal characters.
 
 ### `sha256`
 
-```haskell
+```daml
 sha256 : BytesHex -> BytesHex
 ```
 
@@ -116,18 +105,29 @@ form. The hex encoding uses lowercase letters.
 
 ### `keccak256`
 
-```haskell
+```daml
 keccak256 : BytesHex -> BytesHex
 ```
 
 Computes the KECCAK256 hash of the UTF8 bytes of the `Text`, and returns it in its hex-encoded
 form. The hex encoding uses lowercase letters.
 
+<span id="function-da-crypto-text-secp256k1withvalidation-31956"></span>
+
+### `secp256k1WithValidation`
+
+```daml
+secp256k1WithValidation : SignatureHex -> BytesHex -> PublicKeyHex -> Bool
+```
+
+Validate the SECP256K1 signature given a hex encoded message and a hex encoded DER formatted public key. Prior to
+signature validation, validate the public key and check it is on the SECP256K1 curve.
+
 <span id="function-da-crypto-text-secp256k1withecdsaonly-56908"></span>
 
 ### `secp256k1WithEcdsaOnly`
 
-```haskell
+```daml
 secp256k1WithEcdsaOnly : SignatureHex -> BytesHex -> PublicKeyHex -> Bool
 ```
 
@@ -137,7 +137,7 @@ Validate the SECP256K1 signature given a hex encoded message and a hex encoded D
 
 ### `secp256k1`
 
-```haskell
+```daml
 secp256k1 : SignatureHex -> BytesHex -> PublicKeyHex -> Bool
 ```
 
@@ -147,7 +147,7 @@ Validate the SECP256K1 signature given a SHA256 hash of a hex encoded message an
 
 ### `numericViaStringToHex`
 
-```haskell
+```daml
 numericViaStringToHex : NumericScale n => Numeric n -> BytesHex
 ```
 
@@ -155,7 +155,7 @@ numericViaStringToHex : NumericScale n => Numeric n -> BytesHex
 
 ### `numericViaStringFromHex`
 
-```haskell
+```daml
 numericViaStringFromHex : NumericScale n => BytesHex -> Optional (Numeric n)
 ```
 
@@ -163,7 +163,7 @@ numericViaStringFromHex : NumericScale n => BytesHex -> Optional (Numeric n)
 
 ### `byteCount`
 
-```haskell
+```daml
 byteCount : BytesHex -> Int
 ```
 
@@ -173,7 +173,7 @@ Number of bytes present in a byte encoded string.
 
 ### `minBytes32Hex`
 
-```haskell
+```daml
 minBytes32Hex : BytesHex
 ```
 
@@ -183,7 +183,7 @@ Minimum Bytes32 hex value
 
 ### `maxBytes32Hex`
 
-```haskell
+```daml
 maxBytes32Hex : BytesHex
 ```
 
@@ -193,7 +193,7 @@ Maximum Bytes32 hex value
 
 ### `isBytes32Hex`
 
-```haskell
+```daml
 isBytes32Hex : BytesHex -> Bool
 ```
 
@@ -203,7 +203,7 @@ Validate that the byte encoded string is Bytes32Hex
 
 ### `minUInt32Hex`
 
-```haskell
+```daml
 minUInt32Hex : BytesHex
 ```
 
@@ -213,7 +213,7 @@ Minimum UInt32 hex value
 
 ### `maxUInt32Hex`
 
-```haskell
+```daml
 maxUInt32Hex : BytesHex
 ```
 
@@ -223,7 +223,7 @@ Maximum UInt32 hex value
 
 ### `isUInt32Hex`
 
-```haskell
+```daml
 isUInt32Hex : BytesHex -> Bool
 ```
 
@@ -233,7 +233,7 @@ Validate that the byte encoded string is UInt32Hex
 
 ### `minUInt64Hex`
 
-```haskell
+```daml
 minUInt64Hex : BytesHex
 ```
 
@@ -243,7 +243,7 @@ Minimum UInt64 hex value
 
 ### `maxUInt64Hex`
 
-```haskell
+```daml
 maxUInt64Hex : BytesHex
 ```
 
@@ -253,7 +253,7 @@ Maximum UInt64 hex value
 
 ### `isUInt64Hex`
 
-```haskell
+```daml
 isUInt64Hex : BytesHex -> Bool
 ```
 
@@ -263,7 +263,7 @@ Validate that the byte encoded string is UInt64Hex
 
 ### `minUInt256Hex`
 
-```haskell
+```daml
 minUInt256Hex : BytesHex
 ```
 
@@ -273,7 +273,7 @@ Minimum UInt256 hex value
 
 ### `maxUInt256Hex`
 
-```haskell
+```daml
 maxUInt256Hex : BytesHex
 ```
 
@@ -283,7 +283,7 @@ Maximum UInt256 hex value
 
 ### `isUInt256Hex`
 
-```haskell
+```daml
 isUInt256Hex : BytesHex -> Bool
 ```
 
@@ -293,7 +293,7 @@ Validate that the byte encoded string is UInt256Hex
 
 ### `packHexBytes`
 
-```haskell
+```daml
 packHexBytes : BytesHex -> Int -> Optional BytesHex
 ```
 
@@ -304,7 +304,7 @@ size, then prefix with 00 byte strings. If the byte string is larger, then trunc
 
 ### `sliceHexBytes`
 
-```haskell
+```daml
 sliceHexBytes : BytesHex -> Int -> Int -> Either Text BytesHex
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-date.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-date.mdx
@@ -54,6 +54,7 @@ Constructors:
 
 Instances:
 
+- `instance Serializable DayOfWeek`
 - `instance Eq DayOfWeek`
 - `instance Ord DayOfWeek`
 - `instance Bounded DayOfWeek`
@@ -98,6 +99,7 @@ Constructors:
 
 Instances:
 
+- `instance Serializable Month`
 - `instance Eq Month`
 - `instance Ord Month`
 - `instance Bounded Month`
@@ -110,7 +112,7 @@ Instances:
 
 ### `addDays`
 
-```haskell
+```daml
 addDays : Date -> Int -> Date
 ```
 
@@ -120,7 +122,7 @@ Add the given number of days to a date.
 
 ### `subtractDays`
 
-```haskell
+```daml
 subtractDays : Date -> Int -> Date
 ```
 
@@ -132,7 +134,7 @@ Subtract the given number of days from a date.
 
 ### `subDate`
 
-```haskell
+```daml
 subDate : Date -> Date -> Int
 ```
 
@@ -142,7 +144,7 @@ Returns the number of days between the two given dates.
 
 ### `dayOfWeek`
 
-```haskell
+```daml
 dayOfWeek : Date -> DayOfWeek
 ```
 
@@ -152,7 +154,7 @@ Returns the day of week for the given date.
 
 ### `fromGregorian`
 
-```haskell
+```daml
 fromGregorian : (Int, Month, Int) -> Date
 ```
 
@@ -162,7 +164,7 @@ Constructs a `Date` from the triplet `(year, month, days)`.
 
 ### `toGregorian`
 
-```haskell
+```daml
 toGregorian : Date -> (Int, Month, Int)
 ```
 
@@ -173,7 +175,7 @@ to the Gregorian calendar.
 
 ### `date`
 
-```haskell
+```daml
 date : Int -> Month -> Int -> Date
 ```
 
@@ -185,7 +187,7 @@ Raises an error if `d` is outside the range `1 .. monthDayCount y m`.
 
 ### `isLeapYear`
 
-```haskell
+```daml
 isLeapYear : Int -> Bool
 ```
 
@@ -195,7 +197,7 @@ Returns `True` if the given year is a leap year.
 
 ### `fromMonth`
 
-```haskell
+```daml
 fromMonth : Month -> Int
 ```
 
@@ -206,7 +208,7 @@ to `1`, `Feb` corresponds to `2`, and so on.
 
 ### `monthDayCount`
 
-```haskell
+```daml
 monthDayCount : Int -> Month -> Int
 ```
 
@@ -218,7 +220,7 @@ moves from Julian to Gregorian calendar), but does count leap years.
 
 ### `datetime`
 
-```haskell
+```daml
 datetime : Int -> Month -> Int -> Int -> Int -> Int -> Time
 ```
 
@@ -228,7 +230,7 @@ Constructs an instant using `year`, `month`, `day`, `hours`, `minutes`, `seconds
 
 ### `toDateUTC`
 
-```haskell
+```daml
 toDateUTC : Time -> Date
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-either.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-either.mdx
@@ -39,7 +39,7 @@ Deprecated since: `-`
 
 ### `lefts`
 
-```haskell
+```daml
 lefts : [Either a b] -> [a]
 ```
 
@@ -49,7 +49,7 @@ Extracts all the `Left` elements from a list.
 
 ### `rights`
 
-```haskell
+```daml
 rights : [Either a b] -> [b]
 ```
 
@@ -59,7 +59,7 @@ Extracts all the `Right` elements from a list.
 
 ### `partitionEithers`
 
-```haskell
+```daml
 partitionEithers : [Either a b] -> ([a], [b])
 ```
 
@@ -70,7 +70,7 @@ Partitions a list of `Either` into two lists, the `Left` and
 
 ### `isLeft`
 
-```haskell
+```daml
 isLeft : Either a b -> Bool
 ```
 
@@ -81,7 +81,7 @@ otherwise.
 
 ### `isRight`
 
-```haskell
+```daml
 isRight : Either a b -> Bool
 ```
 
@@ -92,7 +92,7 @@ otherwise.
 
 ### `fromLeft`
 
-```haskell
+```daml
 fromLeft : a -> Either a b -> a
 ```
 
@@ -103,7 +103,7 @@ in case of a `Right`-value.
 
 ### `fromRight`
 
-```haskell
+```daml
 fromRight : b -> Either a b -> b
 ```
 
@@ -114,7 +114,7 @@ in case of a `Left`-value.
 
 ### `optionalToEither`
 
-```haskell
+```daml
 optionalToEither : a -> Optional b -> Either a b
 ```
 
@@ -125,7 +125,7 @@ parameter as the `Left` value if the `Optional` is `None`.
 
 ### `eitherToOptional`
 
-```haskell
+```daml
 eitherToOptional : Either a b -> Optional b
 ```
 
@@ -136,7 +136,7 @@ Convert an `Either` value to a `Optional`, dropping any value in
 
 ### `maybeToEither`
 
-```haskell
+```daml
 maybeToEither : a -> Optional b -> Either a b
 ```
 
@@ -144,6 +144,6 @@ maybeToEither : a -> Optional b -> Either a b
 
 ### `eitherToMaybe`
 
-```haskell
+```daml
 eitherToMaybe : Either a b -> Optional b
 ```

--- a/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
+here: https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
+See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate
 for more information.
 <span id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></span>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,13 +57,14 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
+See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory
 for more information.
 
 Instances:
 
 - `instance GetField category FailureStatus FailureCategory`
 - `instance SetField category FailureStatus FailureCategory`
+- `instance Serializable FailureCategory`
 - `instance Eq FailureCategory`
 - `instance Ord FailureCategory`
 - `instance Show FailureCategory`
@@ -93,6 +94,7 @@ Instances:
 - `instance SetField errorId FailureStatus Text`
 - `instance SetField message FailureStatus Text`
 - `instance SetField meta FailureStatus (TextMap Text)`
+- `instance Serializable FailureStatus`
 - `instance Eq FailureStatus`
 - `instance Ord FailureStatus`
 - `instance Show FailureStatus`
@@ -118,7 +120,7 @@ Instances:
 
 ### `invalidArgument`
 
-```haskell
+```daml
 invalidArgument : FailureCategory
 ```
 
@@ -128,7 +130,7 @@ Alternative name for `InvalidIndependentOfSystemState`.
 
 ### `failedPrecondition`
 
-```haskell
+```daml
 failedPrecondition : FailureCategory
 ```
 
@@ -138,7 +140,7 @@ Alternative name for `InvalidGivenCurrentSystemStateOther`.
 
 ### `failWithStatusPure`
 
-```haskell
+```daml
 failWithStatusPure : FailureStatus -> a
 ```
 
@@ -177,5 +179,3 @@ Fail with a failure status in a pure context
 - `instance ActionFail Update`
 
 - `instance CanAbort Update`
-
-{/* Mintlify preview rebuild marker. */}

--- a/docs-main/appdev/reference/daml-standard-library/da-foldable.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-foldable.mdx
@@ -92,7 +92,7 @@ Instances:
 
 ### `mapA_`
 
-```haskell
+```daml
 mapA_ : (Foldable t, Applicative f) => (a -> f b) -> t a -> f ()
 ```
 
@@ -104,7 +104,7 @@ that doesn't ignore the results see 'DA.Traversable.mapA'.
 
 ### `forA_`
 
-```haskell
+```daml
 forA_ : (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
 ```
 
@@ -115,7 +115,7 @@ that doesn't ignore the results see 'DA.Traversable.forA'.
 
 ### `forM_`
 
-```haskell
+```daml
 forM_ : (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
 ```
 
@@ -123,7 +123,7 @@ forM_ : (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
 
 ### `sequence_`
 
-```haskell
+```daml
 sequence_ : (Foldable t, Action m) => t (m a) -> m ()
 ```
 
@@ -135,7 +135,7 @@ results see 'DA.Traversable.sequence'.
 
 ### `concat`
 
-```haskell
+```daml
 concat : Foldable t => t [a] -> [a]
 ```
 
@@ -145,7 +145,7 @@ The concatenation of all the elements of a container of lists.
 
 ### `and`
 
-```haskell
+```daml
 and : Foldable t => t Bool -> Bool
 ```
 
@@ -155,7 +155,7 @@ and : Foldable t => t Bool -> Bool
 
 ### `or`
 
-```haskell
+```daml
 or : Foldable t => t Bool -> Bool
 ```
 
@@ -165,7 +165,7 @@ or : Foldable t => t Bool -> Bool
 
 ### `any`
 
-```haskell
+```daml
 any : Foldable t => (a -> Bool) -> t a -> Bool
 ```
 
@@ -175,7 +175,7 @@ Determines whether any element of the structure satisfies the predicate.
 
 ### `all`
 
-```haskell
+```daml
 all : Foldable t => (a -> Bool) -> t a -> Bool
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-functor.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-functor.mdx
@@ -31,7 +31,7 @@ Deprecated since: `-`
 
 ### `$>`
 
-```haskell
+```daml
 $> : Functor f => f a -> b -> f b
 ```
 
@@ -42,7 +42,7 @@ value (on the right).
 
 ### `<&>`
 
-```haskell
+```daml
 <&> : Functor f => f a -> (a -> b) -> f b
 ```
 
@@ -54,7 +54,7 @@ arguments are in reverse order.
 
 ### `<$$>`
 
-```haskell
+```daml
 <$$> : (Functor f, Functor g) => (a -> b) -> g (f a) -> g (f b)
 ```
 
@@ -64,7 +64,7 @@ Nested `<$>`.
 
 ### `void`
 
-```haskell
+```daml
 void : Functor f => f a -> f ()
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-internal-interface-anyview.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-internal-interface-anyview.mdx
@@ -35,7 +35,7 @@ Deprecated since: `-`
 
 ### `fromAnyView`
 
-```haskell
+```daml
 fromAnyView : (HasTemplateTypeRep i, HasFromAnyView i v) => AnyView -> Optional v
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-list-builtinorder.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-list-builtinorder.mdx
@@ -51,7 +51,7 @@ Deprecated since: `-`
 
 ### `dedup`
 
-```haskell
+```daml
 dedup : Ord a => [a] -> [a]
 ```
 
@@ -71,7 +71,7 @@ stability, consider using `dedupSort` which is more efficient.
 
 ### `dedupOn`
 
-```haskell
+```daml
 dedupOn : Ord k => (v -> k) -> [v] -> [v]
 ```
 
@@ -91,7 +91,7 @@ stability, consider using `dedupOnSort` which is more efficient.
 
 ### `dedupSort`
 
-```haskell
+```daml
 dedupSort : Ord a => [a] -> [a]
 ```
 
@@ -109,7 +109,7 @@ ordering.
 
 ### `dedupOnSort`
 
-```haskell
+```daml
 dedupOnSort : Ord k => (v -> k) -> [v] -> [v]
 ```
 
@@ -128,7 +128,7 @@ For duplicates, the first element in the list will be included in the output.
 
 ### `sort`
 
-```haskell
+```daml
 sort : Ord a => [a] -> [a]
 ```
 
@@ -146,7 +146,7 @@ are indistinguishable so stability is not relevant here.
 
 ### `sortOn`
 
-```haskell
+```daml
 sortOn : Ord b => (a -> b) -> [a] -> [a]
 ```
 
@@ -165,7 +165,7 @@ will be ordered by their position in the input.
 
 ### `unique`
 
-```haskell
+```daml
 unique : Ord a => [a] -> Bool
 ```
 
@@ -180,7 +180,7 @@ True
 
 ### `uniqueOn`
 
-```haskell
+```daml
 uniqueOn : Ord k => (a -> k) -> [a] -> Bool
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-list-total.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-list-total.mdx
@@ -29,7 +29,7 @@ Deprecated since: `-`
 
 ### `head`
 
-```haskell
+```daml
 head : [a] -> Optional a
 ```
 
@@ -39,7 +39,7 @@ Return the first element of a list. Return `None` if list is empty.
 
 ### `tail`
 
-```haskell
+```daml
 tail : [a] -> Optional [a]
 ```
 
@@ -49,7 +49,7 @@ Return all but the first element of a list. Return `None` if list is empty.
 
 ### `last`
 
-```haskell
+```daml
 last : [a] -> Optional a
 ```
 
@@ -59,7 +59,7 @@ Extract the last element of a list. Returns `None` if list is empty.
 
 ### `init`
 
-```haskell
+```daml
 init : [a] -> Optional [a]
 ```
 
@@ -69,7 +69,7 @@ Return all the elements of a list except the last one. Returns `None` if list is
 
 ### `!!`
 
-```haskell
+```daml
 !! : [a] -> Int -> Optional a
 ```
 
@@ -79,7 +79,7 @@ Return the nth element of a list. Return `None` if index is out of bounds.
 
 ### `foldl1`
 
-```haskell
+```daml
 foldl1 : (a -> a -> a) -> [a] -> Optional a
 ```
 
@@ -91,7 +91,7 @@ Return `None` if list is empty.
 
 ### `foldr1`
 
-```haskell
+```daml
 foldr1 : (a -> a -> a) -> [a] -> Optional a
 ```
 
@@ -102,7 +102,7 @@ For example, `foldr1 f [a,b,c] = f a (f b c)`
 
 ### `foldBalanced1`
 
-```haskell
+```daml
 foldBalanced1 : (a -> a -> a) -> [a] -> Optional a
 ```
 
@@ -119,7 +119,7 @@ Return `None` if list is empty.
 
 ### `minimumBy`
 
-```haskell
+```daml
 minimumBy : (a -> a -> Ordering) -> [a] -> Optional a
 ```
 
@@ -130,7 +130,7 @@ Return `None` if list  is empty.
 
 ### `maximumBy`
 
-```haskell
+```daml
 maximumBy : (a -> a -> Ordering) -> [a] -> Optional a
 ```
 
@@ -141,7 +141,7 @@ Return `None` if list is empty.
 
 ### `minimumOn`
 
-```haskell
+```daml
 minimumOn : Ord k => (a -> k) -> [a] -> Optional a
 ```
 
@@ -153,7 +153,7 @@ Return `None` if list is empty.
 
 ### `maximumOn`
 
-```haskell
+```daml
 maximumOn : Ord k => (a -> k) -> [a] -> Optional a
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-list.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-list.mdx
@@ -31,7 +31,7 @@ Deprecated since: `-`
 
 ### `sort`
 
-```haskell
+```daml
 sort : Ord a => [a] -> [a]
 ```
 
@@ -46,7 +46,7 @@ the order they appeared in the input (a stable sort).
 
 ### `sortBy`
 
-```haskell
+```daml
 sortBy : (a -> a -> Ordering) -> [a] -> [a]
 ```
 
@@ -56,7 +56,7 @@ The `sortBy` function is the non-overloaded version of `sort`.
 
 ### `minimumBy`
 
-```haskell
+```daml
 minimumBy : (a -> a -> Ordering) -> [a] -> a
 ```
 
@@ -67,7 +67,7 @@ is either `LT` or `EQ` for all other `y` in `xs`. `xs` must be non-empty.
 
 ### `maximumBy`
 
-```haskell
+```daml
 maximumBy : (a -> a -> Ordering) -> [a] -> a
 ```
 
@@ -78,7 +78,7 @@ is either `GT` or `EQ` for all other `y` in `xs`. `xs` must be non-empty.
 
 ### `sortOn`
 
-```haskell
+```daml
 sortOn : Ord k => (a -> k) -> [a] -> [a]
 ```
 
@@ -95,7 +95,7 @@ duplicates in the order they appeared in the input.
 
 ### `minimumOn`
 
-```haskell
+```daml
 minimumOn : Ord k => (a -> k) -> [a] -> a
 ```
 
@@ -107,7 +107,7 @@ non-empty.
 
 ### `maximumOn`
 
-```haskell
+```daml
 maximumOn : Ord k => (a -> k) -> [a] -> a
 ```
 
@@ -119,7 +119,7 @@ non-empty.
 
 ### `mergeBy`
 
-```haskell
+```daml
 mergeBy : (a -> a -> Ordering) -> [a] -> [a] -> [a]
 ```
 
@@ -130,7 +130,7 @@ the programmer to specify the comparison function.
 
 ### `combinePairs`
 
-```haskell
+```daml
 combinePairs : (a -> a -> a) -> [a] -> [a]
 ```
 
@@ -141,7 +141,7 @@ function from two list inputs into a single list.
 
 ### `foldBalanced1`
 
-```haskell
+```daml
 foldBalanced1 : (a -> a -> a) -> [a] -> a
 ```
 
@@ -156,7 +156,7 @@ same result as `foldl1` or `foldr1`.
 
 ### `group`
 
-```haskell
+```daml
 group : Eq a => [a] -> [[a]]
 ```
 
@@ -167,7 +167,7 @@ that the concatenation of the result is equal to the argument.
 
 ### `groupBy`
 
-```haskell
+```daml
 groupBy : (a -> a -> Bool) -> [a] -> [[a]]
 ```
 
@@ -177,7 +177,7 @@ The 'groupBy' function is the non-overloaded version of 'group'.
 
 ### `groupOn`
 
-```haskell
+```daml
 groupOn : Eq k => (a -> k) -> [a] -> [[a]]
 ```
 
@@ -188,7 +188,7 @@ extracted value.
 
 ### `dedup`
 
-```haskell
+```daml
 dedup : Ord a => [a] -> [a]
 ```
 
@@ -202,7 +202,7 @@ their own equality test.
 
 ### `dedupBy`
 
-```haskell
+```daml
 dedupBy : (a -> a -> Ordering) -> [a] -> [a]
 ```
 
@@ -212,7 +212,7 @@ A version of `dedup` with a custom predicate.
 
 ### `dedupOn`
 
-```haskell
+```daml
 dedupOn : Ord k => (a -> k) -> [a] -> [a]
 ```
 
@@ -223,7 +223,7 @@ after applyng function. Example use: `dedupOn (.employeeNo) employees`
 
 ### `dedupSort`
 
-```haskell
+```daml
 dedupSort : Ord a => [a] -> [a]
 ```
 
@@ -235,7 +235,7 @@ element.
 
 ### `dedupSortBy`
 
-```haskell
+```daml
 dedupSortBy : (a -> a -> Ordering) -> [a] -> [a]
 ```
 
@@ -245,7 +245,7 @@ A version of `dedupSort` with a custom predicate.
 
 ### `unique`
 
-```haskell
+```daml
 unique : Ord a => [a] -> Bool
 ```
 
@@ -255,7 +255,7 @@ Returns True if and only if there are no duplicate elements in the given list.
 
 ### `uniqueBy`
 
-```haskell
+```daml
 uniqueBy : (a -> a -> Ordering) -> [a] -> Bool
 ```
 
@@ -265,7 +265,7 @@ A version of `unique` with a custom predicate.
 
 ### `uniqueOn`
 
-```haskell
+```daml
 uniqueOn : Ord k => (a -> k) -> [a] -> Bool
 ```
 
@@ -276,7 +276,7 @@ after applyng function. Example use: `assert $ uniqueOn (.employeeNo) employees`
 
 ### `replace`
 
-```haskell
+```daml
 replace : Eq a => [a] -> [a] -> [a] -> [a]
 ```
 
@@ -287,7 +287,7 @@ the search list with the replacement list in the operation list.
 
 ### `dropPrefix`
 
-```haskell
+```daml
 dropPrefix : Eq a => [a] -> [a] -> [a]
 ```
 
@@ -298,7 +298,7 @@ sequence if the sequence doesn't start with the given prefix.
 
 ### `dropSuffix`
 
-```haskell
+```daml
 dropSuffix : Eq a => [a] -> [a] -> [a]
 ```
 
@@ -309,7 +309,7 @@ sequence if the sequence doesn't end with the given suffix.
 
 ### `stripPrefix`
 
-```haskell
+```daml
 stripPrefix : Eq a => [a] -> [a] -> Optional [a]
 ```
 
@@ -321,7 +321,7 @@ given, or `Some` the list after the prefix, if it does.
 
 ### `stripSuffix`
 
-```haskell
+```daml
 stripSuffix : Eq a => [a] -> [a] -> Optional [a]
 ```
 
@@ -332,7 +332,7 @@ entire first list.
 
 ### `stripInfix`
 
-```haskell
+```daml
 stripInfix : Eq a => [a] -> [a] -> Optional ([a], [a])
 ```
 
@@ -351,7 +351,7 @@ None
 
 ### `isPrefixOf`
 
-```haskell
+```daml
 isPrefixOf : Eq a => [a] -> [a] -> Bool
 ```
 
@@ -362,7 +362,7 @@ and only if the first is a prefix of the second.
 
 ### `isSuffixOf`
 
-```haskell
+```daml
 isSuffixOf : Eq a => [a] -> [a] -> Bool
 ```
 
@@ -373,7 +373,7 @@ and only if the first list is a suffix of the second.
 
 ### `isInfixOf`
 
-```haskell
+```daml
 isInfixOf : Eq a => [a] -> [a] -> Bool
 ```
 
@@ -384,7 +384,7 @@ and only if the first list is contained anywhere within the second.
 
 ### `mapAccumL`
 
-```haskell
+```daml
 mapAccumL : (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
 ```
 
@@ -397,7 +397,7 @@ value of this accumulator together with the new list.
 
 ### `mapWithIndex`
 
-```haskell
+```daml
 mapWithIndex : (Int -> a -> b) -> [a] -> [b]
 ```
 
@@ -409,7 +409,7 @@ element in the sequence.
 
 ### `inits`
 
-```haskell
+```daml
 inits : [a] -> [[a]]
 ```
 
@@ -420,7 +420,7 @@ shortest first.
 
 ### `intersperse`
 
-```haskell
+```daml
 intersperse : a -> [a] -> [a]
 ```
 
@@ -431,7 +431,7 @@ The `intersperse` function takes an element and a list and
 
 ### `intercalate`
 
-```haskell
+```daml
 intercalate : [a] -> [[a]] -> [a]
 ```
 
@@ -442,7 +442,7 @@ and concatenates the result.
 
 ### `tails`
 
-```haskell
+```daml
 tails : [a] -> [[a]]
 ```
 
@@ -453,7 +453,7 @@ longest first.
 
 ### `dropWhileEnd`
 
-```haskell
+```daml
 dropWhileEnd : (a -> Bool) -> [a] -> [a]
 ```
 
@@ -463,7 +463,7 @@ A version of `dropWhile` operating from the end.
 
 ### `takeWhileEnd`
 
-```haskell
+```daml
 takeWhileEnd : (a -> Bool) -> [a] -> [a]
 ```
 
@@ -473,7 +473,7 @@ A version of `takeWhile` operating from the end.
 
 ### `transpose`
 
-```haskell
+```daml
 transpose : [[a]] -> [[a]]
 ```
 
@@ -484,7 +484,7 @@ argument.
 
 ### `breakEnd`
 
-```haskell
+```daml
 breakEnd : (a -> Bool) -> [a] -> ([a], [a])
 ```
 
@@ -494,7 +494,7 @@ Break, but from the end.
 
 ### `breakOn`
 
-```haskell
+```daml
 breakOn : Eq a => [a] -> [a] -> ([a], [a])
 ```
 
@@ -508,7 +508,7 @@ before `needle` is matched. The second is the remainder of
 
 ### `breakOnEnd`
 
-```haskell
+```daml
 breakOnEnd : Eq a => [a] -> [a] -> ([a], [a])
 ```
 
@@ -523,7 +523,7 @@ remainder of `haystack`, following the match.
 
 ### `linesBy`
 
-```haskell
+```daml
 linesBy : (a -> Bool) -> [a] -> [[a]]
 ```
 
@@ -534,7 +534,7 @@ is a trailing separator it will be discarded.
 
 ### `wordsBy`
 
-```haskell
+```daml
 wordsBy : (a -> Bool) -> [a] -> [[a]]
 ```
 
@@ -545,7 +545,7 @@ separators are discarded, as are leading or trailing separators.
 
 ### `head`
 
-```haskell
+```daml
 head : [a] -> a
 ```
 
@@ -555,7 +555,7 @@ Extract the first element of a list, which must be non-empty.
 
 ### `tail`
 
-```haskell
+```daml
 tail : [a] -> [a]
 ```
 
@@ -566,7 +566,7 @@ non-empty.
 
 ### `last`
 
-```haskell
+```daml
 last : [a] -> a
 ```
 
@@ -577,7 +577,7 @@ non-empty.
 
 ### `init`
 
-```haskell
+```daml
 init : [a] -> [a]
 ```
 
@@ -588,7 +588,7 @@ must be non-empty.
 
 ### `foldl1`
 
-```haskell
+```daml
 foldl1 : (a -> a -> a) -> [a] -> a
 ```
 
@@ -598,7 +598,7 @@ Left associative fold of a list that must be non-empty.
 
 ### `foldr1`
 
-```haskell
+```daml
 foldr1 : (a -> a -> a) -> [a] -> a
 ```
 
@@ -608,7 +608,7 @@ Right associative fold of a list that must be non-empty.
 
 ### `repeatedly`
 
-```haskell
+```daml
 repeatedly : ([a] -> (b, [a])) -> [a] -> [b]
 ```
 
@@ -619,7 +619,7 @@ and the remainder of the list.
 
 ### `chunksOf`
 
-```haskell
+```daml
 chunksOf : Int -> [a] -> [[a]]
 ```
 
@@ -632,7 +632,7 @@ not divisible by @n@.
 
 ### `delete`
 
-```haskell
+```daml
 delete : Eq a => a -> [a] -> [a]
 ```
 
@@ -651,7 +651,7 @@ supply their own equality test.
 
 ### `deleteBy`
 
-```haskell
+```daml
 deleteBy : (a -> a -> Bool) -> a -> [a] -> [a]
 ```
 
@@ -667,7 +667,7 @@ user-supplied equality predicate.
 
 ### `\\`
 
-```haskell
+```daml
 \\ : Eq a => [a] -> [a] -> [a]
 ```
 
@@ -685,7 +685,7 @@ Note this function is _O(n*m)_ given lists of size _n_ and _m_.
 
 ### `singleton`
 
-```haskell
+```daml
 singleton : a -> [a]
 ```
 
@@ -700,7 +700,7 @@ Produce a singleton list.
 
 ### `!!`
 
-```haskell
+```daml
 !! : [a] -> Int -> a
 ```
 
@@ -714,7 +714,7 @@ unlike in languages such as Java where array indexing is _O(1)_.
 
 ### `elemIndex`
 
-```haskell
+```daml
 elemIndex : Eq a => a -> [a] -> Optional Int
 ```
 
@@ -725,7 +725,7 @@ Will return `None` if not found.
 
 ### `findIndex`
 
-```haskell
+```daml
 findIndex : (a -> Bool) -> [a] -> Optional Int
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-logic.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-logic.mdx
@@ -64,7 +64,7 @@ Instances:
 
 ### `&&&`
 
-```haskell
+```daml
 &&& : Formula t -> Formula t -> Formula t
 ```
 
@@ -75,7 +75,7 @@ be read as "and"
 
 ### `|||`
 
-```haskell
+```daml
 ||| : Formula t -> Formula t -> Formula t
 ```
 
@@ -86,7 +86,7 @@ be read as "or"
 
 ### `true`
 
-```haskell
+```daml
 true : Formula t
 ```
 
@@ -97,7 +97,7 @@ represented as an empty conjunction.
 
 ### `false`
 
-```haskell
+```daml
 false : Formula t
 ```
 
@@ -108,7 +108,7 @@ represented as an empty disjunction.
 
 ### `neg`
 
-```haskell
+```daml
 neg : Formula t -> Formula t
 ```
 
@@ -119,7 +119,7 @@ formulas.
 
 ### `conj`
 
-```haskell
+```daml
 conj : [Formula t] -> Formula t
 ```
 
@@ -130,7 +130,7 @@ of ∧.
 
 ### `disj`
 
-```haskell
+```daml
 disj : [Formula t] -> Formula t
 ```
 
@@ -141,7 +141,7 @@ of ∨.
 
 ### `fromBool`
 
-```haskell
+```daml
 fromBool : Bool -> Formula t
 ```
 
@@ -151,7 +151,7 @@ fromBool : Bool -> Formula t
 
 ### `toNNF`
 
-```haskell
+```daml
 toNNF : Formula t -> Formula t
 ```
 
@@ -162,7 +162,7 @@ toNNF : Formula t -> Formula t
 
 ### `toDNF`
 
-```haskell
+```daml
 toDNF : Formula t -> Formula t
 ```
 
@@ -173,7 +173,7 @@ toDNF : Formula t -> Formula t
 
 ### `traverse`
 
-```haskell
+```daml
 traverse : Applicative f => (t -> f s) -> Formula t -> f (Formula s)
 ```
 
@@ -183,7 +183,7 @@ An implementation of `traverse` in the usual sense.
 
 ### `zipFormulas`
 
-```haskell
+```daml
 zipFormulas : Formula t -> Formula s -> Formula (t, s)
 ```
 
@@ -194,7 +194,7 @@ propositions are different and zips them up.
 
 ### `substitute`
 
-```haskell
+```daml
 substitute : (t -> Optional Bool) -> Formula t -> Formula t
 ```
 
@@ -205,7 +205,7 @@ substitute : (t -> Optional Bool) -> Formula t -> Formula t
 
 ### `reduce`
 
-```haskell
+```daml
 reduce : Formula t -> Formula t
 ```
 
@@ -218,7 +218,7 @@ reduce : Formula t -> Formula t
 
 ### `isBool`
 
-```haskell
+```daml
 isBool : Formula t -> Optional Bool
 ```
 
@@ -230,7 +230,7 @@ Otherwise, it returns `None`.
 
 ### `interpret`
 
-```haskell
+```daml
 interpret : (t -> Optional Bool) -> Formula t -> Either (Formula t) Bool
 ```
 
@@ -241,7 +241,7 @@ a truth function and then reduces as far as possible.
 
 ### `substituteA`
 
-```haskell
+```daml
 substituteA : Applicative f => (t -> f (Optional Bool)) -> Formula t -> f (Formula t)
 ```
 
@@ -252,7 +252,7 @@ values to be obtained from an action.
 
 ### `interpretA`
 
-```haskell
+```daml
 interpretA : Applicative f => (t -> f (Optional Bool)) -> Formula t -> f (Either (Formula t) Bool)
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-map.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-map.mdx
@@ -79,7 +79,7 @@ Deprecated since: `-`
 
 ### `fromList`
 
-```haskell
+```daml
 fromList : Ord k => [(k, v)] -> Map k v
 ```
 
@@ -89,7 +89,7 @@ Create a map from a list of key/value pairs.
 
 ### `fromListWithL`
 
-```haskell
+```daml
 fromListWithL : Ord k => (v -> v -> v) -> [(k, v)] -> Map k v
 ```
 
@@ -111,7 +111,7 @@ True
 
 ### `fromListWithR`
 
-```haskell
+```daml
 fromListWithR : Ord k => (v -> v -> v) -> [(k, v)] -> Map k v
 ```
 
@@ -129,7 +129,7 @@ True
 
 ### `fromListWith`
 
-```haskell
+```daml
 fromListWith : Ord k => (v -> v -> v) -> [(k, v)] -> Map k v
 ```
 
@@ -137,7 +137,7 @@ fromListWith : Ord k => (v -> v -> v) -> [(k, v)] -> Map k v
 
 ### `keys`
 
-```haskell
+```daml
 keys : Map k v -> [k]
 ```
 
@@ -154,7 +154,7 @@ when using `deriving Ord`.
 
 ### `values`
 
-```haskell
+```daml
 values : Map k v -> [v]
 ```
 
@@ -170,7 +170,7 @@ their respective keys from `M.keys`.
 
 ### `toList`
 
-```haskell
+```daml
 toList : Map k v -> [(k, v)]
 ```
 
@@ -181,7 +181,7 @@ by key, as in `M.keys`.
 
 ### `empty`
 
-```haskell
+```daml
 empty : Map k v
 ```
 
@@ -191,7 +191,7 @@ The empty map.
 
 ### `size`
 
-```haskell
+```daml
 size : Map k v -> Int
 ```
 
@@ -201,7 +201,7 @@ Number of elements in the map.
 
 ### `null`
 
-```haskell
+```daml
 null : Map k v -> Bool
 ```
 
@@ -211,7 +211,7 @@ Is the map empty?
 
 ### `lookup`
 
-```haskell
+```daml
 lookup : Ord k => k -> Map k v -> Optional v
 ```
 
@@ -221,7 +221,7 @@ Lookup the value at a key in the map.
 
 ### `member`
 
-```haskell
+```daml
 member : Ord k => k -> Map k v -> Bool
 ```
 
@@ -231,7 +231,7 @@ Is the key a member of the map?
 
 ### `filter`
 
-```haskell
+```daml
 filter : Ord k => (v -> Bool) -> Map k v -> Map k v
 ```
 
@@ -242,7 +242,7 @@ value satisfies the predicate.
 
 ### `filterWithKey`
 
-```haskell
+```daml
 filterWithKey : Ord k => (k -> v -> Bool) -> Map k v -> Map k v
 ```
 
@@ -253,7 +253,7 @@ satisfy the predicate.
 
 ### `delete`
 
-```haskell
+```daml
 delete : Ord k => k -> Map k v -> Map k v
 ```
 
@@ -264,7 +264,7 @@ member of the map, the original map is returned.
 
 ### `singleton`
 
-```haskell
+```daml
 singleton : Ord k => k -> v -> Map k v
 ```
 
@@ -274,7 +274,7 @@ Create a singleton map.
 
 ### `insert`
 
-```haskell
+```daml
 insert : Ord k => k -> v -> Map k v -> Map k v
 ```
 
@@ -286,7 +286,7 @@ supplied value.
 
 ### `insertWith`
 
-```haskell
+```daml
 insertWith : Ord k => (v -> v -> v) -> k -> v -> Map k v -> Map k v
 ```
 
@@ -298,7 +298,7 @@ present in the map, it is combined with the previous value using the given funct
 
 ### `alter`
 
-```haskell
+```daml
 alter : Ord k => (Optional v -> Optional v) -> k -> Map k v -> Map k v
 ```
 
@@ -319,7 +319,7 @@ Some implications of this behavior:
 
 ### `union`
 
-```haskell
+```daml
 union : Ord k => Map k v -> Map k v -> Map k v
 ```
 
@@ -330,7 +330,7 @@ keys are encountered.
 
 ### `unionWith`
 
-```haskell
+```daml
 unionWith : Ord k => (v -> v -> v) -> Map k v -> Map k v -> Map k v
 ```
 
@@ -341,7 +341,7 @@ exist in both maps.
 
 ### `merge`
 
-```haskell
+```daml
 merge : Ord k => (k -> a -> Optional c) -> (k -> b -> Optional c) -> (k -> a -> b -> Optional c) -> Map k a -> Map k b -> Map k c
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-math.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-math.mdx
@@ -39,7 +39,7 @@ Deprecated since: `-`
 
 ### `**`
 
-```haskell
+```daml
 ** : Decimal -> Decimal -> Decimal
 ```
 
@@ -49,7 +49,7 @@ Take a power of a number Example: `2.0 ** 3.0 == 8.0`.
 
 ### `sqrt`
 
-```haskell
+```daml
 sqrt : Decimal -> Decimal
 ```
 
@@ -64,7 +64,7 @@ Calculate the square root of a Decimal.
 
 ### `exp`
 
-```haskell
+```daml
 exp : Decimal -> Decimal
 ```
 
@@ -74,7 +74,7 @@ The exponential function. Example: `exp 0.0 == 1.0`
 
 ### `log`
 
-```haskell
+```daml
 log : Decimal -> Decimal
 ```
 
@@ -84,7 +84,7 @@ The natural logarithm. Example: `log 10.0 == 2.30258509299`
 
 ### `logBase`
 
-```haskell
+```daml
 logBase : Decimal -> Decimal -> Decimal
 ```
 
@@ -94,7 +94,7 @@ The logarithm of a number to a given base. Example: `log 10.0 100.0 == 2.0`
 
 ### `sin`
 
-```haskell
+```daml
 sin : Decimal -> Decimal
 ```
 
@@ -104,7 +104,7 @@ sin : Decimal -> Decimal
 
 ### `cos`
 
-```haskell
+```daml
 cos : Decimal -> Decimal
 ```
 
@@ -114,7 +114,7 @@ cos : Decimal -> Decimal
 
 ### `tan`
 
-```haskell
+```daml
 tan : Decimal -> Decimal
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-nonempty-types.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-nonempty-types.mdx
@@ -58,6 +58,7 @@ Instances:
 - `instance SetField tl (NonEmpty a) [a]`
 - `instance IsParties (NonEmpty Party)`
 - `instance Traversable NonEmpty`
+- `instance Serializable a => Serializable (NonEmpty a)`
 - `instance Functor NonEmpty`
 - `instance Eq a => Eq (NonEmpty a)`
 - `instance Ord a => Ord (NonEmpty a)`

--- a/docs-main/appdev/reference/daml-standard-library/da-nonempty.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-nonempty.mdx
@@ -45,7 +45,7 @@ Deprecated since: `-`
 
 ### `cons`
 
-```haskell
+```daml
 cons : a -> NonEmpty a -> NonEmpty a
 ```
 
@@ -55,7 +55,7 @@ Prepend an element to a non-empty list.
 
 ### `append`
 
-```haskell
+```daml
 append : NonEmpty a -> NonEmpty a -> NonEmpty a
 ```
 
@@ -65,7 +65,7 @@ Append or concatenate two non-empty lists.
 
 ### `map`
 
-```haskell
+```daml
 map : (a -> b) -> NonEmpty a -> NonEmpty b
 ```
 
@@ -75,7 +75,7 @@ Apply a function over each element in the non-empty list.
 
 ### `nonEmpty`
 
-```haskell
+```daml
 nonEmpty : [a] -> Optional (NonEmpty a)
 ```
 
@@ -86,7 +86,7 @@ Turn a list into a non-empty list, if possible. Returns
 
 ### `singleton`
 
-```haskell
+```daml
 singleton : a -> NonEmpty a
 ```
 
@@ -96,7 +96,7 @@ A non-empty list with a single element.
 
 ### `toList`
 
-```haskell
+```daml
 toList : NonEmpty a -> [a]
 ```
 
@@ -106,7 +106,7 @@ Turn a non-empty list into a list (by forgetting that it is not empty).
 
 ### `reverse`
 
-```haskell
+```daml
 reverse : NonEmpty a -> NonEmpty a
 ```
 
@@ -116,7 +116,7 @@ Reverse a non-empty list.
 
 ### `find`
 
-```haskell
+```daml
 find : (a -> Bool) -> NonEmpty a -> Optional a
 ```
 
@@ -126,7 +126,7 @@ Find an element in a non-empty list.
 
 ### `deleteBy`
 
-```haskell
+```daml
 deleteBy : (a -> a -> Bool) -> a -> NonEmpty a -> [a]
 ```
 
@@ -137,7 +137,7 @@ user-supplied equality predicate.
 
 ### `delete`
 
-```haskell
+```daml
 delete : Eq a => a -> NonEmpty a -> [a]
 ```
 
@@ -148,7 +148,7 @@ removing all elements.
 
 ### `foldl1`
 
-```haskell
+```daml
 foldl1 : (a -> a -> a) -> NonEmpty a -> a
 ```
 
@@ -159,7 +159,7 @@ from the left. For example, `foldl1 (+) (NonEmpty 1 [2,3,4]) = ((1 + 2) + 3) + 4
 
 ### `foldr1`
 
-```haskell
+```daml
 foldr1 : (a -> a -> a) -> NonEmpty a -> a
 ```
 
@@ -170,7 +170,7 @@ from the right. For example, `foldr1 (+) (NonEmpty 1 [2,3,4]) = 1 + (2 + (3 + 4)
 
 ### `foldr`
 
-```haskell
+```daml
 foldr : (a -> b -> b) -> b -> NonEmpty a -> b
 ```
 
@@ -182,7 +182,7 @@ from the right, with a given initial value. For example,
 
 ### `foldrA`
 
-```haskell
+```daml
 foldrA : Action m => (a -> b -> m b) -> b -> NonEmpty a -> m b
 ```
 
@@ -192,7 +192,7 @@ The same as `foldr` but running an action each time.
 
 ### `foldr1A`
 
-```haskell
+```daml
 foldr1A : Action m => (a -> a -> m a) -> NonEmpty a -> m a
 ```
 
@@ -202,7 +202,7 @@ The same as `foldr1` but running an action each time.
 
 ### `foldl`
 
-```haskell
+```daml
 foldl : (b -> a -> b) -> b -> NonEmpty a -> b
 ```
 
@@ -214,7 +214,7 @@ from the left, with a given initial value. For example,
 
 ### `foldlA`
 
-```haskell
+```daml
 foldlA : Action m => (b -> a -> m b) -> b -> NonEmpty a -> m b
 ```
 
@@ -224,7 +224,7 @@ The same as `foldl` but running an action each time.
 
 ### `foldl1A`
 
-```haskell
+```daml
 foldl1A : Action m => (a -> a -> m a) -> NonEmpty a -> m a
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-numeric.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-numeric.mdx
@@ -68,7 +68,7 @@ be represented without rounding at the targeted scale.
 
 ### `mul`
 
-```haskell
+```daml
 mul : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
 ```
 
@@ -81,7 +81,7 @@ scale otherwise.
 
 ### `div`
 
-```haskell
+```daml
 div : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
 ```
 
@@ -94,7 +94,7 @@ scale otherwise.
 
 ### `cast`
 
-```haskell
+```daml
 cast : NumericScale n2 => Numeric n1 -> Numeric n2
 ```
 
@@ -104,7 +104,7 @@ Cast a Numeric. Raises an error on overflow or loss of precision.
 
 ### `castAndRound`
 
-```haskell
+```daml
 castAndRound : NumericScale n2 => Numeric n1 -> Numeric n2
 ```
 
@@ -115,7 +115,7 @@ scale otherwise.
 
 ### `shift`
 
-```haskell
+```daml
 shift : NumericScale n2 => Numeric n1 -> Numeric n2
 ```
 
@@ -126,7 +126,7 @@ value by 10^(n1 - n2). Does not overflow or underflow.
 
 ### `pi`
 
-```haskell
+```daml
 pi : NumericScale n => Numeric n
 ```
 
@@ -136,7 +136,7 @@ The number pi.
 
 ### `epsilon`
 
-```haskell
+```daml
 epsilon : NumericScale n => Numeric n
 ```
 
@@ -146,7 +146,7 @@ The minimum strictly positive value that can be represented by a numeric of scal
 
 ### `roundNumeric`
 
-```haskell
+```daml
 roundNumeric : NumericScale n => Int -> RoundingMode -> Numeric n -> Numeric n
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-optional.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-optional.mdx
@@ -45,7 +45,7 @@ Deprecated since: `-`
 
 ### `fromSome`
 
-```haskell
+```daml
 fromSome : Optional a -> a
 ```
 
@@ -59,7 +59,7 @@ to get a better error on failures.
 
 ### `fromSomeNote`
 
-```haskell
+```daml
 fromSomeNote : Text -> Optional a -> a
 ```
 
@@ -69,7 +69,7 @@ Like `fromSome` but with a custom error message.
 
 ### `catOptionals`
 
-```haskell
+```daml
 catOptionals : [Optional a] -> [a]
 ```
 
@@ -80,7 +80,7 @@ list of all the `Some` values.
 
 ### `listToOptional`
 
-```haskell
+```daml
 listToOptional : [a] -> Optional a
 ```
 
@@ -91,7 +91,7 @@ The `listToOptional` function returns `None` on an empty list or
 
 ### `optionalToList`
 
-```haskell
+```daml
 optionalToList : Optional a -> [a]
 ```
 
@@ -102,7 +102,7 @@ The `optionalToList` function returns an empty list when given
 
 ### `fromOptional`
 
-```haskell
+```daml
 fromOptional : a -> Optional a -> a
 ```
 
@@ -114,7 +114,7 @@ otherwise, it returns the value contained in the `Optional`.
 
 ### `isSome`
 
-```haskell
+```daml
 isSome : Optional a -> Bool
 ```
 
@@ -125,7 +125,7 @@ form `Some _`.
 
 ### `isNone`
 
-```haskell
+```daml
 isNone : Optional a -> Bool
 ```
 
@@ -136,7 +136,7 @@ The `isNone` function returns `True` iff its argument is
 
 ### `mapOptional`
 
-```haskell
+```daml
 mapOptional : (a -> Optional b) -> [a] -> [b]
 ```
 
@@ -150,18 +150,51 @@ result list.
 
 ### `whenSome`
 
-```haskell
+```daml
 whenSome : Applicative m => Optional a -> (a -> m ()) -> m ()
 ```
 
 Perform some operation on `Some`, given the field inside the
 `Some`.
 
+<span id="function-da-optional-whensome-5861"></span>
+
+### `whenSome_`
+
+```daml
+whenSome_ : Applicative m => Optional a -> (a -> m b) -> m ()
+```
+
+Perform some operation on `Some` and discard its result,
+given the field inside the `Some`.
+
+<span id="function-da-optional-whennone-99309"></span>
+
+### `whenNone`
+
+```daml
+whenNone : Applicative m => Optional a -> m a -> m a
+```
+
+Perform some operation on `None`.
+Otherwise returns content of `Some` pured to Applicative.
+
+<span id="function-da-optional-whennone-43843"></span>
+
+### `whenNone_`
+
+```daml
+whenNone_ : Applicative m => Optional a -> m b -> m ()
+```
+
+Perform some operation on `None`. Do nothing for `Some`.
+Convenient for discarding `Some` content.
+
 <span id="function-da-optional-findoptional-83634"></span>
 
 ### `findOptional`
 
-```haskell
+```daml
 findOptional : (a -> Optional b) -> [a] -> Optional b
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-record.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see [DA.Record](/appdev/reference/daml-standard-library/da-record).
+For more on Record syntax, see https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html.
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/docs-main/appdev/reference/daml-standard-library/da-set.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-set.mdx
@@ -97,6 +97,7 @@ Instances:
 - `instance GetField map (Set k) (Map k ())`
 - `instance SetField map (Set k) (Map k ())`
 - `instance IsParties (Set Party)`
+- `instance Serializable k => Serializable (Set k)`
 - `instance Ord k => Eq (Set k)`
 - `instance Ord k => Ord (Set k)`
 - `instance (Ord k, Show k) => Show (Set k)`
@@ -107,7 +108,7 @@ Instances:
 
 ### `empty`
 
-```haskell
+```daml
 empty : Set k
 ```
 
@@ -117,7 +118,7 @@ The empty set.
 
 ### `size`
 
-```haskell
+```daml
 size : Set k -> Int
 ```
 
@@ -127,7 +128,7 @@ The number of elements in the set.
 
 ### `toList`
 
-```haskell
+```daml
 toList : Set k -> [k]
 ```
 
@@ -137,7 +138,7 @@ Convert the set to a list of elements.
 
 ### `fromList`
 
-```haskell
+```daml
 fromList : Ord k => [k] -> Set k
 ```
 
@@ -147,7 +148,7 @@ Create a set from a list of elements.
 
 ### `toMap`
 
-```haskell
+```daml
 toMap : Set k -> Map k ()
 ```
 
@@ -157,7 +158,7 @@ Convert a `Set` into a `Map`.
 
 ### `fromMap`
 
-```haskell
+```daml
 fromMap : Map k () -> Set k
 ```
 
@@ -167,7 +168,7 @@ Create a `Set` from a `Map`.
 
 ### `member`
 
-```haskell
+```daml
 member : Ord k => k -> Set k -> Bool
 ```
 
@@ -177,7 +178,7 @@ Is the element in the set?
 
 ### `notMember`
 
-```haskell
+```daml
 notMember : Ord k => k -> Set k -> Bool
 ```
 
@@ -188,7 +189,7 @@ Is the element not in the set?
 
 ### `null`
 
-```haskell
+```daml
 null : Set k -> Bool
 ```
 
@@ -198,7 +199,7 @@ Is this the empty set?
 
 ### `insert`
 
-```haskell
+```daml
 insert : Ord k => k -> Set k -> Set k
 ```
 
@@ -209,7 +210,7 @@ element, this returns the set unchanged.
 
 ### `filter`
 
-```haskell
+```daml
 filter : Ord k => (k -> Bool) -> Set k -> Set k
 ```
 
@@ -219,7 +220,7 @@ Filter all elements that satisfy the predicate.
 
 ### `delete`
 
-```haskell
+```daml
 delete : Ord k => k -> Set k -> Set k
 ```
 
@@ -229,7 +230,7 @@ Delete an element from a set.
 
 ### `singleton`
 
-```haskell
+```daml
 singleton : Ord k => k -> Set k
 ```
 
@@ -239,7 +240,7 @@ Create a singleton set.
 
 ### `union`
 
-```haskell
+```daml
 union : Ord k => Set k -> Set k -> Set k
 ```
 
@@ -249,7 +250,7 @@ The union of two sets.
 
 ### `intersection`
 
-```haskell
+```daml
 intersection : Ord k => Set k -> Set k -> Set k
 ```
 
@@ -259,7 +260,7 @@ The intersection of two sets.
 
 ### `difference`
 
-```haskell
+```daml
 difference : Ord k => Set k -> Set k -> Set k
 ```
 
@@ -275,7 +276,7 @@ fromList [2, 3]
 
 ### `isSubsetOf`
 
-```haskell
+```daml
 isSubsetOf : Ord k => Set k -> Set k -> Bool
 ```
 
@@ -286,7 +287,7 @@ that is, if every element of `a` is in `b`.
 
 ### `isProperSubsetOf`
 
-```haskell
+```daml
 isProperSubsetOf : Ord k => Set k -> Set k -> Bool
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-stack.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-stack.mdx
@@ -70,7 +70,7 @@ Instances:
 
 ### `prettyCallStack`
 
-```haskell
+```daml
 prettyCallStack : CallStack -> Text
 ```
 
@@ -80,7 +80,7 @@ Pretty-print a `CallStack`.
 
 ### `getCallStack`
 
-```haskell
+```daml
 getCallStack : CallStack -> [(Text, SrcLoc)]
 ```
 
@@ -92,7 +92,7 @@ The most recent call comes first.
 
 ### `callStack`
 
-```haskell
+```daml
 callStack : HasCallStack => CallStack
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-text.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-text.mdx
@@ -31,7 +31,7 @@ Deprecated since: `-`
 
 ### `explode`
 
-```haskell
+```daml
 explode : Text -> [Text]
 ```
 
@@ -39,7 +39,7 @@ explode : Text -> [Text]
 
 ### `implode`
 
-```haskell
+```daml
 implode : [Text] -> Text
 ```
 
@@ -47,7 +47,7 @@ implode : [Text] -> Text
 
 ### `isEmpty`
 
-```haskell
+```daml
 isEmpty : Text -> Bool
 ```
 
@@ -57,7 +57,7 @@ Test for emptiness.
 
 ### `isNotEmpty`
 
-```haskell
+```daml
 isNotEmpty : Text -> Bool
 ```
 
@@ -67,7 +67,7 @@ Test for non-emptiness.
 
 ### `length`
 
-```haskell
+```daml
 length : Text -> Int
 ```
 
@@ -77,7 +77,7 @@ Compute the number of symbols in the text.
 
 ### `trim`
 
-```haskell
+```daml
 trim : Text -> Text
 ```
 
@@ -87,7 +87,7 @@ Remove spaces from either side of the given text.
 
 ### `replace`
 
-```haskell
+```daml
 replace : Text -> Text -> Text -> Text
 ```
 
@@ -98,7 +98,7 @@ must not be empty.
 
 ### `lines`
 
-```haskell
+```daml
 lines : Text -> [Text]
 ```
 
@@ -109,7 +109,7 @@ symbols. The resulting texts do not contain newline symbols.
 
 ### `unlines`
 
-```haskell
+```daml
 unlines : [Text] -> Text
 ```
 
@@ -119,7 +119,7 @@ Joins lines, after appending a terminating newline to each.
 
 ### `words`
 
-```haskell
+```daml
 words : Text -> [Text]
 ```
 
@@ -130,7 +130,7 @@ representing white space.
 
 ### `unwords`
 
-```haskell
+```daml
 unwords : [Text] -> Text
 ```
 
@@ -140,7 +140,7 @@ Joins words using single space symbols.
 
 ### `linesBy`
 
-```haskell
+```daml
 linesBy : (Text -> Bool) -> Text -> [Text]
 ```
 
@@ -151,7 +151,7 @@ is a trailing separator it will be discarded.
 
 ### `wordsBy`
 
-```haskell
+```daml
 wordsBy : (Text -> Bool) -> Text -> [Text]
 ```
 
@@ -162,7 +162,7 @@ separators are discarded, as are leading or trailing separators.
 
 ### `intercalate`
 
-```haskell
+```daml
 intercalate : Text -> [Text] -> Text
 ```
 
@@ -173,7 +173,7 @@ in `ts` and concatenates the result.
 
 ### `dropPrefix`
 
-```haskell
+```daml
 dropPrefix : Text -> Text -> Text
 ```
 
@@ -184,7 +184,7 @@ the original text if the text doesn't start with the given prefix.
 
 ### `dropSuffix`
 
-```haskell
+```daml
 dropSuffix : Text -> Text -> Text
 ```
 
@@ -200,7 +200,7 @@ text if the text doesn't end with the given suffix. Examples:
 
 ### `stripSuffix`
 
-```haskell
+```daml
 stripSuffix : Text -> Text -> Optional Text
 ```
 
@@ -216,7 +216,7 @@ entire first text. Examples:
 
 ### `stripPrefix`
 
-```haskell
+```daml
 stripPrefix : Text -> Text -> Optional Text
 ```
 
@@ -228,7 +228,7 @@ the prefix.
 
 ### `isPrefixOf`
 
-```haskell
+```daml
 isPrefixOf : Text -> Text -> Bool
 ```
 
@@ -239,7 +239,7 @@ The `isPrefixOf` function takes two text arguments and returns
 
 ### `isSuffixOf`
 
-```haskell
+```daml
 isSuffixOf : Text -> Text -> Bool
 ```
 
@@ -250,7 +250,7 @@ The `isSuffixOf` function takes two text arguments and returns
 
 ### `isInfixOf`
 
-```haskell
+```daml
 isInfixOf : Text -> Text -> Bool
 ```
 
@@ -262,7 +262,7 @@ anywhere within the second.
 
 ### `takeWhile`
 
-```haskell
+```daml
 takeWhile : (Text -> Bool) -> Text -> Text
 ```
 
@@ -274,7 +274,7 @@ returns the longest prefix (possibly empty) of symbols that satisfy
 
 ### `takeWhileEnd`
 
-```haskell
+```daml
 takeWhileEnd : (Text -> Bool) -> Text -> Text
 ```
 
@@ -286,7 +286,7 @@ that satisfy `p`.
 
 ### `dropWhile`
 
-```haskell
+```daml
 dropWhile : (Text -> Bool) -> Text -> Text
 ```
 
@@ -297,7 +297,7 @@ t`.
 
 ### `dropWhileEnd`
 
-```haskell
+```daml
 dropWhileEnd : (Text -> Bool) -> Text -> Text
 ```
 
@@ -308,7 +308,7 @@ symbols that satisfy the predicate `p` from the end of `t`.
 
 ### `splitOn`
 
-```haskell
+```daml
 splitOn : Text -> Text -> [Text]
 ```
 
@@ -319,7 +319,7 @@ Break a text into pieces separated by the first text argument
 
 ### `splitAt`
 
-```haskell
+```daml
 splitAt : Int -> Text -> (Text, Text)
 ```
 
@@ -330,7 +330,7 @@ Split a text before a given position so that for `0 <= n <= length t`,
 
 ### `take`
 
-```haskell
+```daml
 take : Int -> Text -> Text
 ```
 
@@ -341,7 +341,7 @@ length `n`, or `t` itself if `n` is greater than the length of `t`.
 
 ### `drop`
 
-```haskell
+```daml
 drop : Int -> Text -> Text
 ```
 
@@ -353,7 +353,7 @@ than the length of `t`.
 
 ### `substring`
 
-```haskell
+```daml
 substring : Int -> Int -> Text -> Text
 ```
 
@@ -364,7 +364,7 @@ text starting at `s`.
 
 ### `isPred`
 
-```haskell
+```daml
 isPred : (Text -> Bool) -> Text -> Bool
 ```
 
@@ -375,7 +375,7 @@ for all symbols in `t`.
 
 ### `isSpace`
 
-```haskell
+```daml
 isSpace : Text -> Bool
 ```
 
@@ -386,7 +386,7 @@ spaces.
 
 ### `isNewLine`
 
-```haskell
+```daml
 isNewLine : Text -> Bool
 ```
 
@@ -397,7 +397,7 @@ newlines.
 
 ### `isUpper`
 
-```haskell
+```daml
 isUpper : Text -> Bool
 ```
 
@@ -408,7 +408,7 @@ uppercase symbols.
 
 ### `isLower`
 
-```haskell
+```daml
 isLower : Text -> Bool
 ```
 
@@ -419,7 +419,7 @@ lowercase symbols.
 
 ### `isDigit`
 
-```haskell
+```daml
 isDigit : Text -> Bool
 ```
 
@@ -430,7 +430,7 @@ digit symbols.
 
 ### `isAlpha`
 
-```haskell
+```daml
 isAlpha : Text -> Bool
 ```
 
@@ -441,7 +441,7 @@ alphabet symbols.
 
 ### `isAlphaNum`
 
-```haskell
+```daml
 isAlphaNum : Text -> Bool
 ```
 
@@ -452,7 +452,7 @@ alphanumeric symbols.
 
 ### `parseInt`
 
-```haskell
+```daml
 parseInt : Text -> Optional Int
 ```
 
@@ -462,7 +462,7 @@ Attempt to parse an `Int` value from a given `Text`.
 
 ### `parseNumeric`
 
-```haskell
+```daml
 parseNumeric : NumericScale n => Text -> Optional (Numeric n)
 ```
 
@@ -482,7 +482,7 @@ Examples:
 
 ### `parseDecimal`
 
-```haskell
+```daml
 parseDecimal : Text -> Optional Decimal
 ```
 
@@ -502,7 +502,7 @@ Examples:
 
 ### `sha256`
 
-```haskell
+```daml
 sha256 : Text -> Text
 ```
 
@@ -515,7 +515,7 @@ This function will crash at runtime if you compile Daml to Daml-LF < 1.2.
 
 ### `reverse`
 
-```haskell
+```daml
 reverse : Text -> Text
 ```
 
@@ -528,7 +528,7 @@ Reverse some `Text`.
 
 ### `toCodePoints`
 
-```haskell
+```daml
 toCodePoints : Text -> [Int]
 ```
 
@@ -538,7 +538,7 @@ Convert a `Text` into a sequence of unicode code points.
 
 ### `fromCodePoints`
 
-```haskell
+```daml
 fromCodePoints : [Int] -> Text
 ```
 
@@ -549,7 +549,7 @@ exception if any of the code points is invalid.
 
 ### `asciiToLower`
 
-```haskell
+```daml
 asciiToLower : Text -> Text
 ```
 
@@ -560,7 +560,7 @@ all other characters remain unchanged.
 
 ### `asciiToUpper`
 
-```haskell
+```daml
 asciiToUpper : Text -> Text
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-textmap.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-textmap.mdx
@@ -35,7 +35,7 @@ Deprecated since: `-`
 
 ### `fromList`
 
-```haskell
+```daml
 fromList : [(Text, a)] -> TextMap a
 ```
 
@@ -45,7 +45,7 @@ Create a map from a list of key/value pairs.
 
 ### `fromListWithL`
 
-```haskell
+```daml
 fromListWithL : (a -> a -> a) -> [(Text, a)] -> TextMap a
 ```
 
@@ -67,7 +67,7 @@ True
 
 ### `fromListWithR`
 
-```haskell
+```daml
 fromListWithR : (a -> a -> a) -> [(Text, a)] -> TextMap a
 ```
 
@@ -85,7 +85,7 @@ True
 
 ### `fromListWith`
 
-```haskell
+```daml
 fromListWith : (a -> a -> a) -> [(Text, a)] -> TextMap a
 ```
 
@@ -93,7 +93,7 @@ fromListWith : (a -> a -> a) -> [(Text, a)] -> TextMap a
 
 ### `toList`
 
-```haskell
+```daml
 toList : TextMap a -> [(Text, a)]
 ```
 
@@ -104,7 +104,7 @@ in ascending order.
 
 ### `empty`
 
-```haskell
+```daml
 empty : TextMap a
 ```
 
@@ -114,7 +114,7 @@ The empty map.
 
 ### `size`
 
-```haskell
+```daml
 size : TextMap a -> Int
 ```
 
@@ -124,7 +124,7 @@ Number of elements in the map.
 
 ### `null`
 
-```haskell
+```daml
 null : TextMap v -> Bool
 ```
 
@@ -134,7 +134,7 @@ Is the map empty?
 
 ### `lookup`
 
-```haskell
+```daml
 lookup : Text -> TextMap a -> Optional a
 ```
 
@@ -144,7 +144,7 @@ Lookup the value at a key in the map.
 
 ### `member`
 
-```haskell
+```daml
 member : Text -> TextMap v -> Bool
 ```
 
@@ -154,7 +154,7 @@ Is the key a member of the map?
 
 ### `filter`
 
-```haskell
+```daml
 filter : (v -> Bool) -> TextMap v -> TextMap v
 ```
 
@@ -165,7 +165,7 @@ value satisfies the predicate.
 
 ### `filterWithKey`
 
-```haskell
+```daml
 filterWithKey : (Text -> v -> Bool) -> TextMap v -> TextMap v
 ```
 
@@ -176,7 +176,7 @@ satisfy the predicate.
 
 ### `delete`
 
-```haskell
+```daml
 delete : Text -> TextMap a -> TextMap a
 ```
 
@@ -187,7 +187,7 @@ member of the map, the original map is returned.
 
 ### `singleton`
 
-```haskell
+```daml
 singleton : Text -> a -> TextMap a
 ```
 
@@ -197,7 +197,7 @@ Create a singleton map.
 
 ### `insert`
 
-```haskell
+```daml
 insert : Text -> a -> TextMap a -> TextMap a
 ```
 
@@ -209,7 +209,7 @@ supplied value.
 
 ### `insertWith`
 
-```haskell
+```daml
 insertWith : (v -> v -> v) -> Text -> v -> TextMap v -> TextMap v
 ```
 
@@ -221,7 +221,7 @@ present in the map, it is combined with the previous value using the given funct
 
 ### `union`
 
-```haskell
+```daml
 union : TextMap a -> TextMap a -> TextMap a
 ```
 
@@ -232,7 +232,7 @@ keys are encountered.
 
 ### `merge`
 
-```haskell
+```daml
 merge : (Text -> a -> Optional c) -> (Text -> b -> Optional c) -> (Text -> a -> b -> Optional c) -> TextMap a -> TextMap b -> TextMap c
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-time.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-time.mdx
@@ -43,6 +43,7 @@ The `RelTime` type describes a time offset, i.e. relative time.
 
 Instances:
 
+- `instance Serializable RelTime`
 - `instance Eq RelTime`
 - `instance Ord RelTime`
 - `instance Bounded RelTime`
@@ -56,7 +57,7 @@ Instances:
 
 ### `time`
 
-```haskell
+```daml
 time : Date -> Int -> Int -> Int -> Time
 ```
 
@@ -67,7 +68,7 @@ into a UTC timestamp (`Time`). Does not handle leap seconds.
 
 ### `addRelTime`
 
-```haskell
+```daml
 addRelTime : Time -> RelTime -> Time
 ```
 
@@ -77,7 +78,7 @@ Adjusts `Time` with given time offset.
 
 ### `subTime`
 
-```haskell
+```daml
 subTime : Time -> Time -> RelTime
 ```
 
@@ -87,7 +88,7 @@ Returns time offset between two given instants.
 
 ### `wholeDays`
 
-```haskell
+```daml
 wholeDays : RelTime -> Int
 ```
 
@@ -97,7 +98,7 @@ Returns the number of whole days in a time offset. Fraction of time is rounded t
 
 ### `days`
 
-```haskell
+```daml
 days : Int -> RelTime
 ```
 
@@ -107,7 +108,7 @@ A number of days in relative time.
 
 ### `hours`
 
-```haskell
+```daml
 hours : Int -> RelTime
 ```
 
@@ -117,7 +118,7 @@ A number of hours in relative time.
 
 ### `minutes`
 
-```haskell
+```daml
 minutes : Int -> RelTime
 ```
 
@@ -127,7 +128,7 @@ A number of minutes in relative time.
 
 ### `seconds`
 
-```haskell
+```daml
 seconds : Int -> RelTime
 ```
 
@@ -137,7 +138,7 @@ A number of seconds in relative time.
 
 ### `milliseconds`
 
-```haskell
+```daml
 milliseconds : Int -> RelTime
 ```
 
@@ -147,7 +148,7 @@ A number of milliseconds in relative time.
 
 ### `microseconds`
 
-```haskell
+```daml
 microseconds : Int -> RelTime
 ```
 
@@ -157,7 +158,7 @@ A number of microseconds in relative time.
 
 ### `convertRelTimeToMicroseconds`
 
-```haskell
+```daml
 convertRelTimeToMicroseconds : RelTime -> Int
 ```
 
@@ -168,7 +169,7 @@ Use higher level functions instead of the internal microseconds
 
 ### `convertMicrosecondsToRelTime`
 
-```haskell
+```daml
 convertMicrosecondsToRelTime : Int -> RelTime
 ```
 
@@ -179,7 +180,7 @@ Use higher level functions instead of the internal microseconds
 
 ### `isLedgerTimeLT`
 
-```haskell
+```daml
 isLedgerTimeLT : Time -> Update Bool
 ```
 
@@ -189,7 +190,7 @@ True iff the ledger time of the transaction is less than the given time.
 
 ### `isLedgerTimeLE`
 
-```haskell
+```daml
 isLedgerTimeLE : Time -> Update Bool
 ```
 
@@ -199,7 +200,7 @@ True iff the ledger time of the transaction is less than or equal to the given t
 
 ### `isLedgerTimeGT`
 
-```haskell
+```daml
 isLedgerTimeGT : Time -> Update Bool
 ```
 
@@ -209,7 +210,7 @@ True iff the ledger time of the transaction is greater than the given time.
 
 ### `isLedgerTimeGE`
 
-```haskell
+```daml
 isLedgerTimeGE : Time -> Update Bool
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-traversable.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-traversable.mdx
@@ -69,7 +69,7 @@ Instances:
 
 ### `forA`
 
-```haskell
+```daml
 forA : (Traversable t, Applicative f) => t a -> (a -> f b) -> f (t b)
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-tuple.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-tuple.mdx
@@ -31,7 +31,7 @@ Deprecated since: `-`
 
 ### `first`
 
-```haskell
+```daml
 first : (a -> a') -> (a, b) -> (a', b)
 ```
 
@@ -42,7 +42,7 @@ supplied function to the argument pair's first field.
 
 ### `second`
 
-```haskell
+```daml
 second : (b -> b') -> (a, b) -> (a, b')
 ```
 
@@ -53,7 +53,7 @@ supplied function to the argument pair's second field.
 
 ### `both`
 
-```haskell
+```daml
 both : (a -> b) -> (a, a) -> (b, b)
 ```
 
@@ -65,7 +65,7 @@ fields.
 
 ### `swap`
 
-```haskell
+```daml
 swap : (a, b) -> (b, a)
 ```
 
@@ -76,7 +76,7 @@ argument pair's first and second fields.
 
 ### `dupe`
 
-```haskell
+```daml
 dupe : a -> (a, a)
 ```
 
@@ -88,7 +88,7 @@ Duplicate a single value into a pair.
 
 ### `fst3`
 
-```haskell
+```daml
 fst3 : (a, b, c) -> a
 ```
 
@@ -98,7 +98,7 @@ Extract the 'fst' of a triple.
 
 ### `snd3`
 
-```haskell
+```daml
 snd3 : (a, b, c) -> b
 ```
 
@@ -108,7 +108,7 @@ Extract the 'snd' of a triple.
 
 ### `thd3`
 
-```haskell
+```daml
 thd3 : (a, b, c) -> c
 ```
 
@@ -118,7 +118,7 @@ Extract the final element of a triple.
 
 ### `curry3`
 
-```haskell
+```daml
 curry3 : ((a, b, c) -> d) -> a -> b -> c -> d
 ```
 
@@ -128,7 +128,7 @@ Converts an uncurried function to a curried function.
 
 ### `uncurry3`
 
-```haskell
+```daml
 uncurry3 : (a -> b -> c -> d) -> (a, b, c) -> d
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/da-validation.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-validation.mdx
@@ -47,6 +47,7 @@ Instances:
 - `instance Applicative (Validation err)`
 - `instance Semigroup (Validation err a)`
 - `instance Traversable (Validation err)`
+- `instance (Serializable err, Serializable a) => Serializable (Validation err a)`
 - `instance Functor (Validation err)`
 - `instance (Eq err, Eq a) => Eq (Validation err a)`
 - `instance (Show err, Show a) => Show (Validation err a)`
@@ -57,7 +58,7 @@ Instances:
 
 ### `invalid`
 
-```haskell
+```daml
 invalid : err -> Validation err a
 ```
 
@@ -67,7 +68,7 @@ Fail for the given reason.
 
 ### `ok`
 
-```haskell
+```daml
 ok : a -> Validation err a
 ```
 
@@ -77,7 +78,7 @@ Succeed with the given value.
 
 ### `validate`
 
-```haskell
+```daml
 validate : Either err a -> Validation err a
 ```
 
@@ -87,7 +88,7 @@ Turn an `Either` into a `Validation`.
 
 ### `run`
 
-```haskell
+```daml
 run : Validation err a -> Either (NonEmpty err) a
 ```
 
@@ -98,7 +99,7 @@ taking the non-empty list of errors as the left value.
 
 ### `run1`
 
-```haskell
+```daml
 run1 : Validation err a -> Either err a
 ```
 
@@ -109,7 +110,7 @@ taking just the first error as the left value.
 
 ### `runWithDefault`
 
-```haskell
+```daml
 runWithDefault : a -> Validation err a -> a
 ```
 
@@ -119,7 +120,7 @@ Run a `Validation err a` with a default value in case of errors.
 
 ### `<?>`
 
-```haskell
+```daml
 <?> : Optional b -> err -> Validation err b
 ```
 

--- a/docs-main/appdev/reference/daml-standard-library/index.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/index.mdx
@@ -18,7 +18,7 @@ description: "Reference documentation for Daml Standard Library modules."
 
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
 
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">3.4.11</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">3.5.1</span>
 
 </div>
 
@@ -27,7 +27,7 @@ description: "Reference documentation for Daml Standard Library modules."
 
   <div class="x2mdx-ref-meta-item">
     <dt>Publish version</dt>
-    <dd>3.4.11</dd>
+    <dd>3.5.1</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -281,6 +281,56 @@ Open a module page for declarations, type signatures, warnings, and lifecycle de
   <div class="x2mdx-ref-meta-item">
     <dt>Introduced</dt>
     <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-contractkeys">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.ContractKeys</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.5.1</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: Docs TODO (https://github.com/digital-asset/daml/issues/22673)</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.5.1</dd>
   </div>
 
   <div class="x2mdx-ref-meta-item">
@@ -1928,6 +1978,31 @@ Open a module page for declarations, type signatures, warnings, and lifecycle de
 <div class="x2mdx-ref-badges">
 
   <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5.1</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
 
   <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
 

--- a/docs-main/appdev/reference/daml-standard-library/prelude.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/prelude.mdx
@@ -3,9 +3,6 @@ title: "Prelude"
 description: "Reference documentation for Daml module Prelude."
 ---
 
-import DamlAppdevModulesM3LanguageFundamentalsL145 from "/snippets/daml-docs/appdev_modules_m3-language-fundamentals_L145.mdx";
-import DamlAppdevModulesM3LanguageFundamentalsL452 from "/snippets/daml-docs/appdev_modules_m3-language-fundamentals_L452.mdx";
-
 <span id="module-prelude-72703"></span>
 
 # Prelude
@@ -49,26 +46,6 @@ Instances:
 
 - `instance Eq AnyChoice`
 - `instance Ord AnyChoice`
-
-<span id="type-da-internal-any-anycontractkey-68193"></span>
-
-### `data AnyContractKey`
-
-Existential contract key type that can wrap an arbitrary contract key.
-
-Constructors:
-
-<span id="constr-da-internal-any-anycontractkey-82848"></span>
-- `AnyContractKey`
-| Field | Type | Description |
-| :---- | :--- | :---------- |
-| getAnyContractKey | Any |  |
-| getAnyContractKeyTemplateTypeRep | TemplateTypeRep |  |
-
-Instances:
-
-- `instance Eq AnyContractKey`
-- `instance Ord AnyContractKey`
 
 <span id="type-da-internal-any-anytemplate-63703"></span>
 
@@ -164,6 +141,7 @@ You can use the ID to fetch the contract, among other things.
 
 Instances:
 
+- `instance Serializable (ContractId a)`
 - `instance Eq (ContractId a)`
 - `instance Ord (ContractId a)`
 - `instance Show (ContractId a)`
@@ -177,6 +155,7 @@ The bounds for Date are 0001-01-01 and 9999-12-31.
 
 Instances:
 
+- `instance Serializable Date`
 - `instance Eq Date`
 - `instance Ord Date`
 - `instance Bounded Date`
@@ -199,6 +178,7 @@ Instances:
 - `instance GetField map (Set k) (Map k ())`
 - `instance SetField map (Set k) (Map k ())`
 - `instance Ord k => Traversable (Map k)`
+- `instance (Serializable a, Serializable b) => Serializable (Map a b)`
 - `instance Ord k => Functor (Map k)`
 - `instance (Ord k, Eq v) => Eq (Map k v)`
 - `instance (Ord k, Ord v) => Ord (Map k v)`
@@ -219,6 +199,7 @@ Instances:
 - `instance IsParties (NonEmpty Party)`
 - `instance IsParties (Set Party)`
 - `instance IsParties [Party]`
+- `instance Serializable Party`
 - `instance Eq Party`
 - `instance Ord Party`
 - `instance Show Party`
@@ -238,6 +219,7 @@ Instances:
 - `instance GetField meta FailureStatus (TextMap Text)`
 - `instance SetField meta FailureStatus (TextMap Text)`
 - `instance Traversable TextMap`
+- `instance Serializable a => Serializable (TextMap a)`
 - `instance Functor TextMap`
 - `instance Eq a => Eq (TextMap a)`
 - `instance Ord a => Ord (TextMap a)`
@@ -254,6 +236,7 @@ The bounds for Time are 0001-01-01T00:00:00.000000Z and
 
 Instances:
 
+- `instance Serializable Time`
 - `instance Eq Time`
 - `instance Ord Time`
 - `instance Bounded Time`
@@ -311,6 +294,7 @@ Instances:
 - `instance Applicative Optional`
 - `instance IsParties (Optional Party)`
 - `instance Traversable Optional`
+- `instance Serializable a => Serializable (Optional a)`
 - `instance Functor Optional`
 - `instance Eq a => Eq (Optional a)`
 - `instance Ord a => Ord (Optional a)`
@@ -346,7 +330,7 @@ Constraint satisfied by choices.
 
 <span id="type-da-internal-template-functions-templatekey-95200"></span>
 
-### `type TemplateKey = (Template t, HasKey t k, HasLookupByKey t k, HasFetchByKey t k, HasMaintainer t k, HasToAnyContractKey t k, HasFromAnyContractKey t k)`
+### `type TemplateKey = (Template t, HasKey t k, HasFetchByKey t k, HasMaintainer t k)`
 
 Constraint satisfied by template keys.
 
@@ -398,7 +382,7 @@ Methods:
   template value. A `None` indicates that the expected template
   type doesn't match the underyling template type for the
   interface value.
-  
+
   For example, `fromInterface @MyTemplate value` will try to convert
   the interface value `value` into the template type `MyTemplate`.
 
@@ -451,12 +435,12 @@ Methods:
   Lift a value.
 - `<*> : f (a -> b) -> f a -> f b`
   Sequentially apply the function.
-  
+
   A few functors support an implementation of `<*>` that is more
   efficient than the default one.
 - `liftA2 : (a -> b -> c) -> f a -> f b -> f c`
   Lift a binary function to actions.
-  
+
   Some functors support an implementation of `liftA2` that is more
   efficient than the default one. In particular, if `fmap` is an
   expensive operation, it is likely better to use `liftA2` than to
@@ -744,50 +728,21 @@ Methods:
 
 Exposes `lookupByKey` function. Part of the `TemplateKey` constraint.
 
-Methods:
-
-- `lookupByKey : k -> Update (Optional (ContractId t))`
-  Look up the contract ID `t` associated with a given contract key `k`.
-  
-  You must pass the `t` using an explicit type application. For
-  instance, if you want to look up a contract of template `Account` by its
-  key `k`, you must call `lookupByKey @Account k`.
-
 <span id="class-da-internal-template-functions-hasfetchbykey-54638"></span>
 
 ### `class HasFetchByKey t k`
 
 Exposes `fetchByKey` function. Part of the `TemplateKey` constraint.
 
-Methods:
+<span id="class-da-internal-template-functions-haslookupnbykey-35508"></span>
 
-- `fetchByKey : k -> Update (ContractId t, t)`
-  Fetch the contract ID and contract data associated with a given
-  contract key.
-  
-  You must pass the `t` using an explicit type application. For
-  instance, if you want to fetch a contract of template `Account` by its
-  key `k`, you must call `fetchByKey @Account k`.
+### `class HasLookupNByKey t k`
 
 <span id="class-da-internal-template-functions-hasmaintainer-28932"></span>
 
 ### `class HasMaintainer t k`
 
 Exposes `maintainer` function. Part of the `TemplateKey` constraint.
-
-<span id="class-da-internal-template-functions-hastoanycontractkey-35010"></span>
-
-### `class HasToAnyContractKey t k`
-
-Exposes `toAnyContractKey` function in Daml-LF 1.7 or later.
-Part of the `TemplateKey` constraint.
-
-<span id="class-da-internal-template-functions-hasfromanycontractkey-95587"></span>
-
-### `class HasFromAnyContractKey t k`
-
-Exposes `fromAnyContractKey` function in Daml-LF 1.7 or later.
-Part of the `TemplateKey` constraint.
 
 <span id="class-da-internal-template-functions-hasexercisebykey-36549"></span>
 
@@ -820,7 +775,7 @@ Instances:
 
 ### `assert`
 
-```haskell
+```daml
 assert : CanAssert m => Bool -> m ()
 ```
 
@@ -830,7 +785,7 @@ Check whether a condition is true. If it's not, abort the transaction.
 
 ### `assertMsg`
 
-```haskell
+```daml
 assertMsg : CanAssert m => Text -> Bool -> m ()
 ```
 
@@ -841,7 +796,7 @@ with a message.
 
 ### `assertAfter`
 
-```haskell
+```daml
 assertAfter : (CanAssert m, HasTime m) => Time -> m ()
 ```
 
@@ -851,7 +806,7 @@ Check whether the given time is in the future. If it's not, abort the transactio
 
 ### `assertBefore`
 
-```haskell
+```daml
 assertBefore : (CanAssert m, HasTime m) => Time -> m ()
 ```
 
@@ -861,7 +816,7 @@ Check whether the given time is in the past. If it's not, abort the transaction.
 
 ### `daysSinceEpochToDate`
 
-```haskell
+```daml
 daysSinceEpochToDate : Int -> Date
 ```
 
@@ -872,7 +827,7 @@ January 1, 1970) to a date.
 
 ### `dateToDaysSinceEpoch`
 
-```haskell
+```daml
 dateToDaysSinceEpoch : Date -> Int
 ```
 
@@ -883,7 +838,7 @@ since January 1, 1970).
 
 ### `interfaceTypeRep`
 
-```haskell
+```daml
 interfaceTypeRep : HasInterfaceTypeRep i => i -> TemplateTypeRep
 ```
 
@@ -893,7 +848,7 @@ interfaceTypeRep : HasInterfaceTypeRep i => i -> TemplateTypeRep
 
 ### `toInterface`
 
-```haskell
+```daml
 toInterface : HasToInterface t i => t -> i
 ```
 
@@ -905,7 +860,7 @@ For example `toInterface @MyInterface value` converts a template
 
 ### `toInterfaceContractId`
 
-```haskell
+```daml
 toInterfaceContractId : HasToInterface t i => ContractId t -> ContractId i
 ```
 
@@ -916,7 +871,7 @@ contract id. For example, `toInterfaceContractId @MyInterface cid`.
 
 ### `fromInterfaceContractId`
 
-```haskell
+```daml
 fromInterfaceContractId : HasFromInterface t i => ContractId i -> ContractId t
 ```
 
@@ -945,7 +900,7 @@ In all other cases, consider using `fetchFromInterface` instead.
 
 ### `coerceInterfaceContractId`
 
-```haskell
+```daml
 coerceInterfaceContractId : (HasInterfaceTypeRep i, HasInterfaceTypeRep j) => ContractId i -> ContractId j
 ```
 
@@ -971,7 +926,7 @@ appropriate response to the contract having the wrong type.
 
 ### `fetchFromInterface`
 
-```haskell
+```daml
 fetchFromInterface : (HasFromInterface t i, HasFetch i) => ContractId i -> Update (Optional (ContractId t, t))
 ```
 
@@ -997,7 +952,7 @@ do
 
 ### `_exerciseInterfaceGuard`
 
-```haskell
+```daml
 _exerciseInterfaceGuard : a -> b -> c -> Bool
 ```
 
@@ -1005,7 +960,7 @@ _exerciseInterfaceGuard : a -> b -> c -> Bool
 
 ### `view`
 
-```haskell
+```daml
 view : HasInterfaceView i v => i -> v
 ```
 
@@ -1013,7 +968,7 @@ view : HasInterfaceView i v => i -> v
 
 ### `partyToText`
 
-```haskell
+```daml
 partyToText : Party -> Text
 ```
 
@@ -1025,7 +980,7 @@ the party in `'ticks'` making it clear it was a `Party` originally.
 
 ### `partyFromText`
 
-```haskell
+```daml
 partyFromText : Text -> Optional Party
 ```
 
@@ -1042,7 +997,7 @@ exists on a given ledger is to involve it in a contract.
 This function, together with `partyToText`, forms an isomorphism between
 valid party strings and parties. In other words, the following equations hold:
 
-```haskell-force
+```daml-force
 ∀ p. partyFromText (partyToText p) = Some p
 ∀ txt p. partyFromText txt = Some p ==> partyToText p = txt
 ```
@@ -1053,7 +1008,7 @@ This function will crash at runtime if you compile Daml to Daml-LF < 1.2.
 
 ### `coerceContractId`
 
-```haskell
+```daml
 coerceContractId : ContractId a -> ContractId b
 ```
 
@@ -1065,7 +1020,7 @@ template of the contract on the ledger doesn't match.
 
 ### `curry`
 
-```haskell
+```daml
 curry : ((a, b) -> c) -> a -> b -> c
 ```
 
@@ -1075,7 +1030,9 @@ Turn a function that takes a pair into a function that takes two arguments.
 
 ### `uncurry`
 
-<DamlAppdevModulesM3LanguageFundamentalsL145 />
+```daml
+uncurry : (a -> b -> c) -> (a, b) -> c
+```
 
 Turn a function that takes two arguments into a function that takes a pair.
 
@@ -1083,7 +1040,7 @@ Turn a function that takes two arguments into a function that takes a pair.
 
 ### `>>`
 
-```haskell
+```daml
 >> : Action m => m a -> m b -> m b
 ```
 
@@ -1095,7 +1052,7 @@ in imperative languages.
 
 ### `ap`
 
-```haskell
+```daml
 ap : Applicative f => f (a -> b) -> f a -> f b
 ```
 
@@ -1105,7 +1062,7 @@ Synonym for `<*>`.
 
 ### `return`
 
-```haskell
+```daml
 return : Applicative m => a -> m a
 ```
 
@@ -1116,7 +1073,7 @@ value of type `a`, `return` would give you an `Update a`.
 
 ### `join`
 
-```haskell
+```daml
 join : Action m => m (m a) -> m a
 ```
 
@@ -1126,7 +1083,7 @@ Collapses nested actions into a single action.
 
 ### `identity`
 
-```haskell
+```daml
 identity : a -> a
 ```
 
@@ -1136,7 +1093,7 @@ The identity function.
 
 ### `guard`
 
-```haskell
+```daml
 guard : ActionFail m => Bool -> m ()
 ```
 
@@ -1144,7 +1101,9 @@ guard : ActionFail m => Bool -> m ()
 
 ### `foldl`
 
-<DamlAppdevModulesM3LanguageFundamentalsL452 />
+```daml
+foldl : (b -> a -> b) -> b -> [a] -> b
+```
 
 This function is a left fold, which you can use to inspect/analyse/consume lists.
 `foldl f i xs` performs a left fold over the list `xs` using
@@ -1166,7 +1125,7 @@ Note that foldl works from left-to-right over the list arguments.
 
 ### `find`
 
-```haskell
+```daml
 find : (a -> Bool) -> [a] -> Optional a
 ```
 
@@ -1178,7 +1137,7 @@ is why this function returns an `Optional a`.
 
 ### `length`
 
-```haskell
+```daml
 length : [a] -> Int
 ```
 
@@ -1188,7 +1147,7 @@ Gives the length of the list.
 
 ### `any`
 
-```haskell
+```daml
 any : (a -> Bool) -> [a] -> Bool
 ```
 
@@ -1199,7 +1158,7 @@ Are there any elements in the list where the predicate is true?
 
 ### `all`
 
-```haskell
+```daml
 all : (a -> Bool) -> [a] -> Bool
 ```
 
@@ -1210,7 +1169,7 @@ Is the predicate true for all of the elements in the list?
 
 ### `or`
 
-```haskell
+```daml
 or : [Bool] -> Bool
 ```
 
@@ -1221,7 +1180,7 @@ Is at least one of elements in a list of `Bool` true?
 
 ### `and`
 
-```haskell
+```daml
 and : [Bool] -> Bool
 ```
 
@@ -1232,7 +1191,7 @@ Is every element in a list of Bool true?
 
 ### `elem`
 
-```haskell
+```daml
 elem : Eq a => a -> [a] -> Bool
 ```
 
@@ -1243,7 +1202,7 @@ Does this value exist in this list?
 
 ### `notElem`
 
-```haskell
+```daml
 notElem : Eq a => a -> [a] -> Bool
 ```
 
@@ -1254,7 +1213,7 @@ Negation of `elem`:
 
 ### `<$>`
 
-```haskell
+```daml
 <$> : Functor f => (a -> b) -> f a -> f b
 ```
 
@@ -1264,7 +1223,7 @@ Synonym for `fmap`.
 
 ### `optional`
 
-```haskell
+```daml
 optional : b -> (a -> b) -> Optional a -> b
 ```
 
@@ -1307,7 +1266,7 @@ returns the empty string instead of (for example) `None`:
 
 ### `either`
 
-```haskell
+```daml
 either : (a -> c) -> (b -> c) -> Either a b -> c
 ```
 
@@ -1333,7 +1292,7 @@ or the "times-two" function (if it has an `Int`):
 
 ### `concat`
 
-```haskell
+```daml
 concat : [[a]] -> [a]
 ```
 
@@ -1343,7 +1302,7 @@ Take a list of lists and concatenate those lists into one list.
 
 ### `++`
 
-```haskell
+```daml
 ++ : [a] -> [a] -> [a]
 ```
 
@@ -1353,7 +1312,7 @@ Concatenate two lists.
 
 ### `flip`
 
-```haskell
+```daml
 flip : (a -> b -> c) -> b -> a -> c
 ```
 
@@ -1363,7 +1322,7 @@ Flip the order of the arguments of a two argument function.
 
 ### `reverse`
 
-```haskell
+```daml
 reverse : [a] -> [a]
 ```
 
@@ -1373,7 +1332,7 @@ Reverse a list.
 
 ### `mapA`
 
-```haskell
+```daml
 mapA : Applicative m => (a -> m b) -> [a] -> m [b]
 ```
 
@@ -1383,7 +1342,7 @@ Apply an applicative function to each element of a list.
 
 ### `forA`
 
-```haskell
+```daml
 forA : Applicative m => [a] -> (a -> m b) -> m [b]
 ```
 
@@ -1393,7 +1352,7 @@ forA : Applicative m => [a] -> (a -> m b) -> m [b]
 
 ### `sequence`
 
-```haskell
+```daml
 sequence : Applicative m => [m a] -> m [a]
 ```
 
@@ -1403,7 +1362,7 @@ Perform a list of actions in sequence and collect the results.
 
 ### `=<<`
 
-```haskell
+```daml
 =<< : Action m => (a -> m b) -> m a -> m b
 ```
 
@@ -1413,7 +1372,7 @@ Perform a list of actions in sequence and collect the results.
 
 ### `concatMap`
 
-```haskell
+```daml
 concatMap : (a -> [b]) -> [a] -> [b]
 ```
 
@@ -1423,7 +1382,7 @@ Map a function over each element of a list, and concatenate all the results.
 
 ### `replicate`
 
-```haskell
+```daml
 replicate : Int -> a -> [a]
 ```
 
@@ -1433,7 +1392,7 @@ replicate : Int -> a -> [a]
 
 ### `take`
 
-```haskell
+```daml
 take : Int -> [a] -> [a]
 ```
 
@@ -1443,7 +1402,7 @@ Take the first `n` elements of a list.
 
 ### `drop`
 
-```haskell
+```daml
 drop : Int -> [a] -> [a]
 ```
 
@@ -1453,7 +1412,7 @@ Drop the first `n` elements of a list.
 
 ### `splitAt`
 
-```haskell
+```daml
 splitAt : Int -> [a] -> ([a], [a])
 ```
 
@@ -1463,7 +1422,7 @@ Split a list at a given index.
 
 ### `takeWhile`
 
-```haskell
+```daml
 takeWhile : (a -> Bool) -> [a] -> [a]
 ```
 
@@ -1473,7 +1432,7 @@ Take elements from a list while the predicate holds.
 
 ### `dropWhile`
 
-```haskell
+```daml
 dropWhile : (a -> Bool) -> [a] -> [a]
 ```
 
@@ -1483,7 +1442,7 @@ Drop elements from a list while the predicate holds.
 
 ### `span`
 
-```haskell
+```daml
 span : (a -> Bool) -> [a] -> ([a], [a])
 ```
 
@@ -1493,7 +1452,7 @@ span : (a -> Bool) -> [a] -> ([a], [a])
 
 ### `partition`
 
-```haskell
+```daml
 partition : (a -> Bool) -> [a] -> ([a], [a])
 ```
 
@@ -1512,7 +1471,7 @@ predicate, respectively; i.e.,
 
 ### `break`
 
-```haskell
+```daml
 break : (a -> Bool) -> [a] -> ([a], [a])
 ```
 
@@ -1523,7 +1482,7 @@ Break a list into two, just before the first element where the predicate holds.
 
 ### `lookup`
 
-```haskell
+```daml
 lookup : Eq a => a -> [(a, b)] -> Optional b
 ```
 
@@ -1533,7 +1492,7 @@ Look up the first element with a matching key.
 
 ### `enumerate`
 
-```haskell
+```daml
 enumerate : (Enum a, Bounded a) => [a]
 ```
 
@@ -1543,7 +1502,7 @@ Generate a list containing all values of a given enumeration.
 
 ### `zip`
 
-```haskell
+```daml
 zip : [a] -> [b] -> [(a, b)]
 ```
 
@@ -1554,7 +1513,7 @@ If one list is shorter, the excess elements of the longer list are discarded.
 
 ### `zip3`
 
-```haskell
+```daml
 zip3 : [a] -> [b] -> [c] -> [(a, b, c)]
 ```
 
@@ -1564,7 +1523,7 @@ zip3 : [a] -> [b] -> [c] -> [(a, b, c)]
 
 ### `zipWith`
 
-```haskell
+```daml
 zipWith : (a -> b -> c) -> [a] -> [b] -> [c]
 ```
 
@@ -1576,7 +1535,7 @@ If one list is shorter, the excess elements of the longer list are discarded.
 
 ### `zipWith3`
 
-```haskell
+```daml
 zipWith3 : (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
 ```
 
@@ -1586,7 +1545,7 @@ zipWith3 : (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
 
 ### `unzip`
 
-```haskell
+```daml
 unzip : [(a, b)] -> ([a], [b])
 ```
 
@@ -1596,7 +1555,7 @@ Turn a list of pairs into a pair of lists.
 
 ### `unzip3`
 
-```haskell
+```daml
 unzip3 : [(a, b, c)] -> ([a], [b], [c])
 ```
 
@@ -1606,7 +1565,7 @@ Turn a list of triples into a triple of lists.
 
 ### `traceRaw`
 
-```haskell
+```daml
 traceRaw : Text -> a -> a
 ```
 
@@ -1618,7 +1577,7 @@ The default configuration on the participant logs these messages at DEBUG level.
 
 ### `trace`
 
-```haskell
+```daml
 trace : Show b => b -> a -> a
 ```
 
@@ -1630,7 +1589,7 @@ The default configuration on the participant logs these messages at DEBUG level.
 
 ### `traceId`
 
-```haskell
+```daml
 traceId : Show b => b -> b
 ```
 
@@ -1642,7 +1601,7 @@ The default configuration on the participant logs these messages at DEBUG level.
 
 ### `debug`
 
-```haskell
+```daml
 debug : (Show b, Action m) => b -> m ()
 ```
 
@@ -1654,7 +1613,7 @@ The default configuration on the participant logs these messages at DEBUG level.
 
 ### `debugRaw`
 
-```haskell
+```daml
 debugRaw : Action m => Text -> m ()
 ```
 
@@ -1666,7 +1625,7 @@ The default configuration on the participant logs these messages at DEBUG level.
 
 ### `fst`
 
-```haskell
+```daml
 fst : (a, b) -> a
 ```
 
@@ -1676,7 +1635,7 @@ Return the first element of a tuple.
 
 ### `snd`
 
-```haskell
+```daml
 snd : (a, b) -> b
 ```
 
@@ -1686,7 +1645,7 @@ Return the second element of a tuple.
 
 ### `truncate`
 
-```haskell
+```daml
 truncate : Numeric n -> Int
 ```
 
@@ -1696,7 +1655,7 @@ truncate : Numeric n -> Int
 
 ### `intToNumeric`
 
-```haskell
+```daml
 intToNumeric : NumericScale n => Int -> Numeric n
 ```
 
@@ -1706,7 +1665,7 @@ Convert an `Int` to a `Numeric`.
 
 ### `intToDecimal`
 
-```haskell
+```daml
 intToDecimal : Int -> Decimal
 ```
 
@@ -1716,7 +1675,7 @@ Convert an `Int` to a `Decimal`.
 
 ### `roundBankers`
 
-```haskell
+```daml
 roundBankers : Int -> Numeric n -> Numeric n
 ```
 
@@ -1726,7 +1685,7 @@ Bankers' Rounding: `roundBankers dp x` rounds `x` to `dp` decimal places, where 
 
 ### `roundCommercial`
 
-```haskell
+```daml
 roundCommercial : NumericScale n => Int -> Numeric n -> Numeric n
 ```
 
@@ -1736,7 +1695,7 @@ Commercial Rounding: `roundCommercial dp x` rounds `x` to `dp` decimal places, w
 
 ### `round`
 
-```haskell
+```daml
 round : NumericScale n => Numeric n -> Int
 ```
 
@@ -1746,7 +1705,7 @@ Round a `Numeric` to the nearest integer, where a `.5` is rounded away from zero
 
 ### `floor`
 
-```haskell
+```daml
 floor : NumericScale n => Numeric n -> Int
 ```
 
@@ -1756,7 +1715,7 @@ Round a `Decimal` down to the nearest integer.
 
 ### `ceiling`
 
-```haskell
+```daml
 ceiling : NumericScale n => Numeric n -> Int
 ```
 
@@ -1766,7 +1725,7 @@ Round a `Decimal` up to the nearest integer.
 
 ### `null`
 
-```haskell
+```daml
 null : [a] -> Bool
 ```
 
@@ -1776,7 +1735,7 @@ Is the list empty? `null xs` is true if `xs` is the empty list.
 
 ### `filter`
 
-```haskell
+```daml
 filter : (a -> Bool) -> [a] -> [a]
 ```
 
@@ -1786,7 +1745,7 @@ Filters the list using the function: keep only the elements where the predicate 
 
 ### `sum`
 
-```haskell
+```daml
 sum : Additive a => [a] -> a
 ```
 
@@ -1796,7 +1755,7 @@ Add together all the elements in the list.
 
 ### `product`
 
-```haskell
+```daml
 product : Multiplicative a => [a] -> a
 ```
 
@@ -1806,7 +1765,7 @@ Multiply all the elements in the list together.
 
 ### `undefined`
 
-```haskell
+```daml
 undefined : a
 ```
 
@@ -1817,7 +1776,7 @@ Always throws an error with "Not implemented."
 
 ### `softFetch`
 
-```haskell
+```daml
 softFetch : HasSoftFetch t => ContractId t -> Update t
 ```
 
@@ -1825,7 +1784,7 @@ softFetch : HasSoftFetch t => ContractId t -> Update t
 
 ### `softExercise`
 
-```haskell
+```daml
 softExercise : HasSoftExercise t c r => ContractId t -> c -> Update r
 ```
 
@@ -1833,7 +1792,7 @@ softExercise : HasSoftExercise t c r => ContractId t -> c -> Update r
 
 ### `stakeholder`
 
-```haskell
+```daml
 stakeholder : (HasSignatory t, HasObserver t) => t -> [Party]
 ```
 
@@ -1843,21 +1802,52 @@ The stakeholders of a contract: its signatories and observers.
 
 ### `maintainer`
 
-```haskell
+```daml
 maintainer : HasMaintainer t k => k -> [Party]
 ```
 
 The list of maintainers of a contract key.
 
+<span id="function-da-internal-template-functions-lookupbykey-92781"></span>
+
+### `lookupByKey`
+
+```daml
+lookupByKey : (HasKey t k, HasLookupNByKey t k) => k -> Update (Optional (ContractId t))
+```
+
+Look up the contract ID `t` associated with a given contract key `k` (see
+`lookupNByKey` for more on contract order).
+
+You must pass the `t` using an explicit type application. For
+instance, if you want to look up a contract of template `Account` by its
+key `k`, you must call `lookupByKey @Account k`.
+
+<span id="function-da-internal-template-functions-fetchbykey-95464"></span>
+
+### `fetchByKey`
+
+```daml
+fetchByKey : HasFetchByKey t k => k -> Update (ContractId t, t)
+```
+
+Fetch the first contract ID and contract data associated with the given
+contract key (see `lookupNByKey` for more on contract order).
+
+You must pass the `t` using an explicit type application. For
+instance, if you want to fetch a contract of template `Account` by its
+key `k`, you must call `fetchByKey @Account k`.
+
 <span id="function-da-internal-template-functions-exercisebykey-78695"></span>
 
 ### `exerciseByKey`
 
-```haskell
+```daml
 exerciseByKey : HasExerciseByKey t k c r => k -> c -> Update r
 ```
 
-Exercise a choice on the contract associated with the given key.
+Exercise a choice on the first contract associated with the given key (see
+`lookupNByKey` for more on contract order).
 
 You must pass the `t` using an explicit type application. For
 instance, if you want to exercise a choice `Withdraw` on a contract of
@@ -1868,7 +1858,7 @@ template `Account` given by its key `k`, you must call
 
 ### `createAndExercise`
 
-```haskell
+```daml
 createAndExercise : (HasCreate t, HasExercise t c r) => t -> c -> Update r
 ```
 
@@ -1878,7 +1868,7 @@ Create a contract and exercise the choice on the newly created contract.
 
 ### `templateTypeRep`
 
-```haskell
+```daml
 templateTypeRep : HasTemplateTypeRep t => TemplateTypeRep
 ```
 
@@ -1888,7 +1878,7 @@ Generate a unique textual representation of the template id.
 
 ### `toAnyTemplate`
 
-```haskell
+```daml
 toAnyTemplate : HasToAnyTemplate t => t -> AnyTemplate
 ```
 
@@ -1900,7 +1890,7 @@ Only available for Daml-LF 1.7 or later.
 
 ### `fromAnyTemplate`
 
-```haskell
+```daml
 fromAnyTemplate : HasFromAnyTemplate t => AnyTemplate -> Optional t
 ```
 
@@ -1913,7 +1903,7 @@ Only available for Daml-LF 1.7 or later.
 
 ### `toAnyChoice`
 
-```haskell
+```daml
 toAnyChoice : (HasTemplateTypeRep t, HasToAnyChoice t c r) => c -> AnyChoice
 ```
 
@@ -1928,7 +1918,7 @@ Only available for Daml-LF 1.7 or later.
 
 ### `fromAnyChoice`
 
-```haskell
+```daml
 fromAnyChoice : (HasTemplateTypeRep t, HasFromAnyChoice t c r) => AnyChoice -> Optional c
 ```
 
@@ -1940,43 +1930,12 @@ For example `fromAnyChoice @Account choice`.
 
 Only available for Daml-LF 1.7 or later.
 
-<span id="function-da-internal-template-functions-toanycontractkey-75916"></span>
-
-### `toAnyContractKey`
-
-```haskell
-toAnyContractKey : (HasTemplateTypeRep t, HasToAnyContractKey t k) => k -> AnyContractKey
-```
-
-Wrap a contract key in `AnyContractKey`.
-
-You must pass the template type `t` using an explicit type application.
-For example `toAnyContractKey @Proposal k`.
-
-Only available for Daml-LF 1.7 or later.
-
-<span id="function-da-internal-template-functions-fromanycontractkey-60533"></span>
-
-### `fromAnyContractKey`
-
-```haskell
-fromAnyContractKey : (HasTemplateTypeRep t, HasFromAnyContractKey t k) => AnyContractKey -> Optional k
-```
-
-Extract the underlying key from `AnyContractKey` if the template and
-choice types match, or return `None`.
-
-You must pass the template type `t` using an explicit type application.
-For example `fromAnyContractKey @Proposal k`.
-
-Only available for Daml-LF 1.7 or later.
-
 <span id="function-da-internal-template-functions-visiblebykey-51464"></span>
 
 ### `visibleByKey`
 
-```haskell
-visibleByKey : HasLookupByKey t k => k -> Update Bool
+```daml
+visibleByKey : (HasKey t k, HasLookupNByKey t k) => k -> Update Bool
 ```
 
 True if contract exists, submitter is a stakeholder, and all maintainers
@@ -2000,6 +1959,126 @@ Fails otherwise.
 - `instance Functor (Either e)`
 
 - `instance Ord a => Ord (Down a)`
+
+- `instance Serializable a => Serializable [a]`
+
+- `instance Serializable Int`
+
+- `instance Serializable Text`
+
+- `instance Serializable Bool`
+
+- `instance (Serializable a, Serializable b) => Serializable (Either a b)`
+
+- `instance Serializable Ordering`
+
+- `instance Serializable (Numeric 0)`
+
+- `instance Serializable (Numeric 1)`
+
+- `instance Serializable (Numeric 2)`
+
+- `instance Serializable (Numeric 3)`
+
+- `instance Serializable (Numeric 4)`
+
+- `instance Serializable (Numeric 5)`
+
+- `instance Serializable (Numeric 6)`
+
+- `instance Serializable (Numeric 7)`
+
+- `instance Serializable (Numeric 8)`
+
+- `instance Serializable (Numeric 9)`
+
+- `instance Serializable (Numeric 10)`
+
+- `instance Serializable (Numeric 11)`
+
+- `instance Serializable (Numeric 12)`
+
+- `instance Serializable (Numeric 13)`
+
+- `instance Serializable (Numeric 14)`
+
+- `instance Serializable (Numeric 15)`
+
+- `instance Serializable (Numeric 16)`
+
+- `instance Serializable (Numeric 17)`
+
+- `instance Serializable (Numeric 18)`
+
+- `instance Serializable (Numeric 19)`
+
+- `instance Serializable (Numeric 20)`
+
+- `instance Serializable (Numeric 21)`
+
+- `instance Serializable (Numeric 22)`
+
+- `instance Serializable (Numeric 23)`
+
+- `instance Serializable (Numeric 24)`
+
+- `instance Serializable (Numeric 25)`
+
+- `instance Serializable (Numeric 26)`
+
+- `instance Serializable (Numeric 27)`
+
+- `instance Serializable (Numeric 28)`
+
+- `instance Serializable (Numeric 29)`
+
+- `instance Serializable (Numeric 30)`
+
+- `instance Serializable (Numeric 31)`
+
+- `instance Serializable (Numeric 32)`
+
+- `instance Serializable (Numeric 33)`
+
+- `instance Serializable (Numeric 34)`
+
+- `instance Serializable (Numeric 35)`
+
+- `instance Serializable (Numeric 36)`
+
+- `instance Serializable (Numeric 37)`
+
+- `instance Serializable ()`
+
+- `instance (Serializable a, Serializable b) => Serializable (a, b)`
+
+- `instance (Serializable a, Serializable b, Serializable c) => Serializable (a, b, c)`
+
+- `instance (Serializable a, Serializable b, Serializable c, Serializable d) => Serializable (a, b, c, d)`
+
+- `instance (Serializable a, Serializable b, Serializable c, Serializable d, Serializable e) => Serializable (a, b, c, d, e)`
+
+- `instance Serializable (ContractId a)`
+
+- `instance Serializable a => Serializable (TextMap a)`
+
+- `instance (Serializable a, Serializable b) => Serializable (Map a b)`
+
+- `instance Serializable Time`
+
+- `instance Serializable Date`
+
+- `instance Serializable Party`
+
+- `instance Serializable GeneralError`
+
+- `instance Serializable AssertionFailed`
+
+- `instance Serializable PreconditionFailed`
+
+- `instance Serializable FailureCategory`
+
+- `instance Serializable FailureStatus`
 
 - `instance Ord TemplateTypeRep`
 

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1443,6 +1443,7 @@
                   "appdev/reference/daml-standard-library/da-action-state-class",
                   "appdev/reference/daml-standard-library/da-assert",
                   "appdev/reference/daml-standard-library/da-bifunctor",
+                  "appdev/reference/daml-standard-library/da-contractkeys",
                   "appdev/reference/daml-standard-library/da-crypto-text",
                   "appdev/reference/daml-standard-library/da-date",
                   "appdev/reference/daml-standard-library/da-either",


### PR DESCRIPTION
Updates the Daml Standard Library source pin to the latest DPM SDK version and regenerates the checked-in Daml Standard Library reference pages.

Version changes:
- Daml Standard Library publish_version: 3.4.11 -> 3.5.1

Validation run by the workflow:
- `npm run update:generated-reference-sources -- --source daml-standard-library`
- `npm run generate:daml-standard-library-reference`
- `git diff --check`
