### PR TITLE
remove dpm add command that does not exist

### DIFF
--- a/docs-main/appdev/modules/m1-development-stack.mdx
+++ b/docs-main/appdev/modules/m1-development-stack.mdx
@@ -139,8 +139,7 @@ Manage dependencies and build workflows:
 # Initialize project
 dpm init
 
-# Add dependency
-dpm add package-name
+# Add dependency by editing dam.yaml
 
 # Build
 dpm build

--- a/docs-main/sdks-tools/cli-tools/dpm.mdx
+++ b/docs-main/sdks-tools/cli-tools/dpm.mdx
@@ -6,7 +6,6 @@ description: "Command reference and configuration for dpm, the primary CLI tool 
 import DamlDocsSdksToolsCliToolsDpmL14 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L14.mdx";
 import DamlDocsSdksToolsCliToolsDpmL24 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L24.mdx";
 import DamlDocsSdksToolsCliToolsDpmL30 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L30.mdx";
-import DamlDocsSdksToolsCliToolsDpmL36 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L36.mdx";
 import DamlDocsSdksToolsCliToolsDpmL44 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L44.mdx";
 import DamlDocsSdksToolsCliToolsDpmL50 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L50.mdx";
 import DamlDocsSdksToolsCliToolsDpmL56 from "/snippets/daml-docs/sdks-tools_cli-tools_dpm_L56.mdx";
@@ -147,10 +146,6 @@ dpm version --all -o json
 **`dpm new`** -- Create a new project from a template. Templates provide working examples that you can modify.
 
 <DamlDocsSdksToolsCliToolsDpmL30 />
-
-**`dpm add`** -- Add a dependency to your project. Updates `daml.yaml` with the new package reference.
-
-<DamlDocsSdksToolsCliToolsDpmL36 />
 
 ### Building and Testing
 

--- a/docs-main/snippets/daml-docs/sdks-tools_cli-tools_dpm_L36.mdx
+++ b/docs-main/snippets/daml-docs/sdks-tools_cli-tools_dpm_L36.mdx
@@ -1,3 +1,0 @@
-```bash
-dpm add some-package
-```


### PR DESCRIPTION
`dpm add` command does not exist in that form _yet_ so remove it from the docs for now

Coming soon: `dpm add component...` and `dpm add dar...`