### PR TITLE
Add documentation for CantonBFT

### DIFF
--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -630,7 +630,7 @@ Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follow
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBFT, set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|successor).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -705,7 +705,7 @@ To install the Helm charts needed to start an SV node connected to the cluster, 
 export CHART_VERSION=0.6.8
 ```
 
-An SV node includes a CometBFT node so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
+Unless CantonBFT is being used, you also need to configure a CometBFT node for your SV. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
 
 - Replace all instances of `TARGET_CLUSTER` with test, per the cluster to which you are connecting.
 - Replace all instances of `TARGET_HOSTNAME` with test.global.canton.network.digitalasset.com, per the cluster to which you are connecting.
@@ -739,16 +739,16 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the
-      sequencer and in most cases a fully separate postgres instance is
+      sequencer. For production-grade deployments, a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBFT both of which put relatively heavy load on the
+      CantonBFT, both of which put significant load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|successor).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -823,7 +823,7 @@ To install the Helm charts needed to start an SV node connected to the cluster, 
 export CHART_VERSION=0.6.7
 ```
 
-An SV node includes a CometBFT node so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
+Unless CantonBFT is being used, you also need to configure a CometBFT node for your SV. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
 
 - Replace all instances of `TARGET_CLUSTER` with main, per the cluster to which you are connecting.
 - Replace all instances of `TARGET_HOSTNAME` with global.canton.network.digitalasset.com, per the cluster to which you are connecting.
@@ -857,16 +857,16 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the
-      sequencer and in most cases a fully separate postgres instance is
+      sequencer. For production-grade deployments, a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBFT both of which put relatively heavy load on the
+      CantonBFT, both of which put significant load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|successor).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -345,7 +345,7 @@ To setup the wallet, CNS and SV UI, create the following two secrets.
 
 ## Configuring your CometBFT node
 
-This step is only required when using cometbft. When using CantonBFT skip this step.
+**This step is only required when using CometBFT. When using CantonBFT skip this step.**
 
 Every SV node also deploys a CometBFT node. This node must be configured to join the existing Global Synchronizer BFT chain. To do that, you first must generate the keys that will identify the node.
 
@@ -587,7 +587,7 @@ To install the Helm charts needed to start an SV node connected to the cluster, 
 export CHART_VERSION=0.6.9
 ```
 
-An SV node includes a CometBFT node so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
+Unless CantonBFT is being used, you also need to configure a CometBFT node for your SV. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
 
 - Replace all instances of `TARGET_CLUSTER` with dev, per the cluster to which you are connecting.
 - Replace all instances of `TARGET_HOSTNAME` with dev.global.canton.network.digitalasset.com, per the cluster to which you are connecting.
@@ -617,20 +617,20 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
 - When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
-    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Set `sequencer.driver.externalPort: 443` and set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the
-      sequencer and in most cases a fully separate postgres instance is
+      sequencer. For production-grade deployments, a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBFT both of which put relatively heavy load on the
+      CantonBFT, both of which put significant load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT, set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -735,7 +735,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
 - When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
-    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Set `sequencer.driver.externalPort: 443` and set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the
@@ -853,7 +853,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
 - When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
-    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Set `sequencer.driver.externalPort: 443` and set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -345,6 +345,8 @@ To setup the wallet, CNS and SV UI, create the following two secrets.
 
 ## Configuring your CometBFT node
 
+This step is only required when using cometbft. When using CantonBft skip this step.
+
 Every SV node also deploys a CometBFT node. This node must be configured to join the existing Global Synchronizer BFT chain. To do that, you first must generate the keys that will identify the node.
 
 ### Generating your CometBFT node keys
@@ -613,11 +615,22 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
+- When using CantonBft instead of CometBFT
+    - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
+    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Configure the database through
+      `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
+      strongly recommended to use a separate database from the
+      sequencer and in most cases a fully separate postgres instance is
+      recommended for resource isolation between the sequencer and
+      CantonBft both of which put relatively heavy load on the
+      database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
+- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -656,6 +669,11 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
+- When using CantonBft instead of CometBFT, remove
+  `synchronizers.(current|legacy|successor).cometBFT` and instead set
+  `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
+  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 
@@ -715,11 +733,22 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
+- When using CantonBft instead of CometBFT
+    - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
+    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Configure the database through
+      `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
+      strongly recommended to use a separate database from the
+      sequencer and in most cases a fully separate postgres instance is
+      recommended for resource isolation between the sequencer and
+      CantonBft both of which put relatively heavy load on the
+      database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
+- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -758,6 +787,11 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
+- When using CantonBft instead of CometBFT, remove
+  `synchronizers.(current|legacy|successor).cometBFT` and instead set
+  `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
+  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 
@@ -817,11 +851,22 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
+- When using CantonBft instead of CometBFT
+    - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
+    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Configure the database through
+      `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
+      strongly recommended to use a separate database from the
+      sequencer and in most cases a fully separate postgres instance is
+      recommended for resource isolation between the sequencer and
+      CantonBft both of which put relatively heavy load on the
+      database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
+- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -860,6 +905,11 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
+- When using CantonBft instead of CometBFT, remove
+  `synchronizers.(current|legacy|successor).cometBFT` and instead set
+  `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
+  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 
@@ -1095,11 +1145,12 @@ Each SV is required to configure their cluster ingress to allow traffic from the
 - `https://scan.sv.<YOUR_HOSTNAME>` should be routed to service `scan-web-ui` in the `sv` namespace.
 - `https://scan.sv.<YOUR_HOSTNAME>/api/scan` should be routed to `/api/scan` at port 5012 in service `scan-app` in the `sv` namespace.
 - `https://scan.sv.<YOUR_HOSTNAME>/registry` should be routed to `/registry` at port 5012 in service `scan-app` in the `sv` namespace.
