### PR TITLE
make dpm new available in cf docs repo

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,3 +1,4 @@
-override-components:
-    rst-to-mdx:
-      local-path: ./tools/rst-to-mdx
+components:
+    - name: rst-to-mdx
+      path: ./tools/rst-to-mdx
+    - daml-new:3.5.1


### PR DESCRIPTION
use opt-in component schema --> make `dpm new` available within the cf-docs repo

follow-on PR will use nix to get dpm within this repo rather than relying on the global installation