### PR TITLE
fix typo in ledger-model-detailed.mdx and make the diagram visible 

### DIFF
--- a/docs-main/overview/reference/ledger-model-detailed.mdx
+++ b/docs-main/overview/reference/ledger-model-detailed.mdx
@@ -465,11 +465,11 @@ In the example, the contract model specifies that
 1.  An `Iou obligor owner` contract has only the `obligor` as a signatory.
 2.  A `MustPay obligor owner` contract has both the `obligor` and the `owner` as signatories.
 3.  A `PaintOffer houseOwner painter obligor refNo` contract has only the painter as the signatory. Its associated key consists of the painter and the reference number. The painter is the maintainer.
-4.  A `PaintAgree houseOwner painter refNo` contract has both the house owner and the painter as signat The key consists of the painter and the reference number. The painter is the only maintainer.
+4.  A `PaintAgree houseOwner painter refNo` contract has both the house owner and the painter as signatory. The key consists of the painter and the reference number. The painter is the only maintainer.
 
 In the graphical representation below, signatories of a contract are indicated with a dollar sign (as a mnemonic for an obligation) and use a bold font. Maintainers are marked with `@` (as a mnemonic who enforces uniqueness). Since maintainers are always signatories, parties marked with `@` are implicitly signatories. For example, annotating the paint offer acceptance action with signatories yields the image below.
 
-<img src="/images/docs_website/signatories-paint-offer.svg" className="align-center" style={{width: "60.0%"}} alt="The original paint deal flowchart. P is a maintainer; A and the Bank are signatories." />
+<img src="/images/docs_website/signatories-paint-offer.svg" className="align-center" style={{width: "60.0%", backgroundColor: 'white'}} alt="The original paint deal flowchart. P is a maintainer; A and the Bank are signatories." />
 
 ### Authorization Rules
 


### PR DESCRIPTION
The diagram svg has transparent background  and did not show in dark mode, added white background to force its visibility. 