### PR TITLE
dpm pre-reqs instructions: install rosetta for apple silicon users

### DIFF
--- a/docs-main/sdks-tools/cli-tools/dpm.mdx
+++ b/docs-main/sdks-tools/cli-tools/dpm.mdx
@@ -32,6 +32,11 @@ Dpm runs on Windows, macOS and Linux.  For full functionality, you must have ins
 
 1) [VS Code download](https://code.visualstudio.com/download)
 2) JDK 17 or greater, installed and part of your `JAVA_HOME`.  If you do not already have a JDK installed, try OpenJDK or [Eclipse Adoptium](https://adoptium.net/).
+3) If you are on a Mac with Apple Silicon, you may need to install Rosetta 2 to run x86 binaries.  You can do this by running the following command in a terminal:
+
+```shell
+softwareupdate --install-rosetta
+```
 
 ## Installation
 


### PR DESCRIPTION
• Include instructions to enable rosetta on a Mac with Apple Silicon in order to run x86 binaries that are available via dpm (like damlc and friends)