-- `global-domain-<SERIAL_ID>-cometbft.sv.<YOUR_HOSTNAME>:26<SERIAL_ID>56` should be routed to port 26656 of service `global-domain-<SERIAL_ID>-cometbft-cometbft-p2p` in the `sv` namespace using the TCP protocol. Please note that cometBFT traffic is purely TCP. TLS is not supported so SNI host routing for these traffic is not possible.
 - `https://cns.sv.<YOUR_HOSTNAME>` should be routed to service `ans-web-ui` in the `sv` namespace.
 - `https://cns.sv.<YOUR_HOSTNAME>/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `sv` namespace.
 - `https://sequencer-<SERIAL_ID>.sv.<YOUR_HOSTNAME>` should be routed to port 5008 of service `global-domain-<SERIAL_ID>-sequencer` in the `sv` namespace.
 - `https://info.sv.<YOUR_HOSTNAME>` should be routed to service `info` in the `sv` namespace. This endpoint should be publicly accessible without any IP restrictions.
+- When using CometBFT: `global-domain-<SERIAL_ID>-cometbft.sv.<YOUR_HOSTNAME>:26<SERIAL_ID>56` should be routed to port 26656 of service `global-domain-<SERIAL_ID>-cometbft-cometbft-p2p` in the `sv` namespace using the TCP protocol. Please note that cometBFT traffic is purely TCP. TLS is not supported so SNI host routing for these traffic is not possible.
+- When using CantonBft: `https://sequencer-p2p-<SERIAL_ID>.sv.<YOUR_HOSTNAME>` should be routed to port 5010 of service `global-domain-<SERIAL_ID>-sequencer` in the `sv` namespace. Only other SVs need access to this but not validators.
 
 <Warning>
 To keep the attack surface on your SV deployment and the Global Synchronizer small, please disallow ingress connections to all other services in your SV deployment. It should be assumed that opening up *any* additional port or service represents a security risk that needs to be carefully evaluated on a case-by-case basis.
@@ -1510,10 +1561,11 @@ Below is a complete list of destinations for outbound traffic from the Super Val
 
 Connectivity to the following destinations is required throughout operation to ensure the robustness of the ordering layer and scan:
 
-| Destination  | Url                                                                              | Protocol | Source pod                   |
-|--------------|----------------------------------------------------------------------------------|----------|------------------------------|
-| CometBft P2P | CometBft p2p IPs and ports `26<S>16`, `26<S>26`, `26<S>36`, `26<S>46`, `26<S>56` | TCP      | `global-domain-<S>-cometbft` |
-| All SV Scans | all returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans`        | HTTPS    | scan-app                     |
+| Destination   | Url                                                                                                  | Protocol | Source pod                   |
+|---------------|------------------------------------------------------------------------------------------------------|----------|------------------------------|
+| CometBft P2P  | CometBft p2p IPs and ports `26<S>16`, `26<S>26`, `26<S>36`, `26<S>46`, `26<S>56`                     | TCP      | `global-domain-<S>-cometbft` |
+| CantonBft P2P | urls returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/sv-bft-sequencers` for _all_ SVs | HTTPS    | `global-domain-<S>`          |
+| All SV Scans  | all returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans`                            | HTTPS    | scan-app and sv-app          |
 
 Connectivity from the local scan app to the scan instances of all other SVs is required so that the scan app can backfill its data in a `BFT` fashion. It might also be required in the future to support the operation of the ordering layer (post CometBFT). To get a list of all current scan instances, you can query the `/api/scan/v0/scans` endpoint on any scan instances known to you. For example using the sponsor's scan instance (and with some optional post-processing using [jq](https://jqlang.org/)):
 
@@ -1579,3 +1631,13 @@ Note that SVs must wait `voteCooldownTime` (a governance parameter that defaults
 [^1]: The URL must be reachable from the Canton participant, validator app and SV app running in your cluster, as well as from all web browsers that should be able to interact with the SV and wallet UIs.
 
 {/* COPIED_END */}
+
+## Summary of required changes for CantonBft
+
+The detailed changes are listed in the respective sections above. This section only provides an overview over which components require changes:
+
+- No CometBFT helm chart
+- SV app synchronizers need to be configured to use CantonBft instead of CometBFT
+- Scan must be configured with the p2p url of your own CantonBft node.
+- The global-domain helm chart must be configured to use the CantonBft driver and configured with the database for CantonBft.
+- The p2p url of your CantonBft node must be exposed in your ingress towards other Super Validators.

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -345,7 +345,7 @@ To setup the wallet, CNS and SV UI, create the following two secrets.
 
 ## Configuring your CometBFT node
 
-This step is only required when using cometbft. When using CantonBft skip this step.
+This step is only required when using cometbft. When using CantonBFT skip this step.
 
 Every SV node also deploys a CometBFT node. This node must be configured to join the existing Global Synchronizer BFT chain. To do that, you first must generate the keys that will identify the node.
 
@@ -615,7 +615,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
-- When using CantonBft instead of CometBFT
+- When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
     - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
@@ -623,14 +623,14 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
       strongly recommended to use a separate database from the
       sequencer and in most cases a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBft both of which put relatively heavy load on the
+      CantonBFT both of which put relatively heavy load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -669,10 +669,10 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
-- When using CantonBft instead of CometBFT, remove
+- When using CantonBFT instead of CometBFT, remove
   `synchronizers.(current|legacy|successor).cometBFT` and instead set
   `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
-  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  When migrating from CometBFT to CantonBFT only set it for the `synchronizers` that actually use CantonBFT while
   keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
@@ -733,7 +733,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
-- When using CantonBft instead of CometBFT
+- When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
     - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
@@ -741,14 +741,14 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
       strongly recommended to use a separate database from the
       sequencer and in most cases a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBft both of which put relatively heavy load on the
+      CantonBFT both of which put relatively heavy load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -787,10 +787,10 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
-- When using CantonBft instead of CometBFT, remove
+- When using CantonBFT instead of CometBFT, remove
   `synchronizers.(current|legacy|successor).cometBFT` and instead set
   `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
-  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  When migrating from CometBFT to CantonBFT only set it for the `synchronizers` that actually use CantonBFT while
   keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
@@ -851,7 +851,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
-- When using CantonBft instead of CometBFT
+- When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
     - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
@@ -859,14 +859,14 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
       strongly recommended to use a separate database from the
       sequencer and in most cases a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBft both of which put relatively heavy load on the
+      CantonBFT both of which put relatively heavy load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -905,10 +905,10 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
-- When using CantonBft instead of CometBFT, remove
+- When using CantonBFT instead of CometBFT, remove
   `synchronizers.(current|legacy|successor).cometBFT` and instead set
   `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
-  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  When migrating from CometBFT to CantonBFT only set it for the `synchronizers` that actually use CantonBFT while
   keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
@@ -1150,7 +1150,7 @@ Each SV is required to configure their cluster ingress to allow traffic from the
 - `https://sequencer-<SERIAL_ID>.sv.<YOUR_HOSTNAME>` should be routed to port 5008 of service `global-domain-<SERIAL_ID>-sequencer` in the `sv` namespace.
 - `https://info.sv.<YOUR_HOSTNAME>` should be routed to service `info` in the `sv` namespace. This endpoint should be publicly accessible without any IP restrictions.
 - When using CometBFT: `global-domain-<SERIAL_ID>-cometbft.sv.<YOUR_HOSTNAME>:26<SERIAL_ID>56` should be routed to port 26656 of service `global-domain-<SERIAL_ID>-cometbft-cometbft-p2p` in the `sv` namespace using the TCP protocol. Please note that cometBFT traffic is purely TCP. TLS is not supported so SNI host routing for these traffic is not possible.
