### PR TITLE
Add Daml.Script API reference page

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -602,6 +602,7 @@
               "sdks-tools/cli-tools/dpm",
               "sdks-tools/cli-tools/canton-console",
               "sdks-tools/cli-tools/daml-script",
+              "sdks-tools/cli-tools/daml-script-api",
               "sdks-tools/cli-tools/daml-shell"
             ]
           },

--- a/docs-main/sdks-tools/cli-tools/daml-script-api.mdx
+++ b/docs-main/sdks-tools/cli-tools/daml-script-api.mdx
@@ -1,0 +1,1847 @@
+---
+title: "Daml.Script API Reference"
+description: "Complete API reference for the Daml.Script module, including typeclasses, data types, and functions."
+---
+
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml-script/api/Daml-Script.rst" hash="d624a6eb" */}
+
+The Daml Script testing library.
+
+## Typeclasses
+
+<div id="class-daml-script-internal-questions-submit-issubmitoptions-64211">
+
+**class** IsSubmitOptions options **where**
+
+</div>
+
+> Defines a type that can be transformed into a SubmitOptions
+>
+> <div id="function-daml-script-internal-questions-submit-tosubmitoptions-99319">
+>
+> toSubmitOptions
+> : options -\> SubmitOptions
+>
+> </div>
+
+<div id="class-daml-script-internal-questions-submit-scriptsubmit-55101">
+
+**class** [Applicative](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257) script =\> ScriptSubmit script **where**
+
+</div>
+
+> Defines an applicative that can run transaction submissions. Usually this is simply `Script`.
+>
+> <div id="function-daml-script-internal-questions-submit-liftsubmission-99954">
+>
+> liftSubmission
+> : [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> ConcurrentSubmits a -\> script a
+>
+> </div>
+
+## Data Types
+
+<div id="type-daml-script-internal-questions-usermanagement-invaliduserid-35585">
+
+**data** InvalidUserId
+
+</div>
+
+> Thrown if text for a user identifier does not conform to the format restriction.
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-invaliduserid-47622">
+>
+> InvalidUserId
+>
+> </div>
+>
+> > | Field | Type                                                                                                         | Description |
+> > |-------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | m     | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+
+<div id="type-daml-script-internal-questions-usermanagement-user-21930">
+
+**data** User
+
+</div>
+
+> User-info record for a user in the user management service.
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-user-51383">
+>
+> User
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                                                                                                                                               | Description |
+> > |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | userId       | UserId                                                                                                                                                                                                                                             |             |
+> > | primaryParty | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |             |
+
+<div id="type-daml-script-internal-questions-usermanagement-useralreadyexists-98333">
+
+**data** UserAlreadyExists
+
+</div>
+
+> Thrown if a user to be created already exists.
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-useralreadyexists-40670">
+>
+> UserAlreadyExists
+>
+> </div>
+>
+> > | Field  | Type   | Description |
+> > |--------|--------|-------------|
+> > | userId | UserId |             |
+
+<div id="type-daml-script-internal-questions-usermanagement-userid-11123">
+
+**data** UserId
+
+</div>
+
+> Identifier for a user in the user management service.
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-userid-52094">
+>
+> UserId [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> </div>
+
+<div id="type-daml-script-internal-questions-usermanagement-usernotfound-44479">
+
+**data** UserNotFound
+
+</div>
+
+> Thrown if a user cannot be located for a given user identifier.
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-usernotfound-26338">
+>
+> UserNotFound
+>
+> </div>
+>
+> > | Field  | Type   | Description |
+> > |--------|--------|-------------|
+> > | userId | UserId |             |
+
+<div id="type-daml-script-internal-questions-usermanagement-userright-13475">
+
+**data** UserRight
+
+</div>
+
+> The rights of a user.
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-participantadmin-36398">
+>
+> ParticipantAdmin
+>
+> </div>
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-canactas-78256">
+>
+> CanActAs [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> </div>
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-canreadas-21035">
+>
+> CanReadAs [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> </div>
+>
+> <div id="constr-daml-script-internal-questions-usermanagement-canreadasanyparty-13813">
+>
+> CanReadAsAnyParty
+>
+> </div>
+
+<div id="type-daml-script-internal-questions-submit-concurrentsubmits-82688">
+
+**data** ConcurrentSubmits a
+
+</div>
+
+> Applicative that allows for multiple concurrent transaction submissions See `concurrently` for usage of this type.
+>
+> <div id="constr-daml-script-internal-questions-submit-concurrentsubmits-49827">
+>
+> ConcurrentSubmits
+>
+> </div>
+>
+> > | Field    | Type                                                                                                                                                                       | Description |
+> > |----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | submits  | \[Submission\]                                                                                                                                                             |             |
+> > | continue | \[[Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) SubmitError (\[CommandResult\], TransactionTree)\] -\> a |             |
+
+<div id="type-daml-script-internal-questions-submit-packageid-95921">
+
+**data** PackageId
+
+</div>
+
+> Package-id newtype for package preference
+>
+> <div id="constr-daml-script-internal-questions-submit-packageid-38878">
+>
+> PackageId [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> </div>
+
+<div id="type-daml-script-internal-questions-submit-submitoptions-56692">
+
+**data** SubmitOptions
+
+</div>
+
+> Options to detemine the stakeholders of a transaction, as well as disclosures. Intended to be specified using the `actAs`, `readAs` and `disclose` builders, combined using the Semigroup concat `(<>)` operator.
+>
+> ```daml
+> actAs alice <> readAs [alice, bob] <> disclose myContract
+> ```text
+>
+> Note that actAs and readAs follows the same party derivation rules as `signatory`, see their docs for examples. All submissions must specify at least one `actAs` party, else a runtime error will be thrown. A minimum submission may look like
+>
+> ```daml
+> actAs alice `submit` createCmd MyContract with party = alice
+> ```text
+>
+> For backwards compatibility, a single or set of parties can be provided in place of the `SubmitOptions` to `submit`, which will represent the `actAs` field. The above example could be reduced to
+>
+> ```daml
+> alice `submit` createCmd MyContract with party = alice
+> ```text
+>
+> <div id="constr-daml-script-internal-questions-submit-submitoptions-37975">
+>
+> SubmitOptions
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                         | Description |
+> > |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | soActAs             | \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                      |             |
+> > | soReadAs            | \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                      |             |
+> > | soDisclosures       | \[Disclosure\]                                                                                                                               |             |
+> > | soPackagePreference | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) \[PackageId\] |             |
+> > | soPrefetchKeys      | \[[AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193)\]   |             |
+
+<div id="type-daml-script-internal-questions-submit-error-cryptoerrortype-71749">
+
+**data** CryptoErrorType
+
+</div>
+
+> Daml Crypto (Secp256k1) related submission errors
+>
+> <div id="constr-daml-script-internal-questions-submit-error-malformedbyteencoding-79193">
+>
+> MalformedByteEncoding
+>
+> </div>
+>
+> > | Field | Type                                                                                                         | Description |
+> > |-------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | value | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-malformedkey-58536">
+>
+> MalformedKey
+>
+> </div>
+>
+> > | Field    | Type                                                                                                         | Description |
+> > |----------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | keyValue | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-malformedsignature-13573">
+>
+> MalformedSignature
+>
+> </div>
+>
+> > | Field          | Type                                                                                                         | Description |
+> > |----------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | signatureValue | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-malformedcontractid-56895">
+>
+> MalformedContractId
+>
+> </div>
+>
+> > | Field           | Type                                                                                                         | Description |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractIdValue | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+
+<div id="type-daml-script-internal-questions-submit-error-submiterror-38284">
+
+**data** SubmitError
+
+</div>
+
+> Errors that can be thrown by a command submission via `trySubmit`
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contractnotfound-62819">
+>
+> ContractNotFound
+>
+> </div>
+>
+> > Contract with given contract ID could not be found, and has never existed on this participant When run on Canton, there may be more than one contract ID, and additionalDebuggingInfo is always None On the other hand, when run on IDELedger, there is only ever one contract ID, and additionalDebuggingInfo is always Some
+> >
+> > | Field                   | Type                                                                                                                                                                                                                                                | Description                                                                                    |
+> > |-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+> > | unknownContractIds      | [NonEmpty](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-NonEmpty-Types.html#type-da-nonempty-types-nonempty-16010) [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | Provided as text, as we do not know the template ID of a contract if the lookup fails          |
+> > | additionalDebuggingInfo | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ContractNotFoundAdditionalInfo                                                                                       | should always be None in Canton's case, see https://github.com/digital-asset/daml/issues/17154 |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contractkeynotfound-79659">
+>
+> ContractKeyNotFound
+>
+> </div>
+>
+> > Contract with given contract key could not be found
+> >
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractKey | [AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-unresolvedpackagename-661">
+>
+> UnresolvedPackageName
+>
+> </div>
+>
+> > No vetted package with given package name could be found
+> >
+> > | Field       | Type                                                                                                         | Description |
+> > |-------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | packageName | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-authorizationerror-69757">
+>
+> AuthorizationError
+>
+> </div>
+>
+> > Generic authorization failure, included missing party authority, invalid signatories, etc.
+> >
+> > | Field                     | Type                                                                                                         | Description |
+> > |---------------------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | authorizationErrorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contracthashingerror-75608">
+>
+> ContractHashingError
+>
+> </div>
+>
+> > Failed to hash a contract
+> >
+> > | Field         | Type                                                                                                                                     | Description |
+> > |---------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractId    | AnyContractId                                                                                                                            |             |
+> > | dstTemplateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | createArg     | [AnyTemplate](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703)         |             |
+> > | errorMessage  | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                             |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-disclosedcontractkeyhashingerror-69749">
+>
+> DisclosedContractKeyHashingError
+>
+> </div>
+>
+> > Given disclosed contract key does not match the contract key of the contract on ledger.
+> >
+> > | Field        | Type                                                                                                                                   | Description |
+> > |--------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractId   | AnyContractId                                                                                                                          |             |
+> > | expectedKey  | [AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193) |             |
+> > | givenKeyHash | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                           |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-duplicatecontractkey-60422">
+>
+> DuplicateContractKey
+>
+> </div>
+>
+> > Attempted to create a contract with a contract key that already exists
+> >
+> > | Field                | Type                                                                                                                                                                                                                                                                  | Description                                            |
+> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+> > | duplicateContractKey | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193) | Canton will often not provide this key, IDELedger will |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-inconsistentcontractkey-74433">
+>
+> InconsistentContractKey
+>
+> </div>
+>
+> > Contract key lookup yielded different results
+> >
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractKey | [AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-unhandledexception-86682">
+>
+> UnhandledException
+>
+> </div>
+>
+> > Unhandled user thrown exception
+> >
+> > | Field | Type                                                                                                                                                                                                                                                            | Description                                                                                                                 |
+> > |-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+> > | exc   | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [AnyException](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-anyexception-7004) | Errors more complex than simple records cannot currently be encoded over the grpc status. Such errors will be missing here. |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-usererror-2902">
+>
+> UserError
+>
+> </div>
+>
+> > Transaction failure due to abort/assert calls pre-exceptions
+> >
+> > | Field            | Type                                                                                                         | Description |
+> > |------------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | userErrorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-templatepreconditionviolated-57506">
+>
+> TemplatePreconditionViolated
+>
+> </div>
+>
+> > Failure due to false result from `ensure`, strictly pre-exception. According to docs, not throwable with LF \>= 1.14. On LF \>= 1.14, a failed `ensure` will result in a `PreconditionFailed` exception wrapped in `UnhandledException`.
+>
+> <div id="constr-daml-script-internal-questions-submit-error-createemptycontractkeymaintainers-30280">
+>
+> CreateEmptyContractKeyMaintainers
+>
+> </div>
+>
+> > Attempted to create a contract with empty contract key maintainers
+> >
+> > | Field           | Type                                                                                                                             | Description |
+> > |-----------------|----------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | invalidTemplate | [AnyTemplate](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-fetchemptycontractkeymaintainers-19351">
+>
+> FetchEmptyContractKeyMaintainers
+>
+> </div>
+>
+> > Attempted to fetch a contract with empty contract key maintainers
+> >
+> > | Field             | Type                                                                                                                                   | Description |
+> > |-------------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | failedTemplateKey | [AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-wronglytypedcontract-14384">
+>
+> WronglyTypedContract
+>
+> </div>
+>
+> > Attempted to exercise/fetch a contract with the wrong template type
+> >
+> > | Field              | Type                                                                                                                                     | Description                            |
+> > |--------------------|------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+> > | contractId         | AnyContractId                                                                                                                            | Any contract Id of the actual contract |
+> > | expectedTemplateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |                                        |
+> > | actualTemplateId   | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |                                        |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contractdoesnotimplementinterface-89439">
+>
+> ContractDoesNotImplementInterface
+>
+> </div>
+>
+> > Attempted to use a contract as an interface that it does not implement
+> >
+> > | Field       | Type                                                                                                                                     | Description |
+> > |-------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractId  | AnyContractId                                                                                                                            |             |
+> > | templateId  | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | interfaceId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contractdoesnotimplementrequiringinterface-51672">
+>
+> ContractDoesNotImplementRequiringInterface
+>
+> </div>
+>
+> > Attempted to use a contract as a required interface that it does not implement
+> >
+> > | Field                | Type                                                                                                                                     | Description |
+> > |----------------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractId           | AnyContractId                                                                                                                            |             |
+> > | templateId           | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | requiredInterfaceId  | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | requiringInterfaceId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-noncomparablevalues-97474">
+>
+> NonComparableValues
+>
+> </div>
+>
+> > Attempted to compare values that are not comparable
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contractidincontractkey-60542">
+>
+> ContractIdInContractKey
+>
+> </div>
+>
+> > Illegal Contract ID found in Contract Key
+> >
+> > (no fields)
+>
+> <div id="constr-daml-script-internal-questions-submit-error-contractidcomparability-98492">
+>
+> ContractIdComparability
+>
+> </div>
+>
+> > Attempted to compare incomparable contract IDs. You're doing something very wrong. Two contract IDs with the same prefix are incomparable if one of them is local and the other non-local or if one is relative and the other relative or absolute with a different suffix.
+> >
+> > | Field                    | Type                                                                                                         | Description                                           |
+> > |--------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+> > | globalExistingContractId | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | We do not know the template ID at time of comparison. |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-valuenesting-53471">
+>
+> ValueNesting
+>
+> </div>
+>
+> > A value has been nested beyond a given depth limit
+> >
+> > | Field | Type                                                                                                       | Description                     |
+> > |-------|------------------------------------------------------------------------------------------------------------|---------------------------------|
+> > | limit | [Int](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | Nesting limit that was exceeded |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-localverdictlockedcontracts-9414">
+>
+> LocalVerdictLockedContracts
+>
+> </div>
+>
+> > The transaction refers to locked contracts which are in the process of being created, transferred, or archived by another transaction. If the other transaction fails, this transaction could be successfully retried.
+> >
+> > | Field                       | Type              | Description         |
+> > |-----------------------------|-------------------|---------------------|
+> > | localVerdictLockedContracts | \[AnyContractId\] | Locked contract ids |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-localverdictlockedkeys-14824">
+>
+> LocalVerdictLockedKeys
+>
+> </div>
+>
+> > The transaction refers to locked keys which are in the process of being modified by another transaction.
+> >
+> > | Field                  | Type                                                                                                                                       | Description          |
+> > |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+> > | localVerdictLockedKeys | \[[AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193)\] | Locked contract keys |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-upgradeerror-4562">
+>
+> UpgradeError
+>
+> </div>
+>
+> > Upgrade exception
+> >
+> > | Field        | Type                                                                                                         | Description |
+> > |--------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | errorType    | UpgradeErrorType                                                                                             |             |
+> > | errorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-failurestatuserror-13880">
+>
+> FailureStatusError
+>
+> </div>
+>
+> > Exception resulting from call to `failWithStatus`
+> >
+> > | Field         | Type                                                                                                                                        | Description |
+> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | failureStatus | [FailureStatus](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Fail.html#type-da-internal-fail-types-failurestatus-69615) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-cryptoerror-24426">
+>
+> CryptoError
+>
+> </div>
+>
+> > Crypto exceptions
+> >
+> > | Field              | Type                                                                                                         | Description |
+> > |--------------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | cryptoErrorType    | CryptoErrorType                                                                                              |             |
+> > | cryptoErrorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-deverror-73533">
+>
+> DevError
+>
+> </div>
+>
+> > Development feature exceptions
+> >
+> > | Field           | Type                                                                                                         | Description |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | devErrorType    | DevErrorType                                                                                                 |             |
+> > | devErrorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-unknownerror-23808">
+>
+> UnknownError
+>
+> </div>
+>
+> > Generic catch-all for missing errors.
+> >
+> > | Field               | Type                                                                                                         | Description |
+> > |---------------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | unknownErrorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-truncatederror-47926">
+>
+> TruncatedError
+>
+> </div>
+>
+> > One of the above error types where the full exception body did not fit into the response, and was incomplete.
+> >
+> > | Field                 | Type                                                                                                         | Description                                                                                 |
+> > |-----------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+> > | truncatedErrorType    | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | One of the constructor names of SubmitFailure except DevError, UnknownError, TruncatedError |
+> > | truncatedErrorMessage | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |                                                                                             |
+
+<div id="type-daml-script-internal-questions-submit-error-upgradeerrortype-94779">
+
+**data** UpgradeErrorType
+
+</div>
+
+> SCU related submission errors
+>
+> <div id="constr-daml-script-internal-questions-submit-error-validationfailed-35370">
+>
+> ValidationFailed
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                                                                                                                                                                                                                                                                             | Description |
+> > |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | coid                  | AnyContractId                                                                                                                                                                                                                                                                                                                                                                                    |             |
+> > | srcTemplateId         | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792)                                                                                                                                                                                                                                                         |             |
+> > | dstTemplateId         | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792)                                                                                                                                                                                                                                                         |             |
+> > | srcPackageName        | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                                                                                                                                                                                                                                                                                     |             |
+> > | dstPackageName        | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                                                                                                                                                                                                                                                                                     |             |
+> > | originalSignatories   | \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                                                                                                                                                                                          |             |
+> > | originalObservers     | \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                                                                                                                                                                                          |             |
+> > | originalKeyOpt        | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193), \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]) |             |
+> > | recomputedSignatories | \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                                                                                                                                                                                          |             |
+> > | recomputedObservers   | \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                                                                                                                                                                                          |             |
+> > | recomputedKeyOpt      | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193), \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]) |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-translationfailed-4701">
+>
+> TranslationFailed
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                         | Description |
+> > |---------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | mCoid         | [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId |             |
+> > | srcTemplateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792)     |             |
+> > | dstTemplateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792)     |             |
+> > | createArg     | [AnyTemplate](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703)             |             |
+>
+> <div id="constr-daml-script-internal-questions-submit-error-authenticationfailed-3671">
+>
+> AuthenticationFailed
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                     | Description |
+> > |---------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | coid          | AnyContractId                                                                                                                            |             |
+> > | srcTemplateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | dstTemplateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | createArg     | [AnyTemplate](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703)         |             |
+
+<div id="type-daml-script-internal-questions-transactiontree-created-98301">
+
+**data** Created
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-created-79356">
+>
+> Created
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                             | Description |
+> > |------------|----------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractId | AnyContractId                                                                                                                    |             |
+> > | argument   | [AnyTemplate](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703) |             |
+
+<div id="type-daml-script-internal-questions-transactiontree-createdindexpayload-52051">
+
+**data** CreatedIndexPayload t
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-createdindexpayload-17054">
+>
+> CreatedIndexPayload
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                     | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | templateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | offset     | [Int](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)                               |             |
+
+<div id="type-daml-script-internal-questions-transactiontree-exercised-22057">
+
+**data** Exercised
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-exercised-56388">
+>
+> Exercised
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                         | Description |
+> > |-------------|------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | contractId  | AnyContractId                                                                                                                |             |
+> > | choice      | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                 |             |
+> > | argument    | [AnyChoice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anychoice-86490) |             |
+> > | childEvents | \[TreeEvent\]                                                                                                                |             |
+
+<div id="type-daml-script-internal-questions-transactiontree-exercisedindexpayload-19779">
+
+**data** ExercisedIndexPayload t
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-exercisedindexpayload-97386">
+>
+> ExercisedIndexPayload
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                     | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | templateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | choice     | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                             |             |
+> > | offset     | [Int](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)                               |             |
+> > | child      | TreeIndex t                                                                                                                              |             |
+
+<div id="type-daml-script-internal-questions-transactiontree-transactiontree-91781">
+
+**data** TransactionTree
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-transactiontree-56296">
+>
+> TransactionTree
+>
+> </div>
+>
+> > | Field      | Type          | Description |
+> > |------------|---------------|-------------|
+> > | rootEvents | \[TreeEvent\] |             |
+
+<div id="type-daml-script-internal-questions-transactiontree-treeevent-1267">
+
+**data** TreeEvent
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-createdevent-60119">
+>
+> CreatedEvent Created
+>
+> </div>
+>
+> <div id="constr-daml-script-internal-questions-transactiontree-exercisedevent-2627">
+>
+> ExercisedEvent Exercised
+>
+> </div>
+
+<div id="type-daml-script-internal-questions-transactiontree-treeindex-21327">
+
+**data** TreeIndex t
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-transactiontree-createdindex-88223">
+>
+> CreatedIndex (CreatedIndexPayload t)
+>
+> </div>
+>
+> <div id="constr-daml-script-internal-questions-transactiontree-exercisedindex-22399">
+>
+> ExercisedIndex (ExercisedIndexPayload t)
+>
+> </div>
+
+<div id="type-daml-script-internal-questions-util-anycontractid-11399">
+
+**data** AnyContractId
+
+</div>
+
+> <div id="constr-daml-script-internal-questions-util-anycontractid-12200">
+>
+> AnyContractId
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                     | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | templateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | contractId | [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) ()         |             |
+
+<div id="type-daml-script-internal-questions-partymanagement-participantname-88190">
+
+**data** ParticipantName
+
+</div>
+
+> Participant name for multi-participant script runs to address a specific participant
+>
+> <div id="constr-daml-script-internal-questions-partymanagement-participantname-13079">
+>
+> ParticipantName
+>
+> </div>
+>
+> > | Field           | Type                                                                                                         | Description |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | participantName | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+
+<div id="type-daml-script-internal-questions-partymanagement-partydetails-4369">
+
+**data** PartyDetails
+
+</div>
+
+> The party details returned by the party management service.
+>
+> <div id="constr-daml-script-internal-questions-partymanagement-partydetails-1790">
+>
+> PartyDetails
+>
+> </div>
+>
+> > | Field   | Type                                                                                                                | Description                                         |
+> > |---------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+> > | party   | [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | Party id                                            |
+> > | isLocal | [Bool](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)        | True if party is hosted by the backing participant. |
+
+<div id="type-daml-script-internal-questions-partymanagement-partyidhint-14540">
+
+**data** PartyIdHint
+
+</div>
+
+> A hint to the backing participant what party id to allocate. Must be a valid PartyIdString (as described in @value.proto@).
+>
+> <div id="constr-daml-script-internal-questions-partymanagement-partyidhint-11617">
+>
+> PartyIdHint
+>
+> </div>
+>
+> > | Field       | Type                                                                                                         | Description |
+> > |-------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | partyIdHint | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) |             |
+
+<div id="type-daml-script-internal-questions-crypto-text-privatekeyhex-82732">
+
+**type** PrivateKeyHex
+= [BytesHex](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Crypto-Text.html#type-da-crypto-text-byteshex-47880)
+
+A DER formatted private key to be used for ECDSA message signing
+
+</div>
+
+<div id="type-daml-script-internal-questions-crypto-text-secp256k1keypair-9395">
+
+**data** Secp256k1KeyPair
+
+</div>
+
+> Secp256k1 key pair generated by `secp256k1generatekeypair` for testing.
+>
+> <div id="constr-daml-script-internal-questions-crypto-text-secp256k1keypair-60460">
+>
+> Secp256k1KeyPair
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                     | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | privateKey | PrivateKeyHex                                                                                                                            |             |
+> > | publicKey  | [PublicKeyHex](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Crypto-Text.html#type-da-crypto-text-publickeyhex-51359) |             |
+
+<div id="type-daml-script-internal-questions-commands-commands-79301">
+
+**data** Commands a
+
+</div>
+
+> This is used to build up the commands sent as part of `submit`. If you enable the `ApplicativeDo` extension by adding `{-# LANGUAGE ApplicativeDo #-}` at the top of your file, you can use `do`-notation but the individual commands must not depend on each other and the last statement in a `do` block must be of the form `return expr` or `pure expr`.
+>
+> <div id="constr-daml-script-internal-questions-commands-commands-42332">
+>
+> Commands
+>
+> </div>
+>
+> > | Field    | Type                    | Description |
+> > |----------|-------------------------|-------------|
+> > | commands | \[CommandWithMeta\]     |             |
+> > | continue | \[CommandResult\] -\> a |             |
+
+<div id="type-daml-script-internal-questions-commands-disclosure-40298">
+
+**data** Disclosure
+
+</div>
+
+> Contract disclosures which can be acquired via `queryDisclosure`
+>
+> <div id="constr-daml-script-internal-questions-commands-disclosure-14083">
+>
+> Disclosure
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                     | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | templateId | [TemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792) |             |
+> > | contractId | [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) ()         |             |
+> > | blob       | [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                             |             |
+
+<div id="type-daml-script-internal-lowlevel-script-4781">
+
+**data** Script a
+
+</div>
+
+> This is the type of A Daml script. `Script` is an instance of `Action`, so you can use `do` notation.
+>
+> <div id="constr-daml-script-internal-lowlevel-script-73096">
+>
+> Script
+>
+> </div>
+>
+> > | Field     | Type                        | Description                                                                                                                                                                                                             |
+> > |-----------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | runScript | () -\> Free ScriptF (a, ()) | HIDE We use an inlined StateT () to separate evaluation of something of type Script from execution and to ensure proper sequencing of evaluation. This is mainly so that `debug` does something slightly more sensible. |
+> > | dummy     | ()                          | HIDE Dummy field to make sure damlc does not consider this an old-style typeclass.                                                                                                                                      |
+
+## Functions
+
+<div id="function-daml-script-internal-questions-usermanagement-useridtotext-75939">
+
+userIdToText
+: UserId -\> [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+
+Extract the name-text from a user identitifer.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-validateuserid-51917">
+
+validateUserId
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> Script UserId
+
+Construct a user identifer from text. May throw InvalidUserId.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-createuser-37948">
+
+createUser
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> User -\> \[UserRight\] -\> Script ()
+
+Create a user with the given rights. May throw UserAlreadyExists.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-createuseron-3905">
+
+createUserOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> User -\> \[UserRight\] -\> ParticipantName -\> Script ()
+
+Create a user with the given rights on the given participant. May throw UserAlreadyExists.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-getuser-5077">
+
+getUser
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> Script User
+
+Fetch a user record by user id. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-getuseron-1968">
+
+getUserOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> ParticipantName -\> Script User
+
+Fetch a user record by user id from the given participant. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-listallusers-63416">
+
+listAllUsers
+: Script \[User\]
+
+List all users. This function may make multiple calls to underlying paginated ledger API.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-listalluserson-20857">
+
+listAllUsersOn
+: ParticipantName -\> Script \[User\]
+
+List all users on the given participant. This function may make multiple calls to underlying paginated ledger API.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-grantuserrights-87478">
+
+grantUserRights
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> \[UserRight\] -\> Script \[UserRight\]
+
+Grant rights to a user. Returns the rights that have been newly granted. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-grantuserrightson-91259">
+
+grantUserRightsOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> \[UserRight\] -\> ParticipantName -\> Script \[UserRight\]
+
+Grant rights to a user on the given participant. Returns the rights that have been newly granted. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-revokeuserrights-85325">
+
+revokeUserRights
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> \[UserRight\] -\> Script \[UserRight\]
+
+Revoke rights for a user. Returns the revoked rights. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-revokeuserrightson-21608">
+
+revokeUserRightsOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> \[UserRight\] -\> ParticipantName -\> Script \[UserRight\]
+
+Revoke rights for a user on the given participant. Returns the revoked rights. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-deleteuser-2585">
+
+deleteUser
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> Script ()
+
+Delete a user. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-deleteuseron-74248">
+
+deleteUserOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> ParticipantName -\> Script ()
+
+Delete a user on the given participant. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-listuserrights-50525">
+
+listUserRights
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> Script \[UserRight\]
+
+List the rights of a user. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-listuserrightson-11796">
+
+listUserRightsOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> ParticipantName -\> Script \[UserRight\]
+
+List the rights of a user on the given participant. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-submituser-29476">
+
+submitUser
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> Commands a -\> Script a
+
+Submit the commands with the actAs and readAs claims granted to a user. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-usermanagement-submituseron-39337">
+
+submitUserOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> UserId -\> ParticipantName -\> Commands a -\> Script a
+
+Submit the commands with the actAs and readAs claims granted to the user on the given participant. May throw UserNotFound.
+
+</div>
+
+<div id="function-daml-script-internal-questions-time-settime-32330">
+
+setTime
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Time](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886) -\> Script ()
+
+Set the time via the time service.
+
+This is only supported in Daml Studio and `dpm test` as well as when running over the gRPC API against a ledger in static time mode.
+
+Note that the ledger time service does not support going backwards in time. However, you can go back in time in Daml Studio.
+
+</div>
+
+<div id="function-daml-script-internal-questions-time-sleep-58882">
+
+sleep
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [RelTime](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082) -\> Script ()
+
+Sleep for the given duration.
+
+This is primarily useful in tests where you repeatedly call `query` until a certain state is reached.
+
+Note that this will sleep for the same duration in both wall clock and static time mode.
+
+</div>
+
+<div id="function-daml-script-internal-questions-time-passtime-50024">
+
+passTime
+: [RelTime](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082) -\> Script ()
+
+Advance ledger time by the given interval.
+
+This is only supported in Daml Studio and `dpm test` as well as when running over the gRPC API against a ledger in static time mode. Note that this is not an atomic operation over the gRPC API so no other clients should try to change time while this is running.
+
+Note that the ledger time service does not support going backwards in time. However, you can go back in time in Daml Studio.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-actas-76494">
+
+actAs
+: [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) parties =\> parties -\> SubmitOptions
+
+Builds a SubmitOptions with given actAs parties. Any given submission must include at least one actAs party. Note that the parties type is constrainted by `IsParties`, allowing for specifying parties as any of the following:
+
+```daml
+Party
+[Party]
+NonEmpty Party
+Set Party
+Optional Party
+```
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-readas-67481">
+
+readAs
+: [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) parties =\> parties -\> SubmitOptions
+
+Builds a SubmitOptions with given readAs parties. A given submission may omit any readAs parties and still be valid. Note that the parties type is constrainted by `IsParties`, allowing for specifying parties as any of the following:
+
+```daml
+Party
+[Party]
+NonEmpty Party
+Set Party
+Optional Party
+```
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-disclosemany-53386">
+
+discloseMany
+: \[Disclosure\] -\> SubmitOptions
+
+Provides many Explicit Disclosures to the transaction.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-disclose-59895">
+
+disclose
+: Disclosure -\> SubmitOptions
+
+Provides an Explicit Disclosure to the transaction.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-packagepreference-25445">
+
+packagePreference
+: \[PackageId\] -\> SubmitOptions
+
+Provide a package id selection preference for upgrades for a submission
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-prefetchkeys-84998">
+
+prefetchKeys
+: \[[AnyContractKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193)\] -\> SubmitOptions
+
+Provide a list of contract keys to prefetch for a submission
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-concurrently-75077">
+
+concurrently
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> ConcurrentSubmits a -\> Script a
+
+Allows for concurrent submission of transactions, using an applicative, similar to Commands. Concurrently takes a computation in `ConcurrentSubmits`, which supports all the existing `submit` functions that `Script` supports. It however does not implement `Action`, and thus does not support true binding and computation interdependence NOTE: The submission order of transactions within `concurrently` is deterministic, this function is not intended to test contention. It is only intended to allow faster submission of many unrelated transactions, by not waiting for completion for each transaction before sending the next. Example:
+
+```daml
+exerciseResult <- concurrently $ do
+  alice `submit` createCmd ...
+  res <- alice `submit` exerciseCmd ...
+  bob `submit` createCmd ...
+  pure res
+```
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitresultandtree-13546">
+
+submitResultAndTree
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script (a, TransactionTree)
+
+Equivalent to `submit` but returns the result and the full transaction tree.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-trysubmitresultandtree-33682">
+
+trySubmitResultAndTree
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script ([Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) SubmitError (a, TransactionTree))
+
+Equivalent to `trySubmit` but returns the result and the full transaction tree.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitwitherror-52958">
+
+submitWithError
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script SubmitError
+
+Equivalent to `submitMustFail` but returns the error thrown.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submit-5889">
+
+submit
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script a
+
+`submit p cmds` submits the commands `cmds` as a single transaction from party `p` and returns the value returned by `cmds`. The `options` field can either be any "Parties" like type (See `IsParties`) or `SubmitOptions` which allows for finer control over parameters of the submission.
+
+If the transaction fails, `submit` also fails.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitwithoptions-56152">
+
+submitWithOptions
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script a
+
+<Warning>
+**DEPRECATED**:
+
+Daml 2.9 compatibility helper, use 'submit' instead
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submittree-5925">
+
+submitTree
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script TransactionTree
+
+Equivalent to `submit` but returns the full transaction tree.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-trysubmit-23693">
+
+trySubmit
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script ([Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) SubmitError a)
+
+Submit a transaction and recieve back either the result, or a `SubmitError`. In the majority of failures, this will not crash at runtime.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-trysubmittree-68085">
+
+trySubmitTree
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script ([Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) SubmitError TransactionTree)
+
+Equivalent to `trySubmit` but returns the full transaction tree.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitmustfail-63662">
+
+submitMustFail
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script ()
+
+`submitMustFail p cmds` submits the commands `cmds` as a single transaction from party `p`. See submitWithOptions for details on the `options` field
+
+It only succeeds if the submitting the transaction fails.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitmustfailwithoptions-20017">
+
+submitMustFailWithOptions
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script, IsSubmitOptions options) =\> options -\> Commands a -\> script ()
+
+<Warning>
+**DEPRECATED**:
+
+Daml 2.9 compatibility helper, use 'submitMustFail' instead
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitmulti-45107">
+
+submitMulti
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script) =\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> Commands a -\> script a
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `submit`, `actAs` and `readAs` separately
+</Warning>
+
+`submitMulti actAs readAs cmds` submits `cmds` as a single transaction authorized by `actAs`. Fetched contracts must be visible to at least one party in the union of actAs and readAs.
+
+Note: This behaviour can be achieved using `submit (actAs actors <> readAs readers) cmds` and is only provided for backwards compatibility.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitmultimustfail-77808">
+
+submitMultiMustFail
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script) =\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> Commands a -\> script ()
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `submitMustFail`, `actAs` and `readAs` separately
+</Warning>
+
+`submitMultiMustFail actAs readAs cmds` behaves like `submitMulti actAs readAs cmds` but fails when `submitMulti` succeeds and the other way around.
+
+Note: This behaviour can be achieved using `submitMustFail (actAs actors <> readAs readers) cmds` and is only provided for backwards compatibility.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submittreemulti-4879">
+
+submitTreeMulti
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script) =\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> Commands a -\> script TransactionTree
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `submitTree`, `actAs` and `readAs` separately
+</Warning>
+
+Equivalent to `submitMulti` but returns the full transaction tree.
+
+Note: This behaviour can be achieved using `submitTree (actAs actors <> readAs readers) cmds` and is only provided for backwards compatibility.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-trysubmitmulti-31939">
+
+trySubmitMulti
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), ScriptSubmit script) =\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> \[[Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] -\> Commands a -\> script ([Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) SubmitError a)
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `trySubmit`, `actAs` and `readAs` separately
+</Warning>
+
+Alternate version of `trySubmit` that allows specifying the actAs and readAs parties.
+
+Note: This behaviour can be achieved using `trySubmit (actAs actors <> readAs readers) cmds` and is only provided for backwards compatibility.
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-trysubmitconcurrently-11443">
+
+trySubmitConcurrently
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> \[Commands a\] -\> Script \[[Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) SubmitError a\]
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `concurrent` and `trySubmit` separately
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitwithdisclosures-50120">
+
+submitWithDisclosures
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> \[Disclosure\] -\> Commands a -\> Script a
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `trySubmit` and `disclosures` separately
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-submit-submitwithdisclosuresmustfail-28475">
+
+submitWithDisclosuresMustFail
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> \[Disclosure\] -\> Commands a -\> Script ()
+
+<Warning>
+**DEPRECATED**:
+
+Legacy API, use `submitMustFail` and `disclosures` separately
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-transactiontree-fromtree-1340">
+
+fromTree
+: [Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t =\> TransactionTree -\> TreeIndex t -\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t
+
+Finds the contract id of an event within a tree given a tree index Tree indices are created using the `created(N)` and `exercised(N)` builders which allow building "paths" within a transaction to a create node For example, `exercisedN @MyTemplate1 "MyChoice" 2 $ createdN @MyTemplate2 1` would find the `ContractId MyTemplate2` of the second (0 index) create event under the 3rd exercise event of `MyChoice` from `MyTemplate1`
+
+</div>
+
+<div id="function-daml-script-internal-questions-transactiontree-created-56097">
+
+created
+: [HasTemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastemplatetyperep-24134) t =\> TreeIndex t
+
+Index for the first create event of a given template e.g. `created @MyTemplate`
+
+</div>
+
+<div id="function-daml-script-internal-questions-transactiontree-createdn-71930">
+
+createdN
+: [HasTemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastemplatetyperep-24134) t =\> [Int](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> TreeIndex t
+
+Index for the Nth create event of a given template e.g. `createdN 2 @MyTemplate` `created = createdN 0`
+
+</div>
+
+<div id="function-daml-script-internal-questions-transactiontree-exercised-13349">
+
+exercised
+: [HasTemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastemplatetyperep-24134) t =\> [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> TreeIndex t' -\> TreeIndex t'
+
+Index for the first exercise of a given choice on a given template e.g. `exercised @MyTemplate "MyChoice"`
+
+</div>
+
+<div id="function-daml-script-internal-questions-transactiontree-exercisedn-70910">
+
+exercisedN
+: [HasTemplateTypeRep](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastemplatetyperep-24134) t =\> [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> [Int](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> TreeIndex t' -\> TreeIndex t'
+
+Index for the Nth exercise of a given choice on a given template e.g. `exercisedN @MyTemplate "MyChoice" 2` `exercised c = exercisedN c 0`
+
+</div>
+
+<div id="function-daml-script-internal-questions-util-fromanycontractid-11435">
+
+fromAnyContractId
+: [Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t =\> AnyContractId -\> [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t)
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-query-55941">
+
+query
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p) =\> p -\> Script \[([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t, t)\]
+
+Query the set of active contracts of the template that are visible to the given party.
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-queryfilter-99157">
+
+queryFilter
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) c, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) c, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p) =\> p -\> (c -\> [Bool](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)) -\> Script \[([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) c, c)\]
+
+Query the set of active contracts of the template that are visible to the given party and match the given predicate.
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-querycontractid-24166">
+
+queryContractId
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p, [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713)) =\> p -\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t -\> Script ([Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) t)
+
+Query for the contract with the given contract id.
+
+Returns `None` if there is no active contract the party is a stakeholder on.
+
+WARNING: Over the gRPC backend this performs a linear search over all contracts of the same type, so only use this if the number of active contracts is small.
+
+This is semantically equivalent to calling `query` and filtering on the client side.
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-querydisclosure-12000">
+
+queryDisclosure
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p, [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713)) =\> p -\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t -\> Script ([Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Disclosure)
+
+Queries a Disclosure for a given ContractId. Same performance caveats apply as to `queryContractId`.
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-queryinterface-52085">
+
+queryInterface
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) i, [HasInterfaceView](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) i v, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p) =\> p -\> Script \[([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) i, [Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) v)\]
+
+Query the set of active contract views for an interface that are visible to the given party. If the view function fails for a given contract id, The `Optional v` will be `None`.
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-queryinterfacecontractid-18438">
+
+queryInterfaceContractId
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) i, [HasInterfaceView](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) i v, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p, [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713)) =\> p -\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) i -\> Script ([Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) v)
+
+Query for the contract view with the given contract id.
+
+Returns `None` if there is no active contract the party is a stakeholder on.
+
+Returns `None` if the view function fails for the given contract id.
+
+WARNING: Over the gRPC backend this performs a linear search over all contracts of the same type, so only use this if the number of active contracts is small.
+
+This is semantically equivalent to calling `queryInterface` and filtering on the client side.
+
+</div>
+
+<div id="function-daml-script-internal-questions-query-querycontractkey-51277">
+
+queryContractKey
+: ([HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713), [TemplateKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-templatekey-95200) t k, [IsParties](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-isparties-53750) p) =\> p -\> k -\> Script ([Optional](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t, t))
+
+Returns `None` if there is no active contract with the given key that the party is a stakeholder on.
+
+WARNING: Over the gRPC backend this performs a linear search over all contracts of the same type, so only use this if the number of active contracts is small.
+
+This is semantically equivalent to calling `query` and filtering on the client side.
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-allocateparty-4749">
+
+allocateParty
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> Script [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+Allocate a party with the given display name using the party management service.
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-allocatepartywithhint-96426">
+
+allocatePartyWithHint
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> PartyIdHint -\> Script [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+<Warning>
+**DEPRECATED**:
+
+Daml 3.3 compatibility helper, use 'allocatePartyByHint' instead of 'allocatePartyWithHint'
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-allocatepartybyhint-55067">
+
+allocatePartyByHint
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> PartyIdHint -\> Script [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+Allocate a party with the given id hint using the party management service.
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-allocatepartyon-59020">
+
+allocatePartyOn
+: [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> ParticipantName -\> Script [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+Allocate a party with the given display name on the specified participant using the party management service.
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-allocatepartywithhinton-11859">
+
+allocatePartyWithHintOn
+: [Text](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952) -\> PartyIdHint -\> ParticipantName -\> Script [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+<Warning>
+**DEPRECATED**:
+
+Daml 3.3 compatibility helper, use 'allocatePartyByHintOn' instead of 'allocatePartyWithHintOn'
+</Warning>
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-allocatepartybyhinton-5218">
+
+allocatePartyByHintOn
+: PartyIdHint -\> ParticipantName -\> Script [Party](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+Allocate a party with the given id hint on the specified participant using the party management service.
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-listknownparties-55540">
+
+listKnownParties
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> Script \[PartyDetails\]
+
+List the parties known to the default participant.
+
+</div>
+
+<div id="function-daml-script-internal-questions-partymanagement-listknownpartieson-55333">
+
+listKnownPartiesOn
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> ParticipantName -\> Script \[PartyDetails\]
+
+List the parties known to the given participant.
+
+</div>
+
+<div id="function-daml-script-internal-questions-exceptions-trytoeither-58773">
+
+tryToEither
+: (() -\> Script t) -\> Script ([Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) [AnyException](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-anyexception-7004) t)
+
+Named version of the `try catch` behaviour of Daml-Script. Note that this is no more powerful than `try catch` in daml-script, and will not catch exceptions in submissions. (Use `trySubmit` for this) Input computation is deferred to catch pure exceptions
+
+</div>
+
+<div id="function-daml-script-internal-questions-exceptions-tryfailurestatus-576">
+
+tryFailureStatus
+: Script a -\> Script ([Either](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020) [FailureStatus](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Fail.html#type-da-internal-fail-types-failurestatus-69615) a)
+
+Runs a script for a result. If it fails either by Daml Exceptions or `failWithStatus`, returns the `FailureStatus` that a Canton Ledger would return.
+
+</div>
+
+<div id="function-daml-script-internal-questions-crypto-text-secp256k1signwithecdsaonly-99207">
+
+secp256k1signWithEcdsaOnly
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> PrivateKeyHex -\> [BytesHex](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Crypto-Text.html#type-da-crypto-text-byteshex-47880) -\> Script [BytesHex](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Crypto-Text.html#type-da-crypto-text-byteshex-47880)
+
+Using a DER formatted private key (encoded as a hex string) use Secp256k1 to sign a hex encoded string message.
+
+Note that this implementation uses a random source with a fixed PRNG and seed, ensuring it behaves deterministically during testing.
+
+For example, CCTP attestation services may be mocked in daml-script code.
+
+</div>
+
+<div id="function-daml-script-internal-questions-crypto-text-secp256k1sign-72886">
+
+secp256k1sign
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> PrivateKeyHex -\> [BytesHex](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Crypto-Text.html#type-da-crypto-text-byteshex-47880) -\> Script [BytesHex](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Crypto-Text.html#type-da-crypto-text-byteshex-47880)
+
+Using a DER formatted private key (encoded as a hex string) use Secp256k1 to sign a SHA256 digest of a hex encoded string message.
+
+Note that this implementation uses a random source with a fixed PRNG and seed, ensuring it behaves deterministically during testing.
+
+For example, CCTP attestation services may be mocked in daml-script code.
+
+</div>
+
+<div id="function-daml-script-internal-questions-crypto-text-secp256k1generatekeypair-90200">
+
+secp256k1generatekeypair
+: [HasCallStack](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713) =\> Script Secp256k1KeyPair
+
+Generate DER formatted Secp256k1 public/private key pairs.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-createcmd-46830">
+
+createCmd
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t) =\> t -\> Commands ([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t)
+
+Create a contract of the given template.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-exercisecmd-7438">
+
+exerciseCmd
+: [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r =\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t -\> c -\> Commands r
+
+Exercise a choice on the given contract.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-exercisebykeycmd-80697">
+
+exerciseByKeyCmd
+: ([TemplateKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-templatekey-95200) t k, [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r) =\> k -\> c -\> Commands r
+
+Exercise a choice on the contract with the given key.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-createandexercisewithcidcmd-21289">
+
+createAndExerciseWithCidCmd
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t) =\> t -\> c -\> Commands ([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t, r)
+
+Create a contract and exercise a choice on it in the same transaction, returns the created ContractId, and the choice result.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-createandexercisecmd-8600">
+
+createAndExerciseCmd
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t) =\> t -\> c -\> Commands r
+
+Create a contract and exercise a choice on it in the same transaction, returns only the choice result.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-createexactcmd-86998">
+
+createExactCmd
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t) =\> t -\> Commands ([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t)
+
+Create a contract of the given template, using the exact package ID of the template given - upgrades are disabled.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-exerciseexactcmd-18398">
+
+exerciseExactCmd
+: [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r =\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t -\> c -\> Commands r
+
+Exercise a choice on the given contract, using the exact package ID of the template given - upgrades are disabled.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-exercisebykeyexactcmd-4555">
+
+exerciseByKeyExactCmd
+: ([TemplateKey](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-templatekey-95200) t k, [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r) =\> k -\> c -\> Commands r
+
+Exercise a choice on the contract with the given key, using the exact package ID of the template given - upgrades are disabled.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-createandexercisewithcidexactcmd-15363">
+
+createAndExerciseWithCidExactCmd
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t) =\> t -\> c -\> Commands ([ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t, r)
+
+Create a contract and exercise a choice on it in the same transaction, returns the created ContractId, and the choice result. Uses the exact package ID of the template given - upgrades are disabled.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-createandexerciseexactcmd-54956">
+
+createAndExerciseExactCmd
+: ([Template](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-template-31804) t, [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t c r, [HasEnsure](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasensure-18132) t) =\> t -\> c -\> Commands r
+
+Create a contract and exercise a choice on it in the same transaction, returns only the choice result.
+
+</div>
+
+<div id="function-daml-script-internal-questions-commands-archivecmd-47203">
+
+archiveCmd
+: [Choice](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-functions-choice-82157) t [Archive](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-template-archive-15178) () =\> [ContractId](https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) t -\> Commands ()
+
+Archive the given contract.
+
+`archiveCmd cid` is equivalent to `exerciseCmd cid Archive`.
+
+</div>
+
+<div id="function-daml-script-internal-lowlevel-script-65113">
+
+script
+: Script a -\> Script a
+
+Convenience helper to declare you are writing a Script.
+
+This is only useful for readability and to improve type inference. Any expression of type `Script a` is a valid script regardless of whether it is implemented using `script` or not.
+
+</div>
+
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/cli-tools/daml-script.mdx
+++ b/docs-main/sdks-tools/cli-tools/daml-script.mdx
@@ -15,6 +15,8 @@ import DamlSdksToolsCliToolsDpmL56 from "/snippets/daml-docs/sdks-tools_cli-tool
 
 Daml Script is the primary testing tool for Daml contracts. You write test scenarios as `Script ()` values in Daml source files, then run them with `dpm test`. Scripts execute on a fresh, empty ledger and can allocate parties, submit commands, query state, and assert expected outcomes.
 
+For the complete function and type reference, see [Daml.Script API Reference](/sdks-tools/cli-tools/daml-script-api).
+
 ## Writing a Test Script
 
 A Daml Script is a function that returns `Script ()`. Place your scripts in a test package that depends on your contract package (keep templates and tests in separate packages for clean deployment).


### PR DESCRIPTION
## Summary

- Converts `Daml-Script.rst` from the docs-website repo to MDX using `rst2mdx.py`
- Adds the new page at `sdks-tools/cli-tools/daml-script-api` to the CLI Tools navigation in `docs.json`
- Adds a link from the existing Daml Script page to the new API reference

Closes #845
Closes #846