### PR TITLE
docs: deduplicate localnet instructions, link to canonical page (#763)

### DIFF
--- a/docs-main/global-synchronizer/understand/local-testing.mdx
+++ b/docs-main/global-synchronizer/understand/local-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local Testing"
-description: "Docker-Compose based deployment of a local Canton Network for development and testing"
+description: "Using LocalNet for development and testing of Canton Network applications"
 ---
 
 import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash228 from "/snippets/internal/splice/main/splice-rst-code-docs-src-app-dev-testing-localnet-bash-228.mdx";
@@ -9,206 +9,10 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash190 from "
 import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash175 from "/snippets/internal/splice/main/splice-rst-code-docs-src-app-dev-testing-localnet-bash-175.mdx";
 import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash162 from "/snippets/internal/splice/main/splice-rst-code-docs-src-app-dev-testing-localnet-bash-162.mdx";
 import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetNone147 from "/snippets/internal/splice/main/splice-rst-code-docs-src-app-dev-testing-localnet-none-147.mdx";
-import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetNone126 from "/snippets/internal/splice/main/splice-rst-code-docs-src-app-dev-testing-localnet-none-126.mdx";
 
-{/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="a3270359" */}
+LocalNet provides a local Docker Compose-based Canton Network with three validators, a PostgreSQL database, and web applications (wallet, sv, scan). It is designed for development and testing and is not intended for production use.
 
-LocalNet provides a straightforward topology comprising three participants, three validators, a PostgreSQL database, and several web applications (wallet, sv, scan) behind an NGINX gateway. Each validator plays a distinct role within the Splice ecosystem:
-
-- **app-provider**: for the user operating their application
-- **app-user**: for a user wanting to use the app from the App Provider
-- **sv**: for providing the Global Synchronizer and handling AMT
-
-Designed primarily for development and testing, LocalNet is not intended for production use.
-
-## Setup
-
-{/* NETWORKVARS_START source="/snippets/networkvars/global-synchronizer/understand/local-testing-1.mdx" */}
-<Tabs>
-
-<Tab title="DevNet (0.6.8)">
-
-1.  Download the release artifacts from the <a href="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v0.6.8/0.6.8_splice-node.tar.gz">Download Bundle (DevNet 0.6.8)</a> link, and extract the bundle:
-
-    > ```bash
-    > tar xzvf 0.6.8_splice-node.tar.gz
-    > ```
-
-    The extracted docker compose files defining LocalNet are located in `splice-node/docker-compose/localnet`.
-
-2.  Export these two environment variables used in the later commands:
-
-    - **LOCALNET_DIR**: Specifies the path to the LocalNet directory.
-    - **IMAGE_TAG**: Specifies the version of Splice to be used in LocalNet.
-
-    For the bundle that you downloaded use:
-
-    > ```bash
-    > export LOCALNET_DIR=$PWD/splice-node/docker-compose/localnet
-    > export IMAGE_TAG=0.6.8
-    > ```
-
-3.  See `use-localnet` for the commands to start, stop, inspect, and administrate the LocalNet nodes.
-
-Optional: use the Docker Compose profiles (e.g., `--profile app-provider`) alongside the corresponding environment variables (e.g., `APP_PROVIDER_PROFILE=on/off`) to disable specific validator nodes; for example, to reduce the resource needs of LocalNet. By default, all three validators are active.
-
-Optional: use the following additional environment variables to configure:
-
-- **LOCALNET_DIR/compose.env**: Contains Docker Compose configuration variables.
-- **LOCALNET_ENV_DIR**: Overrides the default environment file directory. The default is `$LOCALNET_DIR/env`.
-- **LOCALNET_ENV_DIR/common.env**: Shared environment variables across Docker Compose and container configurations. It sets default ports, DB credentials, and Splice UI configurations.
-
-Resource constraints for containers can be configured via: - **LOCALNET_DIR/resource-constraints.yaml**
-
-</Tab>
-
-<Tab title="TestNet (0.6.7)">
-
-1.  Download the release artifacts from the <a href="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v0.6.7/0.6.7_splice-node.tar.gz">Download Bundle (TestNet 0.6.7)</a> link, and extract the bundle:
-
-    > ```bash
-    > tar xzvf 0.6.7_splice-node.tar.gz
-    > ```
-
-    The extracted docker compose files defining LocalNet are located in `splice-node/docker-compose/localnet`.
-
-2.  Export these two environment variables used in the later commands:
-
-    - **LOCALNET_DIR**: Specifies the path to the LocalNet directory.
-    - **IMAGE_TAG**: Specifies the version of Splice to be used in LocalNet.
-
-    For the bundle that you downloaded use:
-
-    > ```bash
-    > export LOCALNET_DIR=$PWD/splice-node/docker-compose/localnet
-    > export IMAGE_TAG=0.6.7
-    > ```
-
-3.  See `use-localnet` for the commands to start, stop, inspect, and administrate the LocalNet nodes.
-
-Optional: use the Docker Compose profiles (e.g., `--profile app-provider`) alongside the corresponding environment variables (e.g., `APP_PROVIDER_PROFILE=on/off`) to disable specific validator nodes; for example, to reduce the resource needs of LocalNet. By default, all three validators are active.
-
-Optional: use the following additional environment variables to configure:
-
-- **LOCALNET_DIR/compose.env**: Contains Docker Compose configuration variables.
-- **LOCALNET_ENV_DIR**: Overrides the default environment file directory. The default is `$LOCALNET_DIR/env`.
-- **LOCALNET_ENV_DIR/common.env**: Shared environment variables across Docker Compose and container configurations. It sets default ports, DB credentials, and Splice UI configurations.
-
-Resource constraints for containers can be configured via: - **LOCALNET_DIR/resource-constraints.yaml**
-
-</Tab>
-
-<Tab title="MainNet (0.6.6)">
-
-1.  Download the release artifacts from the <a href="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v0.6.6/0.6.6_splice-node.tar.gz">Download Bundle (MainNet 0.6.6)</a> link, and extract the bundle:
-
-    > ```bash
-    > tar xzvf 0.6.6_splice-node.tar.gz
-    > ```
-
-    The extracted docker compose files defining LocalNet are located in `splice-node/docker-compose/localnet`.
-
-2.  Export these two environment variables used in the later commands:
-
-    - **LOCALNET_DIR**: Specifies the path to the LocalNet directory.
-    - **IMAGE_TAG**: Specifies the version of Splice to be used in LocalNet.
-
-    For the bundle that you downloaded use:
-
-    > ```bash
-    > export LOCALNET_DIR=$PWD/splice-node/docker-compose/localnet
-    > export IMAGE_TAG=0.6.6
-    > ```
-
-3.  See `use-localnet` for the commands to start, stop, inspect, and administrate the LocalNet nodes.
-
-Optional: use the Docker Compose profiles (e.g., `--profile app-provider`) alongside the corresponding environment variables (e.g., `APP_PROVIDER_PROFILE=on/off`) to disable specific validator nodes; for example, to reduce the resource needs of LocalNet. By default, all three validators are active.
-
-Optional: use the following additional environment variables to configure:
-
-- **LOCALNET_DIR/compose.env**: Contains Docker Compose configuration variables.
-- **LOCALNET_ENV_DIR**: Overrides the default environment file directory. The default is `$LOCALNET_DIR/env`.
-- **LOCALNET_ENV_DIR/common.env**: Shared environment variables across Docker Compose and container configurations. It sets default ports, DB credentials, and Splice UI configurations.
-
-Resource constraints for containers can be configured via: - **LOCALNET_DIR/resource-constraints.yaml**
-
-</Tab>
-
-</Tabs>
-{/* NETWORKVARS_END */}
-
-## Exposed Ports
-
-The following section details the ports used by various services. The default database port is **DB_PORT=5432**.
-
-Other ports are generated using specific patterns based on the validator:
-
-- For the Super Validator (sv), the port is specified as `4${PORT_SUFFIX}`.
-- For the App Provider, the port is specified as `3${PORT_SUFFIX}`.
-- For the App User, the port is specified as `2${PORT_SUFFIX}`.
-
-These patterns apply to the following ports suffixes:
-
-- **PARTICIPANT_LEDGER_API_PORT_SUFFIX**: 901
-- **PARTICIPANT_ADMIN_API_PORT_SUFFIX**: 902
-- **PARTICIPANT_JSON_API_PORT_SUFFIX**: 975
-- **VALIDATOR_ADMIN_API_PORT_SUFFIX**: 903
-- **CANTON_HTTP_HEALTHCHECK_PORT_SUFFIX**: 900
-- **CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX**: 961
-
-UI Ports are defined as follows:
-
-- **APP_USER_UI_PORT**: 2000
-- **APP_PROVIDER_UI_PORT**: 3000
-- **SV_UI_PORT**: 4000
-
-## Database
-
-LocalNet uses a single PostgreSQL database for all components. Database configurations are sourced from `LOCALNET_ENV_DIR/postgres.env`.
-
-## Application UIs
-
-- **App User Wallet UI**
-
-  > - **URL**: [http://wallet.localhost:2000](http://wallet.localhost:2000)
-  > - **Description**: Interface for managing user wallets.
-
-- **App Provider Wallet UI**
-
-  > - **URL**: [http://wallet.localhost:3000](http://wallet.localhost:3000)
-  > - **Description**: Interface for managing user wallets.
-
-- **Super Validator Web UI**
-
-  > - **URL**: [http://sv.localhost:4000](http://sv.localhost:4000)
-  > - **Description**: Interface for super validator functionalities.
-
-- **Scan Web UI**
-
-  > - **URL**: [http://scan.localhost:4000](http://scan.localhost:4000)
-  > - **Description**: Interface to monitor transactions.
-
-<Note>
-`LocalNet` rounds may take up to 6 rounds (equivalent to one hour) to display in the scan UI.
-</Note>
-
-In most scenarios, the `*.localhost` domains (e.g., `http://scan.localhost`) will resolve to your local host IP `127.0.0.1`. There are some situations where the resolution does not occur and the solution is to add entries to your `/etc/hosts` file. For example, to resolve `http://scan.localhost` and `http://wallet.localhost` add these entry to the file:
-
-<ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetNone126 />
-
-## Default Wallet Users
-
-- **App User**: app-user
-- **App Provider**: app-provider
-- **SV**: sv
-
-## Swagger UI
-
-When the `swagger-ui` profile is enabled, the Swagger UI for the `JSON Ledger API HTTP Endpoints` across all running participants is available at [http://localhost:9090](http://localhost:9090). Note: Some endpoints require a JWT token when using the **Try it out** feature. One method to obtain this token is via the Canton Console. Start the Canton Console `make canton-console` and execute the following command:
-
-<ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetNone147 />
-
-For proper functionality, Swagger UI relies on a localhost nginx proxy for `canton.localhost` configured for each participant. For example, the `JSON Ledger API HTTP Endpoints` for the app-provider can be accessed at the nginx proxy URL `http://canton.localhost:${APP_PROVIDER_UI_PORT}` via Swagger UI, which corresponds to accessing `localhost:3${PARTICIPANT_JSON_API_PORT}` directly. The nginx proxy only adds additional headers to resolve CORS issues within Swagger UI.
+For setup instructions, network topology, port conventions, configuration options, and a comparison with Sandbox, see the [LocalNet](/sdks-tools/development-tools/localnet) page.
 
 ## Use LocalNet
 
@@ -220,15 +24,15 @@ For proper functionality, Swagger UI relies on a localhost nginx proxy for `cant
 
 <ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash175 />
 
-### Start nodes including a swagger-ui
+### Start nodes including swagger-ui
 
-See `swagger-ui` for more information.
+See [Swagger UI](#swagger-ui) for more information.
 
 <ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash190 />
 
-### Stop nodes including a swagger-ui
+### Stop nodes including swagger-ui
 
-See `swagger-ui` for more information.
+See [Swagger UI](#swagger-ui) for more information.
 
 <ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash206 />
 
@@ -241,24 +45,14 @@ Use the Canton Admin Console to inspect and modify the run configuration of the 
 
 <ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetBash228 />
 
-## Multiple Synchronizers
+## Swagger UI
 
-LocalNet supports running multiple synchronizers side by side.
+When the `swagger-ui` profile is enabled, the Swagger UI for the JSON Ledger API HTTP Endpoints across all running participants is available at [http://localhost:9090](http://localhost:9090).
 
-By default, a single synchronizer controlled by the Super Validator (sv) is active. This synchronizer simulates the **Global Synchronizer**.
+<Note>
+Some endpoints require a JWT token when using the **Try it out** feature. One method to obtain this token is via the Canton Console. Start the Canton Console `make canton-console` and execute the following command:
+</Note>
 
-To enable a second synchronizer called `app-synchronizer`, start LocalNet with the `multi-sync` Docker Compose profile (`--profile multi-sync`). The additional synchronizer has the following characteristics:
+<ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetNone147 />
 
-- It is managed by the `app-sequencer` and `app-mediator` nodes.
-- It simulates a **private synchronizer**.
-- Both the `app-provider` and `app-user` participants are cross-connected to the Global Synchronizer and the `app-synchronizer`.
-
-## Using Non-Default Protocol Versions
-
-The protocol version used in the LocalNet synchronizer and participants can be configured by setting the `CANTON_PROTOCOL_VERSION` environment variable to the required version prior to launching LocalNet. Non-stable protocol versions can be used for early testing, but require explicit opt-in. To enable that, export also a `ALPHA_PROTOCOL_VERSION_ENV=$LOCALNET_DIR/env/alpha-protocol-version.env` environment variable.
-
-<Warning>
-Non-stable protocol versions are unreleased versions that are under development, and are subject to announced breaking changes. One implication of this is that this environment usually cannot be upgraded, and will therefore require a full reset for every change. Use only for early testing and development purposes.
-</Warning>
-
-{/* COPIED_END */}
+For proper functionality, Swagger UI relies on a localhost nginx proxy for `canton.localhost` configured for each participant. For example, the JSON Ledger API HTTP Endpoints for the app-provider can be accessed at the nginx proxy URL `http://canton.localhost:${APP_PROVIDER_UI_PORT}` via Swagger UI, which corresponds to accessing `localhost:3${PARTICIPANT_JSON_API_PORT}` directly. The nginx proxy only adds additional headers to resolve CORS issues within Swagger UI.


### PR DESCRIPTION
Remove duplicated COPIED_START blocks from local-testing.mdx that are already present in the canonical /sdks-tools/development-tools/localnet page (intro, setup tabs, ports, UIs, hosts file, users, multiple synchronizers, non-default protocol versions).

Keep testing-specific content: use-localnet commands, swagger-ui, and canton console access. Add a link to the canonical LocalNet page for setup, topology, and configuration options.

Fixes #763