### PR TITLE
fixes typo in synchronizers.connect_multi

### DIFF
--- a/docs-main/global-synchronizer/reference/canton-console-commands.mdx
+++ b/docs-main/global-synchronizer/reference/canton-console-commands.mdx
@@ -1403,7 +1403,7 @@ Macro to connect a participant to a synchronizer that supports connecting via ma
 
 Synchronizers can provide many endpoints to connect to for availability and performance benefits. This version of connect allows specifying multiple endpoints for a single synchronizer connection: connect_multi("mysynchronizer", Seq(sequencer1, sequencer2)) or: connect_multi("mysynchronizer", Seq("https://host1.mysynchronizer.net", "https://host2.mysynchronizer.net", "https://host3.mysynchronizer.net"))
 
-To create a more advanced connection config use synchronizers.to_config with a single host, then use config.addConnection to add additional connections before connecting: config = myparticipaint.synchronizers.to_config("mysynchronizer", "https://host1.mysynchronizer.net", ...otherArguments) config = config.addConnection("https://host2.mysynchronizer.net", "https://host3.mysynchronizer.net") myparticipant.synchronizers.connect(config)
+To create a more advanced connection config use synchronizers.to_config with a single host, then use config.addConnection to add additional connections before connecting: config = myparticipant.synchronizers.to_config("mysynchronizer", "https://host1.mysynchronizer.net", ...otherArguments) config = config.addConnection("https://host2.mysynchronizer.net", "https://host3.mysynchronizer.net") myparticipant.synchronizers.connect(config)
 
 The arguments are:
 


### PR DESCRIPTION
Resolves typo "`myparticipaint`."
