### PR TITLE
Use marker-based Splice YAML snippets

### DIFF
--- a/config/snippet-config/splice-snippet-list-remote.json
+++ b/config/snippet-config/splice-snippet-list-remote.json
@@ -18,7 +18,9 @@
       "sourceRepo": "splice",
       "sourceFilepath": "apps/app/src/pack/examples/sv-helm/kms-participant-aws-values.yaml",
       "location": {
-        "type": "fullFile"
+        "type": "stringMarker",
+        "start": "KMS_PARTICIPANT_AWS_VALUES_START",
+        "end": "KMS_PARTICIPANT_AWS_VALUES_END"
       },
       "description": "",
       "options": {
@@ -30,7 +32,9 @@
       "sourceRepo": "splice",
       "sourceFilepath": "apps/app/src/pack/examples/sv-helm/kms-participant-gcp-values.yaml",
       "location": {
-        "type": "fullFile"
+        "type": "stringMarker",
+        "start": "KMS_PARTICIPANT_GCP_VALUES_START",
+        "end": "KMS_PARTICIPANT_GCP_VALUES_END"
       },
       "description": "",
       "options": {

--- a/tests/test_generate_external_snippets.py
+++ b/tests/test_generate_external_snippets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -73,6 +74,25 @@ def test_copy_output_targets_docs_main_snippets(
     assert target == fake_root / "docs-main" / "snippets" / "external" / "splice" / "main"
     assert (target / "example.mdx").read_text(encoding="utf-8") == "content"
     assert not (fake_root / "snippets").exists()
+
+
+def test_splice_snippets_are_yaml_string_markers() -> None:
+    config = json.loads(
+        (
+            generator.CF_DOCS_ROOT
+            / "config"
+            / "snippet-config"
+            / "splice-snippet-list-remote.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    for snippet in config["snippets"]:
+        assert snippet["sourceRepo"] == "splice"
+        assert Path(snippet["sourceFilepath"]).suffix in {".yaml", ".yml"}
+        assert snippet["location"]["type"] == "stringMarker"
+        assert snippet["location"]["start"]
+        assert snippet["location"]["end"]
+        assert snippet["options"]["language"] == "yaml"
 
 
 def test_wrapper_copies_helper_runs_extraction_and_copies_output(


### PR DESCRIPTION
## Summary

- switch the two Splice KMS external snippets from full-file extraction to string markers
- keep the existing generated snippet output and consuming pages unchanged
- add a regression test that Splice external snippets stay YAML and marker-based

## Coordination

Source-side companion PR: https://github.com/canton-network/splice/pull/6179

Merge this together with the Splice PR so the new KMS markers exist before cf-docs extraction depends on them.

## Validation

- python3 -m pytest tests/test_generate_external_snippets.py
- git diff --check origin/main