-- When using CantonBft: `https://sequencer-p2p-<SERIAL_ID>.sv.<YOUR_HOSTNAME>` should be routed to port 5010 of service `global-domain-<SERIAL_ID>-sequencer` in the `sv` namespace. Only other SVs need access to this but not validators.
+- When using CantonBFT: `https://sequencer-p2p-<SERIAL_ID>.sv.<YOUR_HOSTNAME>` should be routed to port 5010 of service `global-domain-<SERIAL_ID>-sequencer` in the `sv` namespace. Only other SVs need access to this but not validators.
 
 <Warning>
 To keep the attack surface on your SV deployment and the Global Synchronizer small, please disallow ingress connections to all other services in your SV deployment. It should be assumed that opening up *any* additional port or service represents a security risk that needs to be carefully evaluated on a case-by-case basis.
@@ -1564,7 +1564,7 @@ Connectivity to the following destinations is required throughout operation to e
 | Destination   | Url                                                                                                  | Protocol | Source pod                   |
 |---------------|------------------------------------------------------------------------------------------------------|----------|------------------------------|
 | CometBft P2P  | CometBft p2p IPs and ports `26<S>16`, `26<S>26`, `26<S>36`, `26<S>46`, `26<S>56`                     | TCP      | `global-domain-<S>-cometbft` |
-| CantonBft P2P | urls returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/sv-bft-sequencers` for _all_ SVs | HTTPS    | `global-domain-<S>`          |
+| CantonBFT P2P | urls returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/sv-bft-sequencers` for _all_ SVs | HTTPS    | `global-domain-<S>`          |
 | All SV Scans  | all returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans`                            | HTTPS    | scan-app and sv-app          |
 
 Connectivity from the local scan app to the scan instances of all other SVs is required so that the scan app can backfill its data in a `BFT` fashion. It might also be required in the future to support the operation of the ordering layer (post CometBFT). To get a list of all current scan instances, you can query the `/api/scan/v0/scans` endpoint on any scan instances known to you. For example using the sponsor's scan instance (and with some optional post-processing using [jq](https://jqlang.org/)):
@@ -1632,12 +1632,12 @@ Note that SVs must wait `voteCooldownTime` (a governance parameter that defaults
 
 {/* COPIED_END */}
 
-## Summary of required changes for CantonBft
+## Summary of required changes for CantonBFT
 
 The detailed changes are listed in the respective sections above. This section only provides an overview over which components require changes:
 
 - No CometBFT helm chart
-- SV app synchronizers need to be configured to use CantonBft instead of CometBFT
-- Scan must be configured with the p2p url of your own CantonBft node.
-- The global-domain helm chart must be configured to use the CantonBft driver and configured with the database for CantonBft.
-- The p2p url of your CantonBft node must be exposed in your ingress towards other Super Validators.
+- SV app synchronizers need to be configured to use CantonBFT instead of CometBFT
+- Scan must be configured with the p2p url of your own CantonBFT node.
+- The global-domain helm chart must be configured to use the CantonBFT driver and configured with the database for CantonBFT.
+- The p2p url of your CantonBFT node must be exposed in your ingress towards other Super Validators.

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
@@ -34,11 +34,22 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
+- When using CantonBft instead of CometBFT
+    - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
+    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Configure the database through
+      `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
+      strongly recommended to use a separate database from the
+      sequencer and in most cases a fully separate postgres instance is
+      recommended for resource isolation between the sequencer and
+      CantonBft both of which put relatively heavy load on the
+      database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
+- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -74,6 +85,11 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
+- When using CantonBft instead of CometBFT, remove
+  `synchronizers.(current|legacy|successor).cometBFT` and instead set
+  `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
+  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:
 

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
@@ -34,7 +34,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
-- When using CantonBft instead of CometBFT
+- When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
     - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
@@ -42,14 +42,14 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
       strongly recommended to use a separate database from the
       sequencer and in most cases a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBft both of which put relatively heavy load on the
+      CantonBFT both of which put relatively heavy load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBft set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 
@@ -85,10 +85,10 @@ For configuring your sv app, please modify the file `splice-node/examples/sv-hel
 - Replace `YOUR_CONTACT_POINT` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. If you do not want to share this, set it to an empty string.
 - If you would like to redistribute all or part of the SV rewards with other parties, you can fill up the `extraBeneficiaries` section with the desired parties and the percentage of the reward that corresponds to them. Note that the party you register must be known on the network for the reward coupon issuance to succeed. Furthermore, that party must be hosted on a validator node for its wallet to collect the SV reward coupons. That collection will happen automatically if the wallet is running. If it is not running during the time that the reward coupon can be collected, the corresponding reward is marked as unclaimed, and stored in an DSO-wide unclaimed reward pool. The `extraBeneficiaries` can be changed with just a restart of the SV app.
 - Optionally, uncomment the line for `initialAmuletPrice` and set it to your desired amulet price. This will create an amulet price vote from your SV with the configured price when onboarded. If not set, no vote will be cast. This can always be done later manually from the SV app UI.
-- When using CantonBft instead of CometBFT, remove
+- When using CantonBFT instead of CometBFT, remove
   `synchronizers.(current|legacy|successor).cometBFT` and instead set
   `synchronizers.(current|legacy|successor).enableBftSequencer: true`.
-  When migrating from CometBFT to CantonBft only set it for the `synchronizers` that actually use CantonBft while
+  When migrating from CometBFT to CantonBFT only set it for the `synchronizers` that actually use CantonBFT while
   keeping the CometBFT config for the existing physical synchronizers.
 
 Please modify the file `splice-node/examples/sv-helm/info-values.yaml` as follows:

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
@@ -6,7 +6,7 @@ To install the Helm charts needed to start an SV node connected to the cluster, 
 |chart_version_set|
 ```
 
-An SV node includes a CometBFT node so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
+Unless CantonBFT is being used, you also need to configure a CometBFT node for your SV. Please modify the file `splice-node/examples/sv-helm/cometbft-values.yaml` as follows:
 
 - Replace all instances of `TARGET_CLUSTER` with |splice_cluster|, per the cluster to which you are connecting.
 - Replace all instances of `TARGET_HOSTNAME` with |da_hostname|, per the cluster to which you are connecting.
@@ -40,9 +40,9 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the
-      sequencer and in most cases a fully separate postgres instance is
+      sequencer. For production-grade deployments, a fully separate postgres instance is
       recommended for resource isolation between the sequencer and
-      CantonBFT both of which put relatively heavy load on the
+      CantonBFT, both of which put significant load on the
       database.
 
 Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follows:

--- a/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
+++ b/docs-main/snippets/networkvars/global-synchronizer/deployment/kubernetes-deployment-4.mdx
@@ -36,7 +36,7 @@ Please modify the file `splice-node/examples/sv-helm/global-domain-values.yaml` 
 - Replace `YOUR_SV_NAME` with the name you chose when creating the SV identity.
 - When using CantonBFT instead of CometBFT
     - Replace `sequencer.driver.type: cometbft` by `sequencer.driver.type: cantonbft` and remove the host and port configuration.
-    - Set `sequencer.driver.externalPort: 443` and Set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+    - Set `sequencer.driver.externalPort: 443` and set `sequencer.driver.externalAddress: sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
     - Configure the database through
       `sequencer.driver.persistence.(host|port|databaseName|secretName)`. It is
       strongly recommended to use a separate database from the
@@ -49,7 +49,7 @@ Please modify the file `splice-node/examples/sv-helm/scan-values.yaml` as follow
 
 - No longer needed since splice `0.6.8`: Replace all instances of `MIGRATION_ID` with the migration ID of the global synchronizer on your target cluster.
 - Replace all instances of `SERIAL_ID` with the serial ID of the global synchronizer on your target cluster.
-- When using CantonBFT set `synchronizers.(current|legacy|upgrade).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
+- When using CantonBFT set `synchronizers.(current|legacy|successor).bftSequencerConfig.p2pUrl: https://sequencer-p2p-SERIAL_ID.sv.YOUR_HOSTNAME`
 
 An SV node includes a validator app so you also need to configure that. Please modify the file `splice-node/examples/sv-helm/validator-values.yaml` as follows:
 


### PR DESCRIPTION
Two things to point out:

1. There are still a bunch of diagrams that are not updated. Having two versions of those seems annoying so I'm leaning towards just waiting until we fully switched to CantonBft and then replace them.
2. I'm not fully sure which variant of dabft/cantonbft with what capitalization is official now. Just used one that seems ok and it's easy to search replace once I get an answer.