### PR TITLE
Fix inaccuracies identified in documentation review pass

### DIFF
--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -7,7 +7,7 @@ description: "The Canton Network Token Standard APIs and Daml interfaces"
 
 ## Overview
 
-- See the [text of the CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) for an overview of the APIs that are part of the Canton Network Token Standard.
+- See the [text of the CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) for an overview of the APIs that are part of the Canton Network Token Standard.
 - See the [README in its source-code](https://github.com/canton-network/splice/tree/main/token-standard#readme) for background on how to use the APIs.
 
 ## Holding UTXO Management
@@ -262,7 +262,7 @@ Example code: [Token Standard CLI's code to create a transfer via TransferFactor
 To execute a choice via a Token Standard factory, first you need need to fetch the factory from the corresponding registry.
 
 <Note>
-The mapping from an instrument's `admin` party-id to the corresponding registry URL needs to be maintained currently by wallets themselves, until a generic solution ([likely based on CNS](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#off-ledger-api-discovery-and-access)) is implemented.
+The mapping from an instrument's `admin` party-id to the corresponding registry URL needs to be maintained currently by wallets themselves, until a generic solution ([likely based on CNS](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md#off-ledger-api-discovery-and-access)) is implemented.
 </Note>
 
 The registry will return the relevant factory in the corresponding endpoint:
@@ -323,7 +323,7 @@ Splice releases the optional `splice-util-token-standard-wallet.dar` file, which
 
 ## API References
 
-Refer to [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#details) for more context on the APIs.
+Refer to [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md#details) for more context on the APIs.
 
 ### Token Metadata
 
@@ -332,20 +332,20 @@ Refer to [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/
 
 ### Holding
 
-This allows implementation of a [Portfolio View](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#wallet-client--portfolio-view).
+This allows implementation of a [Portfolio View](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md#wallet-client--portfolio-view).
 
 - Daml reference: [splice-api-token-holding-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1)
 
 ### Transfer Instruction
 
-This allows implementation of [Direct Peer-to-Peer / Free of Payment (FOP) Transfers](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#direct-peer-to-peer--free-of-payment-fop-transfer-workflow).
+This allows implementation of [Direct Peer-to-Peer / Free of Payment (FOP) Transfers](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md#direct-peer-to-peer--free-of-payment-fop-transfer-workflow).
 
 - Daml reference: [splice-api-token-transfer-instruction-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1)
 - OpenAPI reference: [Transfer Instruction API](/reference/splice-transfer-instruction-api/registrytransfer-instructionv1transfer-factory)
 
 ### Allocation
 
-This allows implementation of [Delivery versus Payment (DVP) Transfer Workflows](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#delivery-versus-payment-dvp-transfer-workflows), jointly with the Allocation Instruction and Allocation Request APIs below.
+This allows implementation of [Delivery versus Payment (DVP) Transfer Workflows](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md#delivery-versus-payment-dvp-transfer-workflows), jointly with the Allocation Instruction and Allocation Request APIs below.
 
 - Daml reference: [splice-api-token-allocation-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1)
 - OpenAPI reference: [Allocation API](/reference/splice-allocation-api/registryallocationsv1-choice-contextsexecute-transfer)

--- a/docs-main/appdev/get-started/whats-new.mdx
+++ b/docs-main/appdev/get-started/whats-new.mdx
@@ -8,7 +8,7 @@ For changes shipping in each component, see the corresponding release notes:
 - **Splice and the Global Synchronizer** — [Splice release notes](/global-synchronizer/release-notes/splice), [release history](/global-synchronizer/release-notes/release-history), [weekly patch releases](/global-synchronizer/release-notes/weekly-patch-releases)
 - **Wallet SDK** — [Wallet SDK release notes](/integrations/release-notes/wallet-sdk)
 - **Canton and Daml SDK** — [Canton release notes](/global-synchronizer/release-notes/canton)
-- **CIPs** — [Canton Improvement Proposals](https://github.com/global-synchronizer-foundation/cips)
+- **CIPs** — [Canton Improvement Proposals](https://github.com/canton-foundation/cips)
 
 ## Version compatibility
 

--- a/docs-main/appdev/modules/m2-canton-for-ethereum-devs.mdx
+++ b/docs-main/appdev/modules/m2-canton-for-ethereum-devs.mdx
@@ -167,7 +167,7 @@ Canton has equivalent tooling for most Ethereum development workflows.
 | Remix | VS Code + Daml Extension | IDE with language support |
 | MetaMask | Wallet SDK | User wallet integration |
 | Web3.js / ethers.js | Ledger API (gRPC/JSON) | Application integration |
-| ERC standards | CIPs | [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) (tokens), [CIP-0103](https://github.com/mjuchli-da/cips/blob/cip-dapp-standard/cip-0103/cip-0103.md) (dApp standard) |
+| ERC standards | CIPs | [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) (tokens), [CIP-0103](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0103/cip-0103.md) (dApp standard) |
 
 ## Multi-Party Workflows
 

--- a/docs-main/appdev/modules/m2-canton-for-ethereum-devs.mdx
+++ b/docs-main/appdev/modules/m2-canton-for-ethereum-devs.mdx
@@ -167,7 +167,7 @@ Canton has equivalent tooling for most Ethereum development workflows.
 | Remix | VS Code + Daml Extension | IDE with language support |
 | MetaMask | Wallet SDK | User wallet integration |
 | Web3.js / ethers.js | Ledger API (gRPC/JSON) | Application integration |
-| ERC standards | CIPs | [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) (tokens), [CIP-0103](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0103/cip-0103.md) (dApp standard) |
+| ERC standards | CIPs | [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) (tokens), [CIP-0103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md) (dApp standard) |
 
 ## Multi-Party Workflows
 

--- a/docs-main/appdev/modules/m2-concept-translation.mdx
+++ b/docs-main/appdev/modules/m2-concept-translation.mdx
@@ -178,7 +178,7 @@ function transfer(address to, uint256 amount) public {
 
 | Ethereum Pattern | Canton Equivalent |
 |------------------|-------------------|
-| **ERC-20** | Token Standard ([CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)) |
+| **ERC-20** | Token Standard ([CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)) |
 | **ERC-721/ERC-1155** | dApp Standard ([CIP-0103](https://github.com/mjuchli-da/cips/blob/cip-dapp-standard/cip-0103/cip-0103.md)) |
 | **Proxy pattern** | Smart Contract Upgrade (SCU) |
 | **Factory pattern** | Template instantiation |

--- a/docs-main/appdev/modules/m2-smart-contract-paradigm.mdx
+++ b/docs-main/appdev/modules/m2-smart-contract-paradigm.mdx
@@ -185,7 +185,7 @@ contract MultiSig {
 |------------------|-----------------|
 | **Ownable** | Signatory declaration |
 | **Pausable** | Contract archival + recreation |
-| **ERC-20** | Token Standard ([CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)) |
+| **ERC-20** | Token Standard ([CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)) |
 | **Proxy/Upgradeable** | Smart Contract Upgrade (SCU) |
 | **Pull payment** | Propose/accept pattern |
 | **Factory** | Template + create |

--- a/docs-main/appdev/modules/m3-interfaces.mdx
+++ b/docs-main/appdev/modules/m3-interfaces.mdx
@@ -305,7 +305,7 @@ For context, a simple template definition:
 
 Interfaces are central to interoperability across the Canton Network. Two Canton Improvement Proposals (CIPs) define standard interfaces that app developers should be aware of:
 
-- [CIP-0056 — Token Standard](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md): Defines a standard interface for fungible tokens on Canton Network. If your application issues or transfers tokens, implementing this interface ensures compatibility with wallets and other applications in the ecosystem.
+- [CIP-0056 — Token Standard](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md): Defines a standard interface for fungible tokens on Canton Network. If your application issues or transfers tokens, implementing this interface ensures compatibility with wallets and other applications in the ecosystem.
 
 - [CIP-0103 — dApp Standard](https://github.com/mjuchli-da/cips/blob/cip-dapp-standard/cip-0103/cip-0103.md): Defines standard interfaces for decentralized applications. This CIP is particularly relevant for developers coming from Ethereum, as it maps familiar ERC-style patterns to Daml interfaces.
 

--- a/docs-main/appdev/modules/m4-featured-app-activity-marker.mdx
+++ b/docs-main/appdev/modules/m4-featured-app-activity-marker.mdx
@@ -15,7 +15,7 @@ When your application runs on Canton Network, economically meaningful events can
 
 A `FeaturedAppActivityMarker` records a specific activity event in your application. It signals to the network that something economically relevant happened -- for example, a real-world asset was locked, a token was minted, or a license was renewed.
 
-After [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md), only **featured** apps receive rewards. Unfeatured apps can still create markers, but they will not generate reward coupons.
+After [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md), only **featured** apps receive rewards. Unfeatured apps can still create markers, but they will not generate reward coupons.
 
 ## When to Create Markers
 
@@ -29,7 +29,7 @@ Beyond the basics above, other examples of appropriate markers include settling 
 
 ## How to Create Markers
 
-The `FeaturedAppActivityMarker` contract is specified in [CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md). Your Daml code creates the marker as part of the transaction that performs the economically meaningful action.
+The `FeaturedAppActivityMarker` contract is specified in [CIP-0047](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md). Your Daml code creates the marker as part of the transaction that performs the economically meaningful action.
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="f4ed8911" */}
 
@@ -37,13 +37,13 @@ The `FeaturedAppActivityMarker` contract is specified in [CIP-0047](https://gith
 
 {/* COPIED_END */}
 
-The marker contract includes fields that identify your application, the type of activity, and metadata about the event. Refer to [CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) for the exact contract interface and required fields.
+The marker contract includes fields that identify your application, the type of activity, and metadata about the event. Refer to [CIP-0047](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md) for the exact contract interface and required fields.
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="f4ed8911" */}
 
-The *featured application activity marker* is specified in [CIP 47](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md). A summary follows.
+The *featured application activity marker* is specified in [CIP 47](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md). A summary follows.
 
-Featured application activity markers (FeaturedAppActivityMarker) can be created for a transaction that adds value but does not involve a CC Transfer (e.g., a stable coin transfer or the settlement of a trade). [CIP 47](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) says:
+Featured application activity markers (FeaturedAppActivityMarker) can be created for a transaction that adds value but does not involve a CC Transfer (e.g., a stable coin transfer or the settlement of a trade). [CIP 47](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md) says:
 
 > Featured application providers are expected to create featured application activity markers only for transactions that correspond to a transfer of an asset, or an equivalent transaction, which was enabled by the application provider. The detailed fair usage policy and enforcement thereof is left up to the Tokenomics Committee of the Canton Foundation (CF).
 
@@ -157,6 +157,6 @@ This local testing loop lets you validate your marker creation logic before depl
 ## Further Reading
 
 - [Canton Coin and Traffic](/appdev/modules/m4-canton-coin) -- How CC rewards relate to traffic and transaction costs
-- [CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) -- The specification for FeaturedAppActivityMarker
-- [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) -- The change restricting rewards to featured apps
+- [CIP-0047](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md) -- The specification for FeaturedAppActivityMarker
+- [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) -- The change restricting rewards to featured apps
 - [Deployment Progression](/appdev/modules/m5-deployment-progression) -- Moving from LocalNet to DevNet to MainNet

--- a/docs-main/appdev/modules/m4-sdks-apis.mdx
+++ b/docs-main/appdev/modules/m4-sdks-apis.mdx
@@ -9,7 +9,7 @@ import DamlDocsAppdevModulesM4SdksApisL39 from "/snippets/daml-docs/appdev_modul
 
 Canton provides a set of tools and APIs for building applications against the ledger. This page covers what each component does and when to use it.
 
-## Canton SDK
+## Daml SDK
 
 The Daml SDK bundles the compiler, code generators, sandbox, and supporting tools you need to develop Canton applications. The main entry point is the `dpm` command-line tool.
 

--- a/docs-main/appdev/modules/m7-canton-coin-preapprovals.mdx
+++ b/docs-main/appdev/modules/m7-canton-coin-preapprovals.mdx
@@ -49,7 +49,7 @@ There is currently no support for this in the splice wallet UI but for preapprov
 
 The splice wallet UI will automatically default to using a preapproval for a transfer if the receiver has one setup.
 
-If you are working through APIs instead, in particular for external parties, the preferred way of exercising a Canton Coin transfer is through the Token Standard APIs which will also use a preapproval where possible. Refer to the [CIP](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) and the [token standard reference CLI](https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/transfer.ts) for examples of how to use it.
+If you are working through APIs instead, in particular for external parties, the preferred way of exercising a Canton Coin transfer is through the Token Standard APIs which will also use a preapproval where possible. Refer to the [CIP](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) and the [token standard reference CLI](https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/transfer.ts) for examples of how to use it.
 
 Lastly, the legacy external signing APIs for non-standard Canton Coin transfers on the validator `/v0/admin/external-party/transfer-preapproval/prepare-send` and `/v0/admin/external-party/transfer-preapproval/submit-send` can also be used. Refer to the API docs for details.
 

--- a/docs-main/global-synchronizer/deployment/sv-operations.mdx
+++ b/docs-main/global-synchronizer/deployment/sv-operations.mdx
@@ -95,7 +95,7 @@ SVs are responsible for deciding on suitable synchronizer traffic parameters. In
 
 ### Determining the cost of a single CC transfer
 
-As per Canton Improvement Proposal [cip-0042](https://github.com/global-synchronizer-foundation/cips), the `extraTrafficPrice` should be set so that the cost of a standard CC transfer is 1 USD. Actual traffic costs change depending on factors such as the size of the DSO (number of SVs) and the Canton protocol version (so can change also on protocol upgrades). It is therefore recommended for SVs to measure current costs periodically and adjust traffic parameters accordingly.
+As per Canton Improvement Proposal [cip-0042](https://github.com/canton-foundation/cips), the `extraTrafficPrice` should be set so that the cost of a standard CC transfer is 1 USD. Actual traffic costs change depending on factors such as the size of the DSO (number of SVs) and the Canton protocol version (so can change also on protocol upgrades). It is therefore recommended for SVs to measure current costs periodically and adjust traffic parameters accordingly.
 
 One way to determine the current traffic consumption (in bytes) of a CC transfer is to initiate a CC transfer and observe sequencer logs corresponding to it. Based on the assumption that TestNet has the same configuration and DSO size as MainNet, it is sufficient to conduct this measurement on TestNet. The suggested specific steps are as follows:
 
@@ -209,7 +209,7 @@ Based on that:
 
 ## Determining expired SV rewards for CIP-66 flows
 
-SVs need, in the context of [CIP-0066 - Mint Canton Coin from Unminted/Unclaimed Pool](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0066/cip-0066.md), to determine the total amount of SV rewards that were never claimed and therefore expired within a specific time range. These expired rewards form the basis for the amount that may later be minted from the unclaimed rewards pool through the CIP-66 governance process.
+SVs need, in the context of [CIP-0066 - Mint Canton Coin from Unminted/Unclaimed Pool](https://github.com/canton-foundation/cips/blob/main/cip-0066/cip-0066.md), to determine the total amount of SV rewards that were never claimed and therefore expired within a specific time range. These expired rewards form the basis for the amount that may later be minted from the unclaimed rewards pool through the CIP-66 governance process.
 
 The `unclaimed_sv_rewards.py` utility analyzes the transaction log exposed through the Splice Scan API and identifies all reward coupons issued for a beneficiary that subsequently expired within the configured interval. It then aggregates the corresponding reward amounts to produce the total expired amount relevant for CIP-66 calculations.
 

--- a/docs-main/global-synchronizer/release-notes/release-history.mdx
+++ b/docs-main/global-synchronizer/release-notes/release-history.mdx
@@ -7,7 +7,7 @@ This page provides a high-level overview of all Global Synchronizer software rel
 
 ## Splice 0.5.x (Canton 3.4.x)
 
-The 0.5.x series runs on Canton protocol version 34 and was introduced through [CIP-0089](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0089/cip-0089.md), which required a synchronizer migration with downtime.
+The 0.5.x series runs on Canton protocol version 34 and was introduced through [CIP-0089](https://github.com/canton-foundation/cips/blob/main/cip-0089/cip-0089.md), which required a synchronizer migration with downtime.
 
 | Version | Key changes |
 |---|---|
@@ -23,7 +23,7 @@ The 0.5.x series runs on Canton protocol version 34 and was introduced through [
 
 ## Splice 0.4.x (Canton 3.3.x)
 
-The 0.4.x series runs on Canton protocol version 33. It introduced the Token Standard ([CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)), holding UTXO management, and the featured app activity markers API.
+The 0.4.x series runs on Canton protocol version 33. It introduced the Token Standard ([CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)), holding UTXO management, and the featured app activity markers API.
 
 | Version | Key changes |
 |---|---|

--- a/docs-main/global-synchronizer/release-notes/splice.mdx
+++ b/docs-main/global-synchronizer/release-notes/splice.mdx
@@ -571,7 +571,7 @@ Note: 0.6.0 was skipped as it introduced a regression where the SV UI governance
   No change is required for apps that build against the `token_standard` or `featured_app_activity_markers_api`.
 
 
-  - Restrict `AmuletConfig` to not allow fees as part of [CIP 107](https://github.com/canton-foundation/cips/blob/main/cip-0107/cip-0107.md). This has no functional effect as [CIP 78](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) set the fees to zero already.
+  - Restrict `AmuletConfig` to not allow fees as part of [CIP 107](https://github.com/canton-foundation/cips/blob/main/cip-0107/cip-0107.md). This has no functional effect as [CIP 78](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) set the fees to zero already.
 
     This also disables the choice `AmuletRules_ComputeFees` as it always returned 0. Application providers that statically link against `splice-amulet` will need to remove usages of this choice when recompiling against the new `splice-amulet` version.
 
@@ -830,7 +830,7 @@ Validator node operators are not affected by this requirement, as the change onl
   - `canton.scan-apps.scan-app.acs-store-descriptor-user-version` and `canton.scan-apps.scan-app.tx-log-store-descriptor-user-version` configuration settings have been added to set a `user-version`, respectively for the ACS and TxLog store. Modifying the `user-version` wipes the respective store and triggers re-ingestion. See the SV Operations docs for more details.
   - Added a new external endpoint `GET /v0/unclaimed-development-fund-coupons` to retrieve all active unclaimed development fund coupon contracts.
 - Daml
-  - Implement minting delegation described as part of [CIP-0073 - Weighted Validator Liveness Rewards for SV-Chosen Parties](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md). See the minting delegations section for details.
+  - Implement minting delegation described as part of [CIP-0073 - Weighted Validator Liveness Rewards for SV-Chosen Parties](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md). See the minting delegations section for details.
 
     - New templates have been added in the `splice-wallet` package:
       - **MintingDelegationProposal**: Represents a proposal from beneficiary to the delegate to create a `MintingDelegation`.
@@ -892,7 +892,7 @@ Daml:
 > - Sequencer connections
 > - Fixed an issue in the sequencer connection logic in splice 0.5.6 that resulted in participants randomly crashing and restarting.
 > - Daml
-> - Implement Daml changes for [CIP-0082 - Establish a 5% Development Fund (Foundation-Governed)](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0082/cip-0082.md):
+> - Implement Daml changes for [CIP-0082 - Establish a 5% Development Fund (Foundation-Governed)](https://github.com/canton-foundation/cips/blob/main/cip-0082/cip-0082.md):
 >
 > > - New templates:
 > >   - **UnclaimedDevelopmentFundCoupon**: Represents unallocated Development Fund entitlements created per issuance round. Coupons are owned by the DSO, have no expiry, and serve as accounting instruments. ACS size is managed through merging rather than expiration.
@@ -1011,7 +1011,7 @@ Note: 0.5.2 mistakingly introduced default pruning for Canton participants and s
 ## 0.5.0
 
 <Warning>
-Upgrade to Canton 3.4: This upgrade requires a Synchronizer Migration with Downtime and cannot be applied through a regular upgrade. For details refer to the approved [CIP](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0089/cip-0089.md) as well as the respective documentation pages for validators and SVs.
+Upgrade to Canton 3.4: This upgrade requires a Synchronizer Migration with Downtime and cannot be applied through a regular upgrade. For details refer to the approved [CIP](https://github.com/canton-foundation/cips/blob/main/cip-0089/cip-0089.md) as well as the respective documentation pages for validators and SVs.
 </Warning>
 
 - Deployment
@@ -1060,7 +1060,7 @@ Note: 0.4.24 was published incorrectly and should be skipped in favor of 0.4.25.
 ## 0.4.22
 
 - SV
-  - Improve throughput of `FeaturedAppActivityMarkerTrigger`, which converts `FeaturedAppActivityMarker` contracts to `AppRewardCoupon` contracts as described in [CIP-0047 Featured App Activity Markers](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md). The new implementation uses larger batches (100 markers by default, instead of 5) and parallelizes their execution (by default up to 4x). The work is split between different SVs in a way that completely avoids contention when there are not too many (by default 10k) markers, and that minimizes contention using random sampling of batches when the automation is in catchup mode because there are too many markers. Catchup mode only triggers when one or more of the SVs failed to convert the markers assigned to them for too long.
+  - Improve throughput of `FeaturedAppActivityMarkerTrigger`, which converts `FeaturedAppActivityMarker` contracts to `AppRewardCoupon` contracts as described in [CIP-0047 Featured App Activity Markers](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md). The new implementation uses larger batches (100 markers by default, instead of 5) and parallelizes their execution (by default up to 4x). The work is split between different SVs in a way that completely avoids contention when there are not too many (by default 10k) markers, and that minimizes contention using random sampling of batches when the automation is in catchup mode because there are too many markers. Catchup mode only triggers when one or more of the SVs failed to convert the markers assigned to them for too long.
 
 ## 0.4.21
 
@@ -1111,7 +1111,7 @@ Note: 0.4.24 was published incorrectly and should be skipped in favor of 0.4.25.
 >   - Deployment
 >     - Remove CPU limits from the helm charts for `scan`, `mediator` and `sequencer` apps. This should avoid issues with cpu scheduling that might lead to performance degradations.
 >   - UI
->     - When updating the `AmuletRules` config, the UI will omit any transfer fee steps with value zero from the `AmuletRules` config stored on-ledger. Thereby making the `AmuletRules` contract smaller and saving traffic for transactions using it. This is motivated by [CIP-0078 CC Fee Removal](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) .
+>     - When updating the `AmuletRules` config, the UI will omit any transfer fee steps with value zero from the `AmuletRules` config stored on-ledger. Thereby making the `AmuletRules` contract smaller and saving traffic for transactions using it. This is motivated by [CIP-0078 CC Fee Removal](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) .
 >
 > - Canton and SDK:
 >
@@ -1124,7 +1124,7 @@ Note: 0.4.24 was published incorrectly and should be skipped in favor of 0.4.25.
 > - Daml
 >   - release `splice-util-featured-app-proxies-1.1.0` with support for a `WalletUserProxy`, which simplifies the creation of featured app activity markers for wallet app providers when their users engage in token standard workflows.
 >
->   - Implement Daml changes for [CIP-0079 - Demonstrate Third-Party Price Feed Integration for CC Listing](https://github.com/global-synchronizer-foundation/cips/pull/101/files):
+>   - Implement Daml changes for [CIP-0079 - Demonstrate Third-Party Price Feed Integration for CC Listing](https://github.com/canton-foundation/cips/pull/101/files):
 >
 >     > These Daml changes require an upgrade to the following Daml versions:
 >     >
@@ -1158,7 +1158,7 @@ Note: 0.4.24 was published incorrectly and should be skipped in favor of 0.4.25.
 </Warning>
 
 - Daml
-  - Implement Daml changes for [CIP-0078 - CC Fee Removal](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md):
+  - Implement Daml changes for [CIP-0078 - CC Fee Removal](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md):
 
     > - Change all Amulet transfers to not charge holding fees on inputs.
     > - Fix a bug in the `ensure` clause of `AmuletRules` that prevented setting the Amulet transfer fees to zero.
@@ -1289,7 +1289,7 @@ Note: 0.4.24 was published incorrectly and should be skipped in favor of 0.4.25.
 - Daml
   - Deprecate Daml choices related to DSO delegate elections.
 
-  - Implements [CIP-0068 - Bootstrap network from non-zero round](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0068/cip-0068.md) Now the first SV can specify a non-zero initial round that can be used on network initialization or resets.
+  - Implements [CIP-0068 - Bootstrap network from non-zero round](https://github.com/canton-foundation/cips/blob/main/cip-0068/cip-0068.md) Now the first SV can specify a non-zero initial round that can be used on network initialization or resets.
 
     > These Daml changes requires an upgrade to the following Daml versions:
     >
@@ -1436,7 +1436,7 @@ Note: 0.4.6 had a bug and should be skipped in favor of 0.4.7 which fixed a bug 
 
   This release contains two sets of Daml changes that build upon each other:
 
-  1.  Implement [CIP-0064 - Delegateless Automation](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0064/cip-0064.md)
+  1.  Implement [CIP-0064 - Delegateless Automation](https://github.com/canton-foundation/cips/blob/main/cip-0064/cip-0064.md)
 
       These Daml changes requires an upgrade to the following Daml versions:
 
@@ -1449,7 +1449,7 @@ Note: 0.4.6 had a bug and should be skipped in favor of 0.4.7 which fixed a bug 
       | wallet             | 0.1.9   |
       | walletPayments     | 0.1.9   |
 
-  2.  Implement [CIP-0066 - Mint Canton Coin from Unminted/Unclaimed Pool](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0066/cip-0066.md) and fix security issues and suggestions raised by Quantstamp as part of their [audit of the Splice codebase](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0057/cip-0057.md#abstract). Note that the backend and frontend changes from CIP 66 are not yet implemented so we recommend holding off on upgrading to the new Daml models for now.
+  2.  Implement [CIP-0066 - Mint Canton Coin from Unminted/Unclaimed Pool](https://github.com/canton-foundation/cips/blob/main/cip-0066/cip-0066.md) and fix security issues and suggestions raised by Quantstamp as part of their [audit of the Splice codebase](https://github.com/canton-foundation/cips/blob/main/cip-0057/cip-0057.md#abstract). Note that the backend and frontend changes from CIP 66 are not yet implemented so we recommend holding off on upgrading to the new Daml models for now.
 
       > - CC-1 (low severity): addressed by rate limiting every SV wrt casting votes on a `VoteRequest` and updating their `AmuletPriceVote` to defend against them causing undue contention, which would block other SVs from voting, closing the vote, or advancing the mining rounds.
       >
@@ -1567,11 +1567,11 @@ Note: 0.4.6 had a bug and should be skipped in favor of 0.4.7 which fixed a bug 
 ## 0.4.0
 
 <Warning>
-- Upgrade to Canton 3.3: This upgrade requires a Hard Synchronizer migration and cannot be applied through a regular helm upgrade. For details refer to the [CIP draft](https://github.com/global-synchronizer-foundation/cips/pull/66).
+- Upgrade to Canton 3.3: This upgrade requires a Hard Synchronizer migration and cannot be applied through a regular helm upgrade. For details refer to the [CIP draft](https://github.com/canton-foundation/cips/pull/66).
 </Warning>
 
 - Daml
-  - Implement [CIP 47](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) and [CIP 56](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md).
+  - Implement [CIP 47](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md) and [CIP 56](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md).
 
     This requires an upgrade to the following Daml versions:
 
@@ -1639,7 +1639,7 @@ Note: 0.4.6 had a bug and should be skipped in favor of 0.4.7 which fixed a bug 
 
   - The `splice-util-lib`\` helm chart is no longer published. The library has always been packaged with every helm chart that uses it, there is no need to pull it separately from the ghcr.io container registry.
 
-- Implement [Canton Improvement Proposal cip-0051](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0051/cip-0051.md)
+- Implement [Canton Improvement Proposal cip-0051](https://github.com/canton-foundation/cips/blob/main/cip-0051/cip-0051.md)
 
   > - Added the optional `targetEffectiveAt` field to the `VoteRequest` template, which allows specifying an effective date and time for the vote request. Additionally, the `DsoRules_CloseVoteRequest` now enforces the new semantics for vote requests that include an effective date and time.
   >

--- a/docs-main/global-synchronizer/splice-fundamentals/sv-live-tokenomics.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/sv-live-tokenomics.mdx
@@ -7,7 +7,7 @@ description: "How Super Validator nodes earn and distribute Canton Coin rewards"
 
 Each Super Validator, in each round, creates an SvRewardCoupon.
 
-These SV minting rights are granted by the tokenomics committee in exchange for operating an SV node or contributing key infrastructure or activity to the network. The tokenomics committee uses the CIP process to record the SV rights. The current list of SV rights is thus available from the [CIP repo](https://github.com/global-synchronizer-foundation/cips).
+These SV minting rights are granted by the tokenomics committee in exchange for operating an SV node or contributing key infrastructure or activity to the network. The tokenomics committee uses the CIP process to record the SV rights. The current list of SV rights is thus available from the [CIP repo](https://github.com/canton-foundation/cips).
 
 
 {/* COPIED_END */}

--- a/docs-main/global-synchronizer/troubleshooting-guide/common-questions.mdx
+++ b/docs-main/global-synchronizer/troubleshooting-guide/common-questions.mdx
@@ -33,7 +33,7 @@ DevNet additionally requires VPN connectivity.
 
 Costs break down into infrastructure and network fees.
 
-**Infrastructure costs** depend on your deployment choice. A minimal Kubernetes deployment on a cloud provider runs approximately $500-800/month (compute, database, storage). Docker Compose on a single VM can be cheaper but is not recommended for production.
+**Infrastructure costs** depend on your deployment choice, cloud provider, and transaction volume. See [Prerequisites](/global-synchronizer/deployment/prerequisites) for hardware sizing guidance. Docker Compose on a single VM has lower fixed cost but is not recommended for production.
 
 **Network fees** are paid through traffic, which is purchased with Canton Coin (CC). The amount depends on your transaction volume. Validators earn rewards that can offset these costs. Check the current reward rates on the [Canton Foundation](https://sync.global/) website.
 

--- a/docs-main/global-synchronizer/understand/validator-roles.mdx
+++ b/docs-main/global-synchronizer/understand/validator-roles.mdx
@@ -106,8 +106,7 @@ The network upgrades frequently. Validators must keep pace:
 
 | Timeframe | Action |
 |-----------|--------|
-| **Within 1 week** | Apply security patches |
-| **Within 2 weeks** | Apply minor updates |
+| **As announced** | Apply security patches |
 | **Before deadline** | Major version upgrades (announced in advance) |
 
 <Warning>
@@ -165,12 +164,14 @@ Operating a validator involves several cost categories:
 
 ### Infrastructure Costs
 
-| Component | Typical Range |
-|-----------|---------------|
-| **Compute** | $200-$2000/month |
-| **Database** | $100-$500/month |
-| **Network** | $50-$200/month |
-| **Storage** | Varies with volume |
+Infrastructure costs depend on your deployment method, cloud provider, and transaction volume. See [Prerequisites](/global-synchronizer/deployment/prerequisites) for hardware sizing guidance. Use DevNet or TestNet to measure your actual resource consumption before estimating MainNet costs.
+
+| Component | Notes |
+|-----------|-------|
+| **Compute** | Scales with hosted parties and transaction volume |
+| **Database** | Scales with data volume; managed services (RDS, Cloud SQL) recommended |
+| **Network** | Egress costs depend on traffic volume |
+| **Storage** | Scales with ledger history retained |
 
 ### Network Costs
 

--- a/docs-main/integrations/integration-patterns.mdx
+++ b/docs-main/integrations/integration-patterns.mdx
@@ -80,7 +80,7 @@ flowchart LR
 
 ### Use Case
 
-Create, manage, and transfer tokens following the Canton Token Standard ([CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)).
+Create, manage, and transfer tokens following the Canton Token Standard ([CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)).
 
 ### Architecture
 
@@ -109,7 +109,7 @@ flowchart TB
 
 | Consideration | Approach |
 |---------------|----------|
-| **Interoperability** | Follow [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) for wallet compatibility |
+| **Interoperability** | Follow [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) for wallet compatibility |
 | **Authorization** | Define clear signatory/controller roles |
 | **Privacy** | Token balances visible only to holders |
 

--- a/docs-main/integrations/overview.mdx
+++ b/docs-main/integrations/overview.mdx
@@ -11,7 +11,7 @@ Canton Network provides several categories of integrations:
 
 - **Wallets** — Canton Coin management for users and applications
 - **Exchange integration** — Liquidity bridges and fiat on/off ramps
-- **Token standards** — Interoperable tokens following [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)
+- **Token standards** — Interoperable tokens following [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)
 - **Application integration** — Third-party app connectivity
 
 ## For Different Audiences

--- a/docs-main/integrations/wallets/canton-vs-web3.mdx
+++ b/docs-main/integrations/wallets/canton-vs-web3.mdx
@@ -55,14 +55,14 @@ Canton supports complex workflows:
 
 | Pattern | Description |
 |---------|-------------|
-| **Pre-approvals** | Recipient pre-approves accepting transfers from a specific sender |
+| **Pre-approvals** | Recipient pre-approves accepting transfers from any sender |
 | **Allocations** | Reserve tokens for specific purposes |
 | **DvP** | Atomic delivery-vs-payment exchanges |
 | **Conditional** | Transfers triggered by conditions |
 
 ### Pre-Approvals
 
-Allow a recipient to receive tokens from a specific sender without accepting each incoming transfer:
+Allow a recipient to receive tokens from any sender without accepting each incoming transfer:
 
 ```mermaid
 flowchart LR

--- a/docs-main/integrations/wallets/for-users.mdx
+++ b/docs-main/integrations/wallets/for-users.mdx
@@ -12,7 +12,7 @@ A Canton wallet allows you to:
 | Function | Description |
 |----------|-------------|
 | **Hold Canton Coin** | Store and manage your CC balance |
-| **Hold other tokens** | Hold any [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) compliant token (support varies by wallet) |
+| **Hold other tokens** | Hold any [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) compliant token (support varies by wallet) |
 | **Transfer value** | Send CC to other parties |
 | **Interact with apps** | Connect to Canton Network applications |
 | **View activity** | See your transaction history |
@@ -28,7 +28,7 @@ The Splice project provides a reference wallet implementation:
 - **Features**: Core wallet functionality
 
 <Note>
-The Splice reference wallet is not yet [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) compliant. Support for the token standard is planned for a future release.
+The Splice reference wallet is not yet [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) compliant. Support for the token standard is planned for a future release.
 </Note>
 
 ### Validator-Provided Wallets
@@ -46,7 +46,7 @@ Many Canton applications include wallet functionality:
 
 ### Your Balance
 
-Your wallet shows your Canton Coin balance. Wallets may also display other tokens that follow the [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) token standard—check your specific wallet for supported assets. Unlike other cryptocurrencies:
+Your wallet shows your Canton Coin balance. Wallets may also display other tokens that follow the [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) token standard—check your specific wallet for supported assets. Unlike other cryptocurrencies:
 
 - Only you can see your balance
 - Others cannot query your holdings

--- a/docs-main/overview/learn/global-synchronizer-architecture.mdx
+++ b/docs-main/overview/learn/global-synchronizer-architecture.mdx
@@ -58,7 +58,7 @@ When a validator submits a transaction:
 5. The result is broadcast back through the sequencer to all involved participants
 6. Each participant applies the result to its local ledger
 
-The entire flow typically completes in under a second. The synchronizer never has access to the unencrypted transaction data — it coordinates the protocol without learning what is being transacted.
+The synchronizer never has access to the unencrypted transaction data — it coordinates the protocol without learning what is being transacted.
 
 ## BFT guarantees
 

--- a/docs-main/overview/learn/ledger-model.mdx
+++ b/docs-main/overview/learn/ledger-model.mdx
@@ -202,7 +202,7 @@ flowchart TB
 ## Contract Keys
 
 <Note>
-Contract keys are under development and planned for Canton 3.5.
+Contract keys are not yet supported in Canton Network deployments. Check the [release notes](/global-synchronizer/release-notes/canton) for availability.
 </Note>
 
 Contracts can have **keys**—identifiers that allow lookup without knowing the contract ID.

--- a/docs-main/overview/reference/canton-coin-tokenomics.mdx
+++ b/docs-main/overview/reference/canton-coin-tokenomics.mdx
@@ -140,12 +140,12 @@ Once the accrued holding fee on a UTXO exceeds its face value, Super Validators 
 
 ## CN Token Standard (CIP-0056)
 
-[CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) defines the Canton Network Token Standard, a set of Daml interfaces for token operations including transfers, locks, and metadata queries. The Splice wallet implements CIP-0056 for CC, and applications that handle CC programmatically interact through these standard interfaces.
+[CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) defines the Canton Network Token Standard, a set of Daml interfaces for token operations including transfers, allocations, and metadata queries. The Splice wallet implements CIP-0056 for CC, and applications that handle CC programmatically interact through these standard interfaces.
 
 CIP-0056-based two-step transfers work as follows:
 
-1. The sender locks the desired CC amount, creating a transfer offer.
-2. The receiver accepts the offer, which unlocks the CC and completes the transfer.
+1. The sender exercises `TransferFactory_Transfer`. The registry creates a `TransferInstruction` contract and holds the funds pending the receiver's acceptance.
+2. The receiver exercises `TransferInstruction_Accept`, which completes the transfer and creates new holdings for the receiver.
 
 This two-step flow does not rely on sender-side automation and works well for external parties. Since CIP-0078, these operations incur no fees and generate no activity records.
 

--- a/docs-main/overview/reference/canton-coin-tokenomics.mdx
+++ b/docs-main/overview/reference/canton-coin-tokenomics.mdx
@@ -9,7 +9,7 @@ For background on CC's role in the network and how to obtain it, see [Canton Coi
 
 ## Fee Structure
 
-CC has three fee types. Following [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md), transfer fees and lock fees were eliminated, leaving traffic fees and holding fees as the two active mechanisms.
+CC has three fee types. Following [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md), transfer fees and lock fees were eliminated, leaving traffic fees and holding fees as the two active mechanisms.
 
 ### Traffic Fees
 
@@ -34,7 +34,7 @@ There is no difference in activity record creation for an external party or a lo
 1.  Use a minting delegation to delegate reward collection to a validator, avoiding the need to build custom automation.
 2.  Develop custom automation to call AmuletRules_Transfer at least once per round with all activity records as inputs.
 
-An approved CIP called [Weighted Validator Liveness Rewards for SV-Determined Parties](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md) describes providing this support.
+An approved CIP called [Weighted Validator Liveness Rewards for SV-Determined Parties](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md) describes providing this support.
 
 As an aside, some interesting templates are important to the tokenomics are:
 
@@ -74,7 +74,7 @@ For some of the templates, the attribution of activity can be shared with multip
 
 Beneficiaries are discussed further in the following sections.
 
-[CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) eliminated almost all fees for Canton Coin transfers and locks so unfeatured applications no longer receive any reward. The holding fee remains but its behavior changed so that no holding fees are charged when using a coin as an input to a transfer.
+[CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) eliminated almost all fees for Canton Coin transfers and locks so unfeatured applications no longer receive any reward. The holding fee remains but its behavior changed so that no holding fees are charged when using a coin as an input to a transfer.
 
 The holding fees is a fixed fee, per separate coin contract (UTXO) per unit of time, that is independent of the coin amount. It promotes merging of CC to reduce network storage use by incentivizing merging or removal of dust coins. Holding fees are not charged when transferring coins but only explicitly on expired coin contracts via the `Amulet_Expire` choice. A coin contract (UTXO) may be expired by the Super Validators once its accrued holding fees are greater than its coin value. This makes accounting for holding fees simple as the value of the coin contract is constant and independent of the holding fee.
 
@@ -84,7 +84,7 @@ Because the holding fee is per-UTXO rather than per-CC-amount, small "dust" coin
 
 ### Transfer and Lock Fees (Post CIP-0078)
 
-[CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) eliminated almost all fees for CC transfers and locks. Neither legacy Amulet transfers, CN Token Standard two-step transfers, nor one-step `TransferPreapproval` transfers charge fees. The only exception is that featured one-step transfers still generate an `AppRewardCoupon` for the provider party who maintains the `TransferPreapproval` contract.
+[CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) eliminated almost all fees for CC transfers and locks. Neither legacy Amulet transfers, CN Token Standard two-step transfers, nor one-step `TransferPreapproval` transfers charge fees. The only exception is that featured one-step transfers still generate an `AppRewardCoupon` for the provider party who maintains the `TransferPreapproval` contract.
 
 ## Burn-Mint Equilibrium
 
@@ -112,7 +112,7 @@ For local parties, the validator application runs background automation that min
 - **Minting delegation** -- Delegate reward collection to a validator, avoiding custom automation.
 - **Custom automation** -- Call `AmuletRules_Transfer` at least once per round with all activity records as inputs.
 
-[CIP-0073 (Weighted Validator Liveness Rewards for SV-Determined Parties)](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md) describes additional support for this workflow.
+[CIP-0073 (Weighted Validator Liveness Rewards for SV-Determined Parties)](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md) describes additional support for this workflow.
 
 ## Activity Records
 
@@ -140,7 +140,7 @@ Once the accrued holding fee on a UTXO exceeds its face value, Super Validators 
 
 ## CN Token Standard (CIP-0056)
 
-[CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) defines the Canton Network Token Standard, a set of Daml interfaces for token operations including transfers, allocations, and metadata queries. The Splice wallet implements CIP-0056 for CC, and applications that handle CC programmatically interact through these standard interfaces.
+[CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) defines the Canton Network Token Standard, a set of Daml interfaces for token operations including transfers, allocations, and metadata queries. The Splice wallet implements CIP-0056 for CC, and applications that handle CC programmatically interact through these standard interfaces.
 
 CIP-0056-based two-step transfers work as follows:
 
@@ -149,12 +149,12 @@ CIP-0056-based two-step transfers work as follows:
 
 This two-step flow does not rely on sender-side automation and works well for external parties. Since CIP-0078, these operations incur no fees and generate no activity records.
 
-For API details, see the [CIP-0056 text](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) and the [token standard source code](https://github.com/canton-network/splice/tree/main/token-standard#readme).
+For API details, see the [CIP-0056 text](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) and the [token standard source code](https://github.com/canton-network/splice/tree/main/token-standard#readme).
 
 ## Related Resources
 
 - [Canton Coin and the Global Synchronizer](/overview/understand/canton-coin) -- conceptual overview and how to obtain CC
-- [CIP-0078 (CC Fee Removal)](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) -- the proposal that eliminated transfer and lock fees
-- [CIP-0056 (CN Token Standard)](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) -- standard interfaces for token operations
-- [CIP-0073 (Weighted Validator Liveness Rewards)](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md) -- liveness reward support for SV-determined parties
+- [CIP-0078 (CC Fee Removal)](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) -- the proposal that eliminated transfer and lock fees
+- [CIP-0056 (CN Token Standard)](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) -- standard interfaces for token operations
+- [CIP-0073 (Weighted Validator Liveness Rewards)](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md) -- liveness reward support for SV-determined parties
 - [Canton Coin white paper](https://www.digitalasset.com/hubfs/Canton%20Network%20Files/Documents%20(whitepapers%2c%20etc...)/Canton%20Coin_%20A%20Canton-Network-native%20payment%20application.pdf) -- full formal specification

--- a/docs-main/overview/reference/cip-0056.mdx
+++ b/docs-main/overview/reference/cip-0056.mdx
@@ -3,12 +3,16 @@ title: "CIP-0056: Canton Network Token Standard"
 description: "Reference for CIP-0056, the standard Daml interfaces for token holdings, transfers, and allocations on Canton Network"
 ---
 
-[CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) defines the Canton Network Token Standard -- a set of Daml interfaces and off-ledger APIs that allow wallets and applications to interact with tokenized assets across registries in a uniform way. Any registry that implements CIP-0056 can be served by any compliant wallet, and any application can orchestrate transfers and settlements without depending on registry-specific code.
+[CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) defines the Canton Network Token Standard -- a set of Daml interfaces and off-ledger APIs that allow wallets and applications to interact with tokenized assets across registries in a uniform way. Any registry that implements CIP-0056 can be served by any compliant wallet, and any application can orchestrate transfers and settlements without depending on registry-specific code.
 
 The Splice wallet implements CIP-0056 for Canton Coin (CC), where the underlying Daml template is called `Amulet`. Other asset registries on Canton Network can implement the same interfaces for their own instruments.
 
 <Note>
-CIP-0056 targets a 24-hour window between transaction preparation and submission to support external signing workflows. The current CC implementation supports only a 10-minute window. This limitation is expected to be removed in a future release.
+CIP-0056 targets a 24-hour window between transaction preparation and submission to support external signing workflows. The current CC implementation supports only a 10-minute window. [CIP-0107](https://github.com/canton-foundation/cips/blob/main/cip-0107/cip-0107.md) (approved March 2026) addresses this limitation and will make CC fully compliant once implemented.
+</Note>
+
+<Note>
+[CIP-0112](https://github.com/canton-foundation/cips/blob/main/cip-0112/cip-0112.md) (approved June 2026) defines Canton Network Token Standard V2, which extends CIP-0056 with improvements for privacy, performance, and traditional accounting. CIP-0056 remains the current deployed standard.
 </Note>
 
 ## What CIP-0056 Standardizes
@@ -103,7 +107,7 @@ When the receiver has no preapproval, or when the registry requires additional a
 
 The receiver can also reject the instruction (`TransferInstruction_Reject`), which returns the funds to the sender. The sender can withdraw before acceptance (`TransferInstruction_Withdraw`). Both paths are designed so that wallets can parse the transaction history and determine whether any given instruction succeeded or failed.
 
-Two-step transfers do not require sender-side automation after the initial instruction, making them well suited for external parties that sign transactions with keys they control. Since [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md), two-step CC transfers incur no fees.
+Two-step transfers do not require sender-side automation after the initial instruction, making them well suited for external parties that sign transactions with keys they control. Since [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md), two-step CC transfers incur no fees.
 
 ### DvP Settlements Using Allocations
 
@@ -171,7 +175,7 @@ The [Token Standard CLI](https://github.com/canton-network/splice/tree/main/toke
 
 ## Further Reading
 
-- [Full CIP-0056 text](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)
+- [Full CIP-0056 text](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)
 - [Token standard source code](https://github.com/canton-network/splice/tree/main/token-standard)
 - [Wallet SDK](https://github.com/canton-network/wallet-gateway/tree/main/sdk/wallet-sdk)
 - [Canton Coin Tokenomics](/overview/reference/canton-coin-tokenomics) -- fee structure and UTXO dust expiry for CC specifically

--- a/docs-main/overview/reference/cip-0056.mdx
+++ b/docs-main/overview/reference/cip-0056.mdx
@@ -7,6 +7,10 @@ description: "Reference for CIP-0056, the standard Daml interfaces for token hol
 
 The Splice wallet implements CIP-0056 for Canton Coin (CC), where the underlying Daml template is called `Amulet`. Other asset registries on Canton Network can implement the same interfaces for their own instruments.
 
+<Note>
+CIP-0056 targets a 24-hour window between transaction preparation and submission to support external signing workflows. The current CC implementation supports only a 10-minute window. This limitation is expected to be removed in a future release.
+</Note>
+
 ## What CIP-0056 Standardizes
 
 The standard covers three categories of functionality:

--- a/docs-main/overview/reference/cip-index.mdx
+++ b/docs-main/overview/reference/cip-index.mdx
@@ -3,69 +3,77 @@ title: "CIP Index"
 description: "Reference index of Canton Improvement Proposals (CIPs) by type, number, and status"
 ---
 
-This page catalogs Canton Improvement Proposals across all types. The canonical source of truth is the [CIP GitHub repository](https://github.com/global-synchronizer-foundation/cips), where each CIP has its own directory containing the full proposal text. For background on what CIPs are and how they work, see [What are CIPs?](/overview/reference/what-are-cips). To submit a new proposal, see the [CIP Reference](/overview/reference/what-are-cips#how-to-propose-a-cip).
+This page catalogs Canton Improvement Proposals across all types. The canonical source of truth is the [CIP GitHub repository](https://github.com/canton-foundation/cips), where each CIP has its own directory containing the full proposal text. For background on what CIPs are and how they work, see [What are CIPs?](/overview/reference/what-are-cips). To submit a new proposal, see the [CIP Reference](/overview/reference/what-are-cips#how-to-propose-a-cip).
 
 ## Standards Track CIPs
 
 | Number | Title | Status |
 |--------|-------|--------|
-| [CIP-0012](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0012/cip-0012.md) | Minor Adjustments to Canton Coin Processing and Operational Configuration | Final |
-| [CIP-0013](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0013/cip-0013.md) | Correct an Error in the Daml Models Controlling the Re-onboarding Process | Final |
-| [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) | Canton Network Token Standard | Final |
-| [CIP-0062](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0062/cip-0062.md) | Synchronizer Migration with Downtime to Splice 0.4.0 / Canton 3.3 | Final |
-| [CIP-0064](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0064/cip-0064.md) | Delegateless Automation | Final |
-| [CIP-0068](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0068/cip-0068.md) | Bootstrap Network from Non-Zero Round | Final |
-| [CIP-0103](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0103/cip-0103.md) | dApp Standard | Approved |
+| [CIP-0012](https://github.com/canton-foundation/cips/blob/main/cip-0012/cip-0012.md) | Minor Adjustments to Canton Coin Processing and Operational Configuration | Final |
+| [CIP-0013](https://github.com/canton-foundation/cips/blob/main/cip-0013/cip-0013.md) | Correct an Error in the Daml Models Controlling the Re-onboarding Process | Final |
+| [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) | Canton Network Token Standard | Final |
+| [CIP-0062](https://github.com/canton-foundation/cips/blob/main/cip-0062/cip-0062.md) | Synchronizer Migration with Downtime to Splice 0.4.0 / Canton 3.3 | Final |
+| [CIP-0064](https://github.com/canton-foundation/cips/blob/main/cip-0064/cip-0064.md) | Delegateless Automation | Final |
+| [CIP-0068](https://github.com/canton-foundation/cips/blob/main/cip-0068/cip-0068.md) | Bootstrap Network from Non-Zero Round | Final |
+| [CIP-0103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md) | dApp Standard | Approved |
+| [CIP-0107](https://github.com/canton-foundation/cips/blob/main/cip-0107/cip-0107.md) | 24h Submission Delay for End-User CC Transactions | Approved |
+| [CIP-0112](https://github.com/canton-foundation/cips/blob/main/cip-0112/cip-0112.md) | Canton Network Token Standard V2 | Approved |
+| [CIP-0117](https://github.com/canton-foundation/cips/blob/main/cip-0117/cip-0117.md) | Logical Synchronizers | Approved |
 
 ## Tokenomics CIPs
 
 | Number | Title | Status |
 |--------|-------|--------|
-| [CIP-0001](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0001/cip-0001.md) | Replace the SV Tranche Time Delays with a Weighted Reward | Final |
-| [CIP-0002](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0002/cip-0002.md) | Minor Adjustments to the Tokenomics Variables | Replaced |
-| [CIP-0003](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0003/cip-0003.md) | Distribute Canton Coin Rewards to Any Validator on the Network | Final |
-| [CIP-0007](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0007/cip-0007.md) | SVs Can Earn Extra SV Reward Weight When Bringing Validators or Apps | Replaced |
-| [CIP-0008](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0008/cip-0008.md) | Update and Refinement to CIP-0002 | Replaced |
-| [CIP-0020](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0020/cip-0020.md) | Update and Refinement to CIP-0002 | Final |
-| [CIP-0024](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0024/cip-0024.md) | SVs and Validators Can Earn SV Reward Weight When Bringing Validators or Apps | Final |
-| [CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) | Featured App Activity Markers | Final |
-| [CIP-0048](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0048/cip-0048.md) | Raising the Rewards Cap for Validators and Application Providers | Final |
-| [CIP-0066](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0066/cip-0066.md) | Mint Canton Coin from Unminted/Unclaimed Pool | Final |
-| [CIP-0067](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0067/cip-0067.md) | One-Time Allocation of Historical Unclaimed Rewards to GSF | Final |
-| [CIP-0070](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0070/cip-0070.md) | Adjusting Reward Caps for Validators | Withdrawn |
-| [CIP-0073](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md) | Weighted Validator Liveness Rewards for SV-Determined Parties | Replaced |
-| [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) | Canton Coin Fee Removal | Final |
-| [CIP-0084](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0084/cip-0084.md) | Tokenomics Committee to Recommend $/MB Price Tuning | Approved |
-| [CIP-0086](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0086/cip-0086.md) | ERC-20 Middleware and Distributed Indexer for Canton Network | Approved |
-| [CIP-0089](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0089/cip-0089.md) | Synchronizer Migration with Downtime to Splice 0.5.0 / Canton 3.4 | Approved |
-| [CIP-0096](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0096/cip-0096.md) | Removing Liveness Rewards from Validator Rewards Pool | Approved |
-| [CIP-0098](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0098/cip-0098.md) | Cap Per-Transaction Application Rewards at $1.50 | Approved |
-| [CIP-0104](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0104/cip-0104.md) | Traffic-Based App Rewards | Proposed |
+| [CIP-0001](https://github.com/canton-foundation/cips/blob/main/cip-0001/cip-0001.md) | Replace the SV Tranche Time Delays with a Weighted Reward | Final |
+| [CIP-0002](https://github.com/canton-foundation/cips/blob/main/cip-0002/cip-0002.md) | Minor Adjustments to the Tokenomics Variables | Replaced |
+| [CIP-0003](https://github.com/canton-foundation/cips/blob/main/cip-0003/cip-0003.md) | Distribute Canton Coin Rewards to Any Validator on the Network | Final |
+| [CIP-0007](https://github.com/canton-foundation/cips/blob/main/cip-0007/cip-0007.md) | SVs Can Earn Extra SV Reward Weight When Bringing Validators or Apps | Replaced |
+| [CIP-0008](https://github.com/canton-foundation/cips/blob/main/cip-0008/cip-0008.md) | Update and Refinement to CIP-0002 | Replaced |
+| [CIP-0020](https://github.com/canton-foundation/cips/blob/main/cip-0020/cip-0020.md) | Update and Refinement to CIP-0002 | Final |
+| [CIP-0024](https://github.com/canton-foundation/cips/blob/main/cip-0024/cip-0024.md) | SVs and Validators Can Earn SV Reward Weight When Bringing Validators or Apps | Final |
+| [CIP-0047](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md) | Featured App Activity Markers | Final |
+| [CIP-0048](https://github.com/canton-foundation/cips/blob/main/cip-0048/cip-0048.md) | Raising the Rewards Cap for Validators and Application Providers | Final |
+| [CIP-0066](https://github.com/canton-foundation/cips/blob/main/cip-0066/cip-0066.md) | Mint Canton Coin from Unminted/Unclaimed Pool | Final |
+| [CIP-0067](https://github.com/canton-foundation/cips/blob/main/cip-0067/cip-0067.md) | One-Time Allocation of Historical Unclaimed Rewards to GSF | Final |
+| [CIP-0070](https://github.com/canton-foundation/cips/blob/main/cip-0070/cip-0070.md) | Adjusting Reward Caps for Validators | Withdrawn |
+| [CIP-0073](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md) | Weighted Validator Liveness Rewards for SV-Determined Parties | Replaced |
+| [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) | Canton Coin Fee Removal | Final |
+| [CIP-0084](https://github.com/canton-foundation/cips/blob/main/cip-0084/cip-0084.md) | Tokenomics Committee to Recommend $/MB Price Tuning | Approved |
+| [CIP-0086](https://github.com/canton-foundation/cips/blob/main/cip-0086/cip-0086.md) | ERC-20 Middleware and Distributed Indexer for Canton Network | Approved |
+| [CIP-0089](https://github.com/canton-foundation/cips/blob/main/cip-0089/cip-0089.md) | Synchronizer Migration with Downtime to Splice 0.5.0 / Canton 3.4 | Approved |
+| [CIP-0096](https://github.com/canton-foundation/cips/blob/main/cip-0096/cip-0096.md) | Removing Liveness Rewards from Validator Rewards Pool | Approved |
+| [CIP-0098](https://github.com/canton-foundation/cips/blob/main/cip-0098/cip-0098.md) | Cap Per-Transaction Application Rewards at $1.50 | Approved |
+| [CIP-0104](https://github.com/canton-foundation/cips/blob/main/cip-0104/cip-0104.md) | Traffic-Based App Rewards | Proposed |
+| [CIP-0105](https://github.com/canton-foundation/cips/blob/main/cip-0105/cip-0105.md) | Super Validator (SV) Locking & Long-Term Commitment Framework | Approved |
+| [CIP-0114](https://github.com/canton-foundation/cips/blob/main/cip-0114/cip-0114.md) | Digital Asset Treasury (DAT) SV Program | Approved |
+| [CIP-0116](https://github.com/canton-foundation/cips/blob/main/cip-0116/cip-0116.md) | Featured App Locking | Active |
+| [CIP-0119](https://github.com/canton-foundation/cips/blob/main/cip-0119/cip-0119.md) | Free Canton Coin Transfer-Preapproval Base Duration | Approved |
 
 ## Process CIPs
 
 | Number | Title | Status |
 |--------|-------|--------|
-| [CIP-0000](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0000/cip-0000.md) | CIP Process | Active |
-| [CIP-0006](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0006/cip-0006.md) | Define the Process of Distributing and Approving | Active |
-| [CIP-0050](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0050/cip-0050.md) | Controlled Validator Growth Through Trusted Operators | Withdrawn |
+| [CIP-0000](https://github.com/canton-foundation/cips/blob/main/cip-0000/cip-0000.md) | CIP Process | Active |
+| [CIP-0006](https://github.com/canton-foundation/cips/blob/main/cip-0006/cip-0006.md) | Define the Process of Distributing and Approving | Active |
+| [CIP-0050](https://github.com/canton-foundation/cips/blob/main/cip-0050/cip-0050.md) | Controlled Validator Growth Through Trusted Operators | Withdrawn |
+| [CIP-0111](https://github.com/canton-foundation/cips/blob/main/cip-0111/cip-0111.md) | Process for Reducing Super Validator Weight | Approved |
 
 ## Governance CIPs
 
-The majority of CIPs are Governance proposals covering Super Validator onboarding, committee formation, and operational policies. A selection of notable governance CIPs is listed below. For the full set (60+ governance proposals), see the [CIP repository](https://github.com/global-synchronizer-foundation/cips).
+The majority of CIPs are Governance proposals covering Super Validator onboarding, committee formation, and operational policies. A selection of notable governance CIPs is listed below. For the full set (60+ governance proposals), see the [CIP repository](https://github.com/canton-foundation/cips).
 
 | Number | Title | Status |
 |--------|-------|--------|
-| [CIP-0014](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0014/cip-0014.md) | Enhancements to the Scan API to Facilitate Tax Accounting | Final |
-| [CIP-0021](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0021/cip-0021.md) | Introduce Featured Application and Validator Committee | Active |
-| [CIP-0042](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0042/cip-0042.md) | Stable Price per Canton Coin Transfer via Synchronizer Fees | Active |
-| [CIP-0045](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0045/cip-0045.md) | SV Operating Requirements | Active |
-| [CIP-0051](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0051/cip-0051.md) | Streamline On-Chain Governance Votes | Final |
-| [CIP-0079](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0079/cip-0079.md) | Demonstrate Third-Party Price Feed Integration for CC Listing | Approved |
-| [CIP-0082](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0082/cip-0082.md) | Establish a 5% Development Fund (Foundation-Governed) | Approved |
-| [CIP-0092](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0092/cip-0092.md) | Controlled Transition to Dynamic Market Feeds Post-Listing | Approved |
-| [CIP-0100](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0100/cip-0100.md) | Governance of the CIP-0082 Development Fund | Approved |
+| [CIP-0014](https://github.com/canton-foundation/cips/blob/main/cip-0014/cip-0014.md) | Enhancements to the Scan API to Facilitate Tax Accounting | Final |
+| [CIP-0021](https://github.com/canton-foundation/cips/blob/main/cip-0021/cip-0021.md) | Introduce Featured Application and Validator Committee | Active |
+| [CIP-0042](https://github.com/canton-foundation/cips/blob/main/cip-0042/cip-0042.md) | Stable Price per Canton Coin Transfer via Synchronizer Fees | Active |
+| [CIP-0045](https://github.com/canton-foundation/cips/blob/main/cip-0045/cip-0045.md) | SV Operating Requirements | Active |
+| [CIP-0051](https://github.com/canton-foundation/cips/blob/main/cip-0051/cip-0051.md) | Streamline On-Chain Governance Votes | Final |
+| [CIP-0079](https://github.com/canton-foundation/cips/blob/main/cip-0079/cip-0079.md) | Demonstrate Third-Party Price Feed Integration for CC Listing | Approved |
+| [CIP-0082](https://github.com/canton-foundation/cips/blob/main/cip-0082/cip-0082.md) | Establish a 5% Development Fund (Foundation-Governed) | Active |
+| [CIP-0092](https://github.com/canton-foundation/cips/blob/main/cip-0092/cip-0092.md) | Controlled Transition to Dynamic Market Feeds Post-Listing | Approved |
+| [CIP-0100](https://github.com/canton-foundation/cips/blob/main/cip-0100/cip-0100.md) | Governance of the CIP-0082 Development Fund | Active |
 
 <Info>
-This index reflects the state of the CIP repository at the time of writing and may not include proposals added after this page was last updated. Always check the [GitHub repository](https://github.com/global-synchronizer-foundation/cips) for the latest proposals.
+This index reflects the state of the CIP repository at the time of writing and may not include proposals added after this page was last updated. Always check the [GitHub repository](https://github.com/canton-foundation/cips) for the latest proposals.
 </Info>

--- a/docs-main/overview/reference/gsf-policies.mdx
+++ b/docs-main/overview/reference/gsf-policies.mdx
@@ -108,7 +108,7 @@ Super Validators that do not upgrade in time can cause operational issues. For e
 
 Changes to network rules, standards, and protocols are proposed through Canton Improvement Proposals (CIPs). The CIP process provides a structured way for anyone in the ecosystem to propose changes, with final ratification by Super Validator vote.
 
-For details on the CIP process, including how to propose one, see [CIP Reference](/overview/reference/what-are-cips). The full list of CIPs is maintained at [github.com/global-synchronizer-foundation/cips](https://github.com/global-synchronizer-foundation/cips).
+For details on the CIP process, including how to propose one, see [CIP Reference](/overview/reference/what-are-cips). The full list of CIPs is maintained at [github.com/canton-foundation/cips](https://github.com/canton-foundation/cips).
 
 ## Communication channels
 
@@ -123,5 +123,5 @@ The CF maintains several channels for validator operators and ecosystem particip
 - [CF website](https://canton.foundation) -- foundation information and membership
 - [Canton Network](https://canton.network) -- network overview and entry point
 - [CF configs repository](https://github.com/global-synchronizer-foundation/configs) -- network configuration parameters
-- [CIP repository](https://github.com/global-synchronizer-foundation/cips) -- Canton Improvement Proposals
+- [CIP repository](https://github.com/canton-foundation/cips) -- Canton Improvement Proposals
 - [SV Governance Reference](/overview/reference/sv-governance-reference) -- technical details on the DSO party and voting mechanics

--- a/docs-main/overview/reference/splice-wallet-reference.mdx
+++ b/docs-main/overview/reference/splice-wallet-reference.mdx
@@ -37,7 +37,7 @@ The validator app runs several background automations on behalf of wallet users.
 
 CC transfers between parties follow one of three patterns.
 
-**Two-step token standard transfer.** The sender locks CC into a `TransferInstruction` contract. The receiver then accepts (unlocking and completing the transfer), rejects, or lets it expire. The sender can also withdraw the offer before acceptance, reclaiming the locked funds. Since [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md), no fees are charged on these transfers.
+**Two-step token standard transfer.** The sender locks CC into a `TransferInstruction` contract. The receiver then accepts (unlocking and completing the transfer), rejects, or lets it expire. The sender can also withdraw the offer before acceptance, reclaiming the locked funds. Since [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md), no fees are charged on these transfers.
 
 **One-step preapproved transfer.** If the receiver has set up a `TransferPreapproval` contract, the sender can transfer CC in a single step without the receiver needing to accept. The receiver's validator operator acts as the `provider` party on the preapproval and handles its periodic renewal. If the provider is a featured application provider, the transfer generates an `AppRewardCoupon`.
 

--- a/docs-main/overview/reference/sv-governance-reference.mdx
+++ b/docs-main/overview/reference/sv-governance-reference.mdx
@@ -74,7 +74,7 @@ Some actions do not require manual voting. SV nodes create confirmations automat
 
 SVs govern network parameters through voted config changes. Key configurable parameters include:
 
-- **Traffic pricing** (`extraTrafficPrice`) -- The USD cost per MB of synchronizer traffic. Per [CIP-0042](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0042/cip-0042.md), this should be calibrated so a standard Canton Coin transfer costs 1 USD.
+- **Traffic pricing** (`extraTrafficPrice`) -- The USD cost per MB of synchronizer traffic. Per [CIP-0042](https://github.com/canton-foundation/cips/blob/main/cip-0042/cip-0042.md), this should be calibrated so a standard Canton Coin transfer costs 1 USD.
 - **Read vs. write scaling factor** (`readVsWriteScalingFactor`) -- The ratio of read traffic cost relative to write traffic cost, reflecting the lower infrastructure cost of message delivery compared to ordering and persistence.
 - **CC-USD conversion rate** -- Each SV publishes their desired dollar-to-CC rate on-chain. The DSO uses the **median** of all published values, making the rate resistant to manipulation by any single SV.
 - **Round duration** -- The length of mining rounds (default: 10 minutes), which determines how frequently rewards are calculated and issued.
@@ -88,7 +88,7 @@ Traffic parameters require periodic recalibration. Actual traffic costs change d
 
 Formal changes to Canton Network standards and protocols go through the Canton Improvement Proposal (CIP) process. CIPs cover technical specifications, governance procedures, and informational guidelines. SVs vote on CIP adoption through the same on-chain governance mechanism described above.
 
-For a full overview of the CIP lifecycle and how to participate, see [What Are CIPs?](/overview/reference/what-are-cips). The CIP repository is maintained at [github.com/global-synchronizer-foundation/cips](https://github.com/global-synchronizer-foundation/cips).
+For a full overview of the CIP lifecycle and how to participate, see [What Are CIPs?](/overview/reference/what-are-cips). The CIP repository is maintained at [github.com/canton-foundation/cips](https://github.com/canton-foundation/cips).
 
 ## Canton Foundation
 

--- a/docs-main/overview/reference/tokenomics-of-gs.mdx
+++ b/docs-main/overview/reference/tokenomics-of-gs.mdx
@@ -50,10 +50,10 @@ All of these parameters live on the `AmuletRules` contract and can be queried th
 
 Network activity is tracked through **activity records**, each carrying a weight that determines the party's share of CC minting for a given round. Five key contract templates drive the accounting:
 
-- **`SvRewardCoupon`** -- one per Super Validator per round. SV minting rights are granted by the tokenomics committee through the [CIP process](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0000/cip-0000.md) in exchange for operating SV infrastructure or contributing key resources.
+- **`SvRewardCoupon`** -- one per Super Validator per round. SV minting rights are granted by the tokenomics committee through the [CIP process](https://github.com/canton-foundation/cips/blob/main/cip-0000/cip-0000.md) in exchange for operating SV infrastructure or contributing key resources.
 - **`ValidatorRewardCoupon`** -- created whenever CC is burned (traffic purchase) or an `AmuletRules_Transfer` executes. The coupon's weight reflects the amount of CC the validator burned.
 - **`ValidatorLivenessActivityRecord`** -- one per live validator per round. Rewards a validator for being available to validate and confirm transactions and provides initial funds for purchasing extra traffic after onboarding.
-- **`AppRewardCoupon`** -- created when a featured application's transaction succeeds or when a `FeaturedAppActivityMarker` is converted by SV automation. Only featured applications receive rewards (per [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md)).
+- **`AppRewardCoupon`** -- created when a featured application's transaction succeeds or when a `FeaturedAppActivityMarker` is converted by SV automation. Only featured applications receive rewards (per [CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md)).
 - **`FeaturedAppActivityMarker`** -- created in the business transaction for economically meaningful events (asset transfers, token mints/burns). SV automation converts these into `AppRewardCoupon` contracts.
 
 {/* End adapted block from overview_tokenomics.rst */}
@@ -69,13 +69,13 @@ The `IssuanceConfig` on the `AmuletRules` contract defines the maximum CC that c
 
 Within each tranche, per-coupon issuance is capped (`validatorRewardCap`, `featuredAppRewardCap`, `unfeaturedAppRewardCap`, `validatorFaucetCap`). If total coupon demand in a tranche is below the cap, the surplus flows to the next tranche -- for example, unclaimed validator activity rewards flow to the validator liveness faucet, and unclaimed unfeatured app rewards flow to featured app rewards. Unclaimed rewards beyond all tranches go to SV rewards.
 
-A `developmentFundPercentage` (default 5%) is set aside from each round's issuance for the development fund under [CIP-0082](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0082/cip-0082.md), before the remainder is split across the tranches above.
+A `developmentFundPercentage` (default 5%) is set aside from each round's issuance for the development fund under [CIP-0082](https://github.com/canton-foundation/cips/blob/main/cip-0082/cip-0082.md), before the remainder is split across the tranches above.
 
 ## Fee Schedules and Round Snapshots
 
 Fee parameters are stored on the **`AmuletRules`** contract, which the DSO governs through on-ledger voting. When a new mining round opens, the current fee values and conversion rate are snapshotted into an **`OpenMiningRound`** contract so that all transactions within that round use consistent pricing. As the round progresses through its phases, an **`IssuingMiningRound`** contract records the computed amount-to-mint-per-activity-weight for each reward type.
 
-[CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md) eliminated nearly all fees for CC transfers and locks. The holding fee remains -- a fixed fee per separate coin contract (UTXO) per unit of time, independent of coin amount. Holding fees incentivize merging small coins to reduce on-ledger storage. They are charged only on expired coin contracts via `Amulet_Expire`, not during transfers.
+[CIP-0078](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md) eliminated nearly all fees for CC transfers and locks. The holding fee remains -- a fixed fee per separate coin contract (UTXO) per unit of time, independent of coin amount. Holding fees incentivize merging small coins to reduce on-ledger storage. They are charged only on expired coin contracts via `Amulet_Expire`, not during transfers.
 
 ## CC-USD Conversion Rate
 
@@ -94,10 +94,10 @@ Validators earn CC through two mechanisms that run every round:
 - **Liveness rewards** -- each live validator creates a `ValidatorLivenessActivityRecord`, earning a share of the validator faucet tranche. The per-validator faucet cap defaults to $2.85 USD equivalent per round. Liveness rewards give new validators initial CC to fund traffic purchases.
 - **Activity rewards** -- when a validator's users burn CC (traffic purchases or transfers), the resulting `ValidatorRewardCoupon` entitles the validator to mint CC proportional to the amount burned. Validators that drive more network usage earn more.
 
-For validators hosting external parties (parties that sign with their own keys rather than through the validator), minting can be handled either through a **minting delegation** to the validator or through custom automation calling `AmuletRules_Transfer` each round. [CIP-0073](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md) describes weighted validator liveness rewards for SV-determined parties.
+For validators hosting external parties (parties that sign with their own keys rather than through the validator), minting can be handled either through a **minting delegation** to the validator or through custom automation calling `AmuletRules_Transfer` each round. [CIP-0073](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md) describes weighted validator liveness rewards for SV-determined parties.
 
 ## Further Reading
 
 - [Canton Coin white paper](https://www.digitalasset.com/hubfs/Canton%20Network%20Files/Documents%20(whitepapers%2c%20etc...)/Canton%20Coin_%20A%20Canton-Network-native%20payment%20application.pdf) -- full technical specification of the burn-mint mechanism
 - [Canton Network white paper](https://www.digitalasset.com/hubfs/Canton/Canton%20Network%20-%20White%20Paper.pdf) -- broader network architecture and design
-- [CIP repository](https://github.com/global-synchronizer-foundation/cips) -- governance proposals including fee and reward changes
+- [CIP repository](https://github.com/canton-foundation/cips) -- governance proposals including fee and reward changes

--- a/docs-main/overview/reference/tokenomics-of-gs.mdx
+++ b/docs-main/overview/reference/tokenomics-of-gs.mdx
@@ -39,7 +39,7 @@ Traffic accounting is per-validator -- all parties hosted on the same validator 
 The actual traffic drawn from a validator's balance for a given message depends on:
 
 - **Payload size** -- the byte size of the sequenced message.
-- **Number of recipients** -- each recipient adds a delivery surcharge controlled by `readVsWriteScalingFactor` (specified in basis points). For example, at a factor of 4, a 1 MB message with 10 recipients costs `1,000,000 * (1 + 10 * 0.004) = 1,040,000` bytes.
+- **Number of recipients** -- each recipient adds a delivery surcharge controlled by `readVsWriteScalingFactor` (specified in parts per 10,000). For example, at a factor of 4, a 1 MB message with 10 recipients costs `1,000,000 * (1 + 10 * 0.0004) = 1,004,000` bytes.
 - **Extra traffic price** -- the `extraTrafficPrice` in USD per MB, charged in CC at the prevailing conversion rate.
 
 All of these parameters live on the `AmuletRules` contract and can be queried through the Scan API.

--- a/docs-main/overview/reference/validator-node-components.mdx
+++ b/docs-main/overview/reference/validator-node-components.mdx
@@ -124,7 +124,7 @@ The Splice DARs are Daml packages that implement Canton Network's built-in appli
 
 ### Token Standard DARs
 
-The Token Standard DARs implement the [Canton Network Token Standard (CIP-0056)](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md). They provide a standardized interface for transferring Canton Coin (and potentially other tokens) through Daml interfaces. Applications that integrate with Canton Coin should build against these interfaces rather than the lower-level Amulet contracts.
+The Token Standard DARs implement the [Canton Network Token Standard (CIP-0056)](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md). They provide a standardized interface for transferring Canton Coin (and potentially other tokens) through Daml interfaces. Applications that integrate with Canton Coin should build against these interfaces rather than the lower-level Amulet contracts.
 
 ## Canton Participant
 

--- a/docs-main/overview/reference/what-are-cips.mdx
+++ b/docs-main/overview/reference/what-are-cips.mdx
@@ -5,7 +5,7 @@ description: "Formal structure, lifecycle, and governance mechanics of Canton Im
 
 Canton Improvement Proposals (CIPs) are formal design documents that describe standards, protocol changes, governance procedures, and guidelines for Canton Network. They serve as the primary mechanism through which the community proposes and ratifies changes to the network.
 
-The CIP process is modeled on established improvement proposal frameworks (such as Ethereum's EIPs and Python's PEPs) and is formally defined in [CIP-0000](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0000/cip-0000.md). All CIPs are maintained in a [public GitHub repository](https://github.com/global-synchronizer-foundation/cips) managed by the Canton Foundation.
+The CIP process is modeled on established improvement proposal frameworks (such as Ethereum's EIPs and Python's PEPs) and is formally defined in [CIP-0000](https://github.com/canton-foundation/cips/blob/main/cip-0000/cip-0000.md). All CIPs are maintained in a [public GitHub repository](https://github.com/canton-foundation/cips) managed by the Canton Foundation.
 
 For an introductory overview of CIPs and why they matter, see the [CIPs introduction](/overview/understand/cips-introduction).
 
@@ -45,7 +45,7 @@ To move from discussion to a formal vote, you need one Super Validator to sponso
 
 ## Review and approval
 
-CIP editors manage the review process. Their responsibilities include verifying technical soundness, confirming that community discussion has taken place on the mailing list, validating format compliance, and assigning the official CIP number and category. Editors can make editorial corrections independently but do not rule on whether a CIP should be approved — that decision belongs to the Super Validator vote. The current editorial team is listed in [CIP-0000](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0000/cip-0000.md).
+CIP editors manage the review process. Their responsibilities include verifying technical soundness, confirming that community discussion has taken place on the mailing list, validating format compliance, and assigning the official CIP number and category. Editors can make editorial corrections independently but do not rule on whether a CIP should be approved — that decision belongs to the Super Validator vote. The current editorial team is listed in [CIP-0000](https://github.com/canton-foundation/cips/blob/main/cip-0000/cip-0000.md).
 
 Before a CIP can move to a vote, minimum discussion periods apply on the `cip-discuss` mailing list:
 
@@ -83,18 +83,18 @@ The CIP repository contains a template you can use as a starting point. For the 
 
 The following CIPs illustrate the range of topics the process covers.
 
-**[CIP-0056: Canton Network Token Standard](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)** (Standards Track, Final) — Defines six standardized APIs for token operations on Canton Network, covering metadata, holdings, peer-to-peer transfers, and delivery-versus-payment settlement. Canton Coin implements all standard APIs. CIP-0056 draws on ideas from ERC-20 but is adapted for Canton's UTXO model and privacy architecture. If you are building a token on Canton Network, this is the standard you need to implement.
+**[CIP-0056: Canton Network Token Standard](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)** (Standards Track, Final) — Defines six standardized APIs for token operations on Canton Network, covering metadata, holdings, peer-to-peer transfers, and delivery-versus-payment settlement. Canton Coin implements all standard APIs. CIP-0056 draws on ideas from ERC-20 but is adapted for Canton's UTXO model and privacy architecture. If you are building a token on Canton Network, this is the standard you need to implement.
 
-**[CIP-0078: Canton Coin Fee Removal](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0078/cip-0078.md)** (Tokenomics, Final) — Eliminates transaction fees on Canton Coin transfers. Holding fees remain only on coin expiry to prevent accumulation of economically unviable dust coins. This change simplifies developer workflows that previously required fee-funding logic, and was viable because approximately 95% of MainNet burn already derived from traffic purchases rather than transfer fees.
+**[CIP-0078: Canton Coin Fee Removal](https://github.com/canton-foundation/cips/blob/main/cip-0078/cip-0078.md)** (Tokenomics, Final) — Eliminates transaction fees on Canton Coin transfers. Holding fees remain only on coin expiry to prevent accumulation of economically unviable dust coins. This change simplifies developer workflows that previously required fee-funding logic, and was viable because approximately 95% of MainNet burn already derived from traffic purchases rather than transfer fees.
 
-**[CIP-0073: Weighted Validator Liveness Rewards](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md)** (Tokenomics, Replaced by CIP-0096) — Extended validator liveness rewards to any party and introduced governance-adjustable reward weight multipliers. This CIP was later superseded by CIP-0096, which refined the reward model.
+**[CIP-0073: Weighted Validator Liveness Rewards](https://github.com/canton-foundation/cips/blob/main/cip-0073/cip-0073.md)** (Tokenomics, Replaced by CIP-0096) — Extended validator liveness rewards to any party and introduced governance-adjustable reward weight multipliers. This CIP was later superseded by CIP-0096, which refined the reward model.
 
-**[CIP-0103: dApp Standard](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0103/cip-0103.md)** (Standards Track, Approved) — Specifies a vendor-neutral dApp API that decouples network connectivity and key management from application logic. The standard supports both synchronous and asynchronous operation models, allowing any dApp to work with any wallet implementation.
+**[CIP-0103: dApp Standard](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md)** (Standards Track, Approved) — Specifies a vendor-neutral dApp API that decouples network connectivity and key management from application logic. The standard supports both synchronous and asynchronous operation models, allowing any dApp to work with any wallet implementation.
 
 ## Resources
 
-- [CIP repository on GitHub](https://github.com/global-synchronizer-foundation/cips) — All CIP documents and the canonical CIP-0000 process definition
-- [CIP-0000: CIP Process](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0000/cip-0000.md) — The authoritative specification of the CIP process, including editorial team, voting rules, and format requirements
+- [CIP repository on GitHub](https://github.com/canton-foundation/cips) — All CIP documents and the canonical CIP-0000 process definition
+- [CIP-0000: CIP Process](https://github.com/canton-foundation/cips/blob/main/cip-0000/cip-0000.md) — The authoritative specification of the CIP process, including editorial team, voting rules, and format requirements
 - [CF mailing lists](https://lists.sync.global/) — The `cip-discuss` and `cip-vote` lists where CIP discussion and voting take place
 - [SV governance reference](/overview/reference/sv-governance-reference) — On-chain governance mechanics that CIPs feed into after approval
 
@@ -112,7 +112,7 @@ Not every CIP reaches acceptance. Proposals can be withdrawn by the author, defe
 
 ### Writing a CIP
 
-CIPs are submitted as pull requests to the [CIP repository on GitHub](https://github.com/global-synchronizer-foundation/cips). Each CIP lives in its own directory (e.g., `cip-0056/cip-0056.md`).
+CIPs are submitted as pull requests to the [CIP repository on GitHub](https://github.com/canton-foundation/cips). Each CIP lives in its own directory (e.g., `cip-0056/cip-0056.md`).
 
 A CIP document should include the following sections:
 
@@ -170,7 +170,7 @@ The CIP repository tracks the implementation status of each accepted proposal.
 
 ### Tips for effective proposals
 
-- Start by searching the [existing CIPs](https://github.com/global-synchronizer-foundation/cips) and discussion archives to make sure your idea has not already been proposed or addressed.
+- Start by searching the [existing CIPs](https://github.com/canton-foundation/cips) and discussion archives to make sure your idea has not already been proposed or addressed.
 - Talk to the community early. Floating an idea in the discussion channels before writing a full CIP can save time and improve the proposal.
 - Be specific in the specification section. Vague language leads to extended discussion and delays.
 - Address backwards compatibility explicitly, even if you believe the change is fully backwards-compatible. Reviewers will ask about it.

--- a/docs-main/overview/reference/what-are-cips.mdx
+++ b/docs-main/overview/reference/what-are-cips.mdx
@@ -24,7 +24,7 @@ Each CIP belongs to one of five categories:
 A CIP progresses through a defined set of stages:
 
 - **Draft** — The author develops the proposal and gathers feedback on the `cip-discuss` mailing list. At this stage, the CIP does not yet have an official number.
-- **Proposed** — After securing sponsorship from two Super Validators, the author submits the CIP to the `cip-vote` mailing list for formal consideration. A CIP editor assigns the official number at this point.
+- **Proposed** — After the author secures a sponsor and an endorser from the Super Validators, the sponsoring Super Validator sends the CIP to the `cip-vote` mailing list for formal consideration. A CIP editor assigns the official number at this point.
 - **Approved** — The CIP receives a two-thirds majority vote from Super Validator rights holders during a 10-day voting window.
 - **Active** — For approved CIPs that require no on-chain implementation (such as Process or Informational CIPs), the proposal takes effect immediately upon approval.
 - **Final** — For approved CIPs that require on-chain adoption (typically Standards Track, Governance, or Tokenomics CIPs), the proposal reaches Final once two-thirds of Super Validators have implemented the change on-chain.
@@ -41,7 +41,7 @@ Any member of the public can author a CIP. You join the `cip-discuss` mailing li
 
 Not every change requires a CIP. Small enhancements to a specific software project proceed through that project's own development workflow. You need a CIP when the change affects interoperability across validators, modifies governance rules, alters tokenomics parameters, or establishes a network-wide standard that multiple parties must implement. If in doubt, start a discussion on the `cip-discuss` list — the community and editors will advise whether a formal CIP is warranted.
 
-To move from discussion to a formal vote, you need sponsorship from two Super Validators. Sponsorship signals that at least two SV operators consider the proposal worth putting to a network-wide vote. It does not imply endorsement of the proposal's content.
+To move from discussion to a formal vote, you need one Super Validator to sponsor your CIP and a second to endorse it. If you yourself represent a Super Validator, only one endorser is required. The sponsoring SV then sends the CIP to the `cip-vote` mailing list on your behalf.
 
 ## Review and approval
 
@@ -56,7 +56,7 @@ Before a CIP can move to a vote, minimum discussion periods apply on the `cip-di
 
 These minimums exist to ensure that proposals receive adequate scrutiny relative to their impact. A Standards Track CIP changing protocol behavior warrants longer discussion than an Informational guideline.
 
-Once the discussion period has elapsed and two Super Validators have agreed to sponsor the proposal, voting proceeds on the `cip-vote` list using GitHub Team Voting. The voting window lasts 10 days. Approval requires a two-thirds majority of Super Validator rights holders voting in favor.
+Once the discussion period has elapsed and the CIP has a sponsor and an endorser from the Super Validators, the sponsoring SV sends the CIP to the `cip-vote` list and voting proceeds using GitHub Team Voting. The voting window lasts 10 days. Approval requires a two-thirds majority of Super Validator rights holders voting in favor.
 
 ## Relationship to on-chain governance
 
@@ -153,7 +153,7 @@ Once a CIP is considered mature, it moves to formal review. At this stage:
 
 1. The CIP is marked as "Review" status in the repository.
 2. Super Validators evaluate the proposal against their own operational and business requirements.
-3. A governance vote is initiated through the SV web UI. Acceptance requires approval from a quorum of Super Validators (approximately 2/3 of onboarded SVs).
+3. A governance vote is initiated through the SV web UI. Acceptance requires a two-thirds majority of Super Validator rights holders voting in favor.
 
 If the vote passes, the CIP status is updated to "Accepted" and implementation can proceed. If the vote fails, the author can revise the proposal and resubmit, or withdraw it.
 

--- a/docs-main/overview/understand/cips-introduction.mdx
+++ b/docs-main/overview/understand/cips-introduction.mdx
@@ -39,7 +39,7 @@ The token standard defines interfaces for fungible tokens on Canton Network.
 | **APIs** | Token Metadata, Holding, TransferInstruction, Allocation, AllocationRequest, AllocationInstruction |
 | **Interoperability** | Wallet and app compatibility |
 
-**GitHub:** [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)
+**GitHub:** [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)
 
 Key features:
 - Standard holding representation
@@ -87,7 +87,7 @@ When building applications, consider relevant CIPs:
 
 | Resource | Content |
 |----------|---------|
-| [GitHub Repository](https://github.com/global-synchronizer-foundation/cips) | All CIP documents |
+| [GitHub Repository](https://github.com/canton-foundation/cips) | All CIP documents |
 | [canton.foundation](https://canton.foundation) | Governance information |
 | Community channels | Discussion and updates |
 
@@ -105,11 +105,11 @@ To propose or contribute to CIPs:
 
 <CardGroup cols={2}>
 
-<Card title="Token Standard" icon="coins" href="https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md">
+<Card title="Token Standard" icon="coins" href="https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md">
   Implement the Canton Token Standard.
 </Card>
 
-<Card title="CIP Repository" icon="github" href="https://github.com/global-synchronizer-foundation/cips">
+<Card title="CIP Repository" icon="github" href="https://github.com/canton-foundation/cips">
   Browse all CIPs on GitHub.
 </Card>
 

--- a/docs-main/overview/understand/cips-introduction.mdx
+++ b/docs-main/overview/understand/cips-introduction.mdx
@@ -36,7 +36,7 @@ The token standard defines interfaces for fungible tokens on Canton Network.
 | Aspect | Specification |
 |--------|---------------|
 | **Purpose** | Standardize token operations |
-| **Interfaces** | Holding, Transfer, Lock |
+| **Interfaces** | Holding, TransferInstruction, AllocationRequest, AllocationInstruction, Allocation, BurnMint |
 | **Interoperability** | Wallet and app compatibility |
 
 **GitHub:** [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)

--- a/docs-main/overview/understand/cips-introduction.mdx
+++ b/docs-main/overview/understand/cips-introduction.mdx
@@ -36,7 +36,7 @@ The token standard defines interfaces for fungible tokens on Canton Network.
 | Aspect | Specification |
 |--------|---------------|
 | **Purpose** | Standardize token operations |
-| **Interfaces** | Holding, TransferInstruction, AllocationRequest, AllocationInstruction, Allocation, BurnMint |
+| **APIs** | Token Metadata, Holding, TransferInstruction, Allocation, AllocationRequest, AllocationInstruction |
 | **Interoperability** | Wallet and app compatibility |
 
 **GitHub:** [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md)

--- a/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
@@ -15,7 +15,7 @@ Refer to the [Token Standard documentation](/appdev/deep-dives/token-standard) s
 
 ## Featured App Activity Markers API (CIP-0047)
 
-- See the [text of the CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) for its background on its design and its specification.
+- See the [text of the CIP-0047](https://github.com/canton-foundation/cips/blob/main/cip-0047/cip-0047.md) for its background on its design and its specification.
 
 - The Daml interfaces that are part of the Featured App Activity Markers API are defined in:
 

--- a/docs-main/sdks-tools/sdks/wallet-sdk.mdx
+++ b/docs-main/sdks-tools/sdks/wallet-sdk.mdx
@@ -87,7 +87,7 @@ Token transfers follow a prepare-sign-submit flow. The SDK handles command const
 
 <DamlDocsSdksToolsSdksWalletSdkL161 />
 
-Transaction finality typically takes 3-10 seconds. Signed transactions are idempotent, so you can safely retry if the result does not appear on your ledger.
+Signed transactions are idempotent, so you can safely retry if the result does not appear on your ledger.
 
 ### Transfer modes
 

--- a/docs-main/sdks-tools/sdks/wallet-sdk.mdx
+++ b/docs-main/sdks-tools/sdks/wallet-sdk.mdx
@@ -65,7 +65,7 @@ The SDK generates Ed25519 key pairs by default. BIP-0039 mnemonic-based key gene
 
 ## Token operations
 
-The SDK exposes token standard operations through `sdk.tokenStandard`. These follow [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md), the Canton Network token standard.
+The SDK exposes token standard operations through `sdk.tokenStandard`. These follow [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md), the Canton Network token standard.
 
 ### Querying holdings (UTXOs)
 
@@ -154,12 +154,12 @@ Third-party dApps can submit transactions to your wallet for signing through a s
 
 The dApp API follows an [OpenRPC specification](https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-api.json). A dApp calls `prepareExecute` or `prepareExecuteAndWait`, and the wallet provider prepares, signs, and submits the transaction on the user's behalf.
 
-The SDK can decode prepared transactions into human-readable JSON for display to users before signing. For details on this flow, see [CIP-0103](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0103/cip-0103.md) (the dApp Standard).
+The SDK can decode prepared transactions into human-readable JSON for display to users before signing. For details on this flow, see [CIP-0103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md) (the dApp Standard).
 
 ## Further resources
 
 - [Wallet Gateway GitHub repository](https://github.com/canton-network/wallet-gateway) -- contains the Wallet SDK source, API specs, and example scripts
 - [Token standard documentation](/appdev/deep-dives/token-standard) -- full token standard reference
-- [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) -- Canton Network token standard specification
+- [CIP-0056](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md) -- Canton Network token standard specification
 - [External party signing tutorial](/appdev/deep-dives/external-signing-onboarding) -- step-by-step external signing walkthrough
 - [CN Quickstart](https://github.com/digital-asset/cn-quickstart) -- reference application for getting started with Canton Network development


### PR DESCRIPTION
Fixes a set of factual inaccuracies identified during a cross-page consistency review of non-COPIED documentation.

- **`canton-vs-web3.mdx`**: Corrected description of `TransferPreapproval` sender scope — preapprovals accept incoming transfers from any sender, not a specific sender. The `sender` is a choice argument on `TransferPreapproval_Send`, not a field on the contract.

- **`cips-introduction.mdx`**: Fixed the CIP-0056 API list. Correct six APIs are: Token Metadata, Holding, TransferInstruction, Allocation, AllocationRequest, AllocationInstruction.

- **`canton-coin-tokenomics.mdx`**: Updated the two-step transfer description to use CIP-0056 terminology (`TransferFactory_Transfer` / `TransferInstruction_Accept`) and corrected the fee scope wording.

- **`what-are-cips.mdx`**: Fixed sponsor/endorser mechanics per CIP-0000 — one SV sponsors, a second endorses; the sponsoring SV (not the author) sends the CIP to `cip-vote`. Corrected voting threshold language to match CIP-0000 wording.

- **`cip-0056.mdx`**: Added notes on CIP-0107 (24h submission window, approved March 2026) and CIP-0112 (Token Standard V2, approved June 2026).

- **`cip-index.mdx` and 26 other files**: Replaced all `global-synchronizer-foundation/cips` links with the canonical `canton-foundation/cips`. Added CIP-0107, CIP-0112, CIP-0117 (Standards Track); CIP-0105, CIP-0114, CIP-0116, CIP-0119 (Tokenomics); CIP-0111 (Process). Corrected CIP-0082 and CIP-0100 status from Approved to Active.

