### PR TITLE
Fix TypeDoc code span entity rendering

### DIFF
--- a/docs-main/reference/typescript.mdx
+++ b/docs-main/reference/typescript.mdx
@@ -93,7 +93,7 @@ Interface for objects representing Daml choices.
 | Member | Type | Description |
 | --- | --- | --- |
 | `choiceName` | `string` | The choice name. |
-| `template` | `() =&gt; TemplateOrInterface` | Returns the template to which this choice belongs. |
+| `template` | `() => TemplateOrInterface` | Returns the template to which this choice belongs. |
 
 <span id="interface-choicefrom"></span>
 
@@ -121,7 +121,7 @@ The origin companion that contained a [[Choice]].
 
 | Member | Type | Description |
 | --- | --- | --- |
-| `template` | `() =&gt; O` | Returns the template to which this choice belongs. |
+| `template` | `() => O` | Returns the template to which this choice belongs. |
 
 <span id="interface-contracttypecompanion"></span>
 
@@ -226,15 +226,15 @@ iteration is unspecified; the only guarantee is that the order in ``keys`` and
 
 | Member | Type | Description |
 | --- | --- | --- |
-| `delete` | `(k: K) =&gt; Map&lt;K, V&gt;` | - |
-| `entries` | `() =&gt; Iterator&lt;[K, V], undefined, undefined&gt;` | - |
-| `entriesArray` | `() =&gt; [K, V][]` | - |
-| `forEach` | `(f: (value: V, key: K, map: Map&lt;K, V&gt;) =&gt; T, u?: U) =&gt; void` | - |
-| `get` | `(k: K) =&gt; undefined \| V` | - |
-| `has` | `(k: K) =&gt; boolean` | - |
-| `keys` | `() =&gt; Iterator&lt;K, undefined, undefined&gt;` | - |
-| `set` | `(k: K, v: V) =&gt; Map&lt;K, V&gt;` | - |
-| `values` | `() =&gt; Iterator&lt;V, undefined, undefined&gt;` | - |
+| `delete` | `(k: K) => Map<K, V>` | - |
+| `entries` | `() => Iterator<[K, V], undefined, undefined>` | - |
+| `entriesArray` | `() => [K, V][]` | - |
+| `forEach` | `(f: (value: V, key: K, map: Map<K, V>) => T, u?: U) => void` | - |
+| `get` | `(k: K) => undefined \| V` | - |
+| `has` | `(k: K) => boolean` | - |
+| `keys` | `() => Iterator<K, undefined, undefined>` | - |
+| `set` | `(k: K, v: V) => Map<K, V>` | - |
+| `values` | `() => Iterator<V, undefined, undefined>` | - |
 
 <span id="interface-serializable"></span>
 
@@ -295,7 +295,7 @@ Interface for objects representing Daml templates. It is similar to the
 
 | Member | Type | Description |
 | --- | --- | --- |
-| `Archive` | `Choice&lt;T, {}, {}, K&gt; &amp; ChoiceFrom&lt;Template&lt;T, K, I&gt;&gt;` | - |
+| `Archive` | `Choice<T, {}, {}, K> & ChoiceFrom<Template<T, K, I>>` | - |
 | `templateId` | `I` | - |
 | `templateIdWithPackageId` | `string` | - |
 
@@ -844,7 +844,7 @@ ContractId<T extends void = void>(_t: Serializable<T> | TemplateOrInterface<T & 
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `_t` | `Serializable&lt;T&gt; \| TemplateOrInterface&lt;T &amp; object, unknown, string&gt;` | yes | - |
+| `_t` | `Serializable<T> \| TemplateOrInterface<T & object, unknown, string>` | yes | - |
 
 Returns: `Serializable<ContractId<T>>`
 
@@ -903,7 +903,7 @@ List<T extends void = void>(t: Serializable<T>): Serializable<T[]>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `t` | `Serializable&lt;T&gt;` | yes | - |
+| `t` | `Serializable<T>` | yes | - |
 
 Returns: `Serializable<T[]>`
 
@@ -936,8 +936,8 @@ Map<K extends void = void, V extends void = void>(kd: Serializable<K>, vd: Seria
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `kd` | `Serializable&lt;K&gt;` | yes | - |
-| `vd` | `Serializable&lt;V&gt;` | yes | - |
+| `kd` | `Serializable<K>` | yes | - |
+| `vd` | `Serializable<V>` | yes | - |
 
 Returns: `Serializable<Map<K, V>>`
 
@@ -997,7 +997,7 @@ Optional<T extends void = void>(t: Serializable<T>): Serializable<Optional<T>>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `t` | `Serializable&lt;T&gt;` | yes | - |
+| `t` | `Serializable<T>` | yes | - |
 
 Returns: `Serializable<Optional<T>>`
 
@@ -1029,6 +1029,6 @@ TextMap<T extends void = void>(t: Serializable<T>): Serializable<TextMap<T>>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `t` | `Serializable&lt;T&gt;` | yes | - |
+| `t` | `Serializable<T>` | yes | - |
 
 Returns: `Serializable<TextMap<T>>`

--- a/docs-main/reference/typescript/dapp-sdk.mdx
+++ b/docs-main/reference/typescript/dapp-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@canton-network/dapp-sdk"
+title: "dApp SDK"
 description: "TypeScript client library reference for dApp integrations."
 ---
 
@@ -134,31 +134,31 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | `TxChangedSignedPayload` | `void` | Payload for the TxChangedSignedEvent. |
 | `Wallet` | `void` | Structure representing a wallet |
 | `AccessToken` | `string` | JWT authentication token. |
-| `AccountsChanged` | `() =&gt; Promise&lt;AccountsChangedEvent&gt;` | - |
+| `AccountsChanged` | `() => Promise<AccountsChangedEvent>` | - |
 | `AccountsChangedEvent` | `Wallet[]` | Event emitted when the user's accounts change. |
 | `ActAs` | `Party[]` | Set of parties on whose behalf the command should be executed, if submitted. If not set, the primary wallet's party is used. |
 | `CommandId` | `string` | The unique identifier of the command associated with the transaction. |
 | `CompletionOffset` | `number` | - |
-| `Connect` | `() =&gt; Promise&lt;ConnectResult&gt;` | - |
+| `Connect` | `() => Promise<ConnectResult>` | - |
 | `ContractId` | `string` | The unique identifier of the disclosed contract. |
 | `CreatedEventBlob` | `string` | The blob data of the created event for the disclosed contract. |
 | `Disabled` | `boolean` | Whether the wallet is disabled. Wallets are disabled when no signing provider matches the party's namespace during sync. Disabled wallets use participant as the default signing provider. |
 | `DisclosedContracts` | `DisclosedContract[]` | List of contract IDs to be disclosed with the command. |
-| `Disconnect` | `() =&gt; Promise&lt;Null&gt;` | - |
+| `Disconnect` | `() => Promise<Null>` | - |
 | `ExternalTxId` | `string` | Unique identifier of the signed transaction given by the Signing Provider. This may not be the same as the internal txId given by the Wallet Gateway. |
-| `GetActiveNetwork` | `() =&gt; Promise&lt;Network&gt;` | - |
-| `GetPrimaryAccount` | `() =&gt; Promise&lt;Wallet&gt;` | - |
+| `GetActiveNetwork` | `() => Promise<Network>` | - |
+| `GetPrimaryAccount` | `() => Promise<Wallet>` | - |
 | `Hint` | `string` | The party hint and name of the wallet. |
-| `IsConnected` | `() =&gt; Promise&lt;ConnectResult&gt;` | - |
+| `IsConnected` | `() => Promise<ConnectResult>` | - |
 | `IsConnectedValue` | `boolean` | Whether or not the user is authenticated with the Wallet. |
 | `IsNetworkConnected` | `boolean` | Whether or not a connection to a network is established. |
-| `LedgerApi` | `(params: LedgerApiParams) =&gt; Promise&lt;LedgerApiResult&gt;` | - |
+| `LedgerApi` | `(params: LedgerApiParams) => Promise<LedgerApiResult>` | - |
 | `LedgerApiUrl` | `string` | The base URL of the ledger API. |
-| `ListAccounts` | `() =&gt; Promise&lt;ListAccountsResult&gt;` | - |
+| `ListAccounts` | `() => Promise<ListAccountsResult>` | - |
 | `ListAccountsResult` | `Wallet[]` | An array of accounts that the user has authorized the dapp to access.. |
 | `Message` | `string` | The message to sign. |
 | `MessageId` | `string` | The unique identifier of the message associated with the message to be signed. |
-| `MessageSignature` | `() =&gt; Promise&lt;MessageSignatureEvent&gt;` | - |
+| `MessageSignature` | `() => Promise<MessageSignatureEvent>` | - |
 | `MessageSignatureEvent` | `MessageSignaturePendingEvent \| MessageSignatureSignedEvent \| MessageSignatureFailedEvent` | Event emitted when a message signature is requested or completed. |
 | `Namespace` | `string` | The namespace of the party. |
 | `NetworkId` | `string` | The network ID the wallet corresponds to. |
@@ -168,8 +168,8 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | `PackageIdSelectionPreference` | `PackageId[]` | The package-id selection preference of the client for resolving package names and interface instances in command submission and interpretation |
 | `Party` | `string` | The party that signed the transaction. |
 | `PartyId` | `string` | The party ID corresponding to the wallet. |
-| `PrepareExecute` | `(params: PrepareExecuteParams) =&gt; Promise&lt;Null&gt;` | - |
-| `PrepareExecuteAndWait` | `(params: PrepareExecuteParams) =&gt; Promise&lt;PrepareExecuteAndWaitResult&gt;` | - |
+| `PrepareExecute` | `(params: PrepareExecuteParams) => Promise<Null>` | - |
+| `PrepareExecuteAndWait` | `(params: PrepareExecuteParams) => Promise<PrepareExecuteAndWaitResult>` | - |
 | `Primary` | `boolean` | Set as primary wallet for dApp usage. |
 | `ProviderId` | `string` | The unique identifier of the Provider. |
 | `ProviderType` | `"browser" \| "desktop" \| "mobile" \| "remote"` | The type of client that implements the Provider. |
@@ -178,12 +178,12 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | `Reason` | `string` | Reason for the wallet state, e.g., 'no signing provider matched'. |
 | `RequestMethod` | `"get" \| "post" \| "patch" \| "put" \| "delete"` | - |
 | `Resource` | `string` | - |
-| `RpcTypes` | `{ accountsChanged: { params: Params&lt;AccountsChanged&gt;; result: Result&lt;AccountsChanged&gt; }; connect: { params: Params&lt;Connect&gt;; result: Result&lt;Connect&gt; }; disconnect: { params: Params&lt;Disconnect&gt;; result: Result&lt;Disconnect&gt; }; getActiveNetwork: { params: Params&lt;GetActiveNetwork&gt;; result: Result&lt;GetActiveNetwork&gt; }; getPrimaryAccount: { params: Params&lt;GetPrimaryAccount&gt;; result: Result&lt;GetPrimaryAccount&gt; }; isConnected: { params: Params&lt;IsConnected&gt;; result: Result&lt;IsConnected&gt; }; ledgerApi: { params: Params&lt;LedgerApi&gt;; result: Result&lt;LedgerApi&gt; }; listAccounts: { params: Params&lt;ListAccounts&gt;; result: Result&lt;ListAccounts&gt; }; messageSignature: { params: Params&lt;MessageSignature&gt;; result: Result&lt;MessageSignature&gt; }; prepareExecute: { params: Params&lt;PrepareExecute&gt;; result: Result&lt;PrepareExecute&gt; }; prepareExecuteAndWait: { params: Params&lt;PrepareExecuteAndWait&gt;; result: Result&lt;PrepareExecuteAndWait&gt; }; signMessage: { params: Params&lt;SignMessage&gt;; result: Result&lt;SignMessage&gt; }; status: { params: Params&lt;Status&gt;; result: Result&lt;Status&gt; }; txChanged: { params: Params&lt;TxChanged&gt;; result: Result&lt;TxChanged&gt; } }` | - |
+| `RpcTypes` | `{ accountsChanged: { params: Params<AccountsChanged>; result: Result<AccountsChanged> }; connect: { params: Params<Connect>; result: Result<Connect> }; disconnect: { params: Params<Disconnect>; result: Result<Disconnect> }; getActiveNetwork: { params: Params<GetActiveNetwork>; result: Result<GetActiveNetwork> }; getPrimaryAccount: { params: Params<GetPrimaryAccount>; result: Result<GetPrimaryAccount> }; isConnected: { params: Params<IsConnected>; result: Result<IsConnected> }; ledgerApi: { params: Params<LedgerApi>; result: Result<LedgerApi> }; listAccounts: { params: Params<ListAccounts>; result: Result<ListAccounts> }; messageSignature: { params: Params<MessageSignature>; result: Result<MessageSignature> }; prepareExecute: { params: Params<PrepareExecute>; result: Result<PrepareExecute> }; prepareExecuteAndWait: { params: Params<PrepareExecuteAndWait>; result: Result<PrepareExecuteAndWait> }; signMessage: { params: Params<SignMessage>; result: Result<SignMessage> }; status: { params: Params<Status>; result: Result<Status> }; txChanged: { params: Params<TxChanged>; result: Result<TxChanged> } }` | - |
 | `Signature` | `string` | The signature of the message. |
 | `SignedBy` | `string` | The identifier of the provider that signed the transaction. |
 | `SigningProviderId` | `string` | The signing provider ID the wallet corresponds to. |
-| `SignMessage` | `(params: SignMessageParams) =&gt; Promise&lt;SignMessageResult&gt;` | - |
-| `Status` | `() =&gt; Promise&lt;StatusEvent&gt;` | Generated! Represents an alias to any of the provided schemas |
+| `SignMessage` | `(params: SignMessageParams) => Promise<SignMessageResult>` | - |
+| `Status` | `() => Promise<StatusEvent>` | Generated! Represents an alias to any of the provided schemas |
 | `StatusExecuted` | `"executed"` | The status of the transaction. |
 | `StatusFailed` | `"failed"` | The status of the message signature. |
 | `StatusPending` | `"pending"` | The status of the message signature. |
@@ -191,7 +191,7 @@ Generated from published `@canton-network/dapp-sdk` TypeDoc snapshots.
 | `SynchronizerId` | `string` | If not set, a suitable synchronizer that this node is connected to will be chosen. |
 | `TemplateId` | `string` | The template identifier of the disclosed contract. |
 | `TopologyTransactions` | `string` | The topology transactions |
-| `TxChanged` | `() =&gt; Promise&lt;TxChangedEvent&gt;` | - |
+| `TxChanged` | `() => Promise<TxChangedEvent>` | - |
 | `TxChangedEvent` | `TxChangedPendingEvent \| TxChangedSignedEvent \| TxChangedExecutedEvent \| TxChangedFailedEvent` | Event emitted when a transaction changes. |
 | `UpdateId` | `string` | The update ID corresponding to the transaction. |
 | `Url` | `string` | The URL of the Wallet Provider. |
@@ -650,7 +650,7 @@ interface ActiveSession
 | Member | Type | Description |
 | --- | --- | --- |
 | `adapter` | `ProviderAdapter` | - |
-| `provider` | `Provider&lt;RpcTypes&gt;` | - |
+| `provider` | `Provider<RpcTypes>` | - |
 | `providerId` | `string` | - |
 
 <span id="interface-dappclientoptions"></span>
@@ -837,7 +837,7 @@ interface WalletConnectAdapterConfig
 | --- | --- | --- |
 | `chainId` | `string` | - |
 | `metadata` | `{ description: string; icons: string[]; name: string; url: string }` | - |
-| `onUri` | `(uri: string) =&gt; void` | Called with the pairing URI so the dApp can display or forward it. |
+| `onUri` | `(uri: string) => void` | Called with the pairing URI so the dApp can display or forward it. |
 | `projectId` | `string` | - |
 
 <span id="interface-walletinfo"></span>
@@ -1283,7 +1283,7 @@ onAccountsChanged(listener: EventListener<AccountsChangedEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;AccountsChangedEvent&gt;` | yes | - |
+| `listener` | `EventListener<AccountsChangedEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1309,7 +1309,7 @@ onConnected(listener: EventListener<StatusEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;StatusEvent&gt;` | yes | - |
+| `listener` | `EventListener<StatusEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1335,7 +1335,7 @@ onStatusChanged(listener: EventListener<StatusEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;StatusEvent&gt;` | yes | - |
+| `listener` | `EventListener<StatusEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1361,7 +1361,7 @@ onTxChanged(listener: EventListener<TxChangedEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;TxChangedEvent&gt;` | yes | - |
+| `listener` | `EventListener<TxChangedEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1461,7 +1461,7 @@ removeOnAccountsChanged(listener: EventListener<AccountsChangedEvent>): Promise<
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;AccountsChangedEvent&gt;` | yes | - |
+| `listener` | `EventListener<AccountsChangedEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1487,7 +1487,7 @@ removeOnConnected(listener: EventListener<StatusEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;StatusEvent&gt;` | yes | - |
+| `listener` | `EventListener<StatusEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1513,7 +1513,7 @@ removeOnStatusChanged(listener: EventListener<StatusEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;StatusEvent&gt;` | yes | - |
+| `listener` | `EventListener<StatusEvent>` | yes | - |
 
 Returns: `Promise<void>`
 
@@ -1539,7 +1539,7 @@ removeOnTxChanged(listener: EventListener<TxChangedEvent>): Promise<void>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `listener` | `EventListener&lt;TxChangedEvent&gt;` | yes | - |
+| `listener` | `EventListener<TxChangedEvent>` | yes | - |
 
 Returns: `Promise<void>`
 

--- a/docs-main/reference/typescript/wallet-sdk.mdx
+++ b/docs-main/reference/typescript/wallet-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@canton-network/wallet-sdk"
+title: "Wallet SDK"
 description: "TypeScript client library reference for wallet integrations."
 ---
 
@@ -208,7 +208,7 @@ Generated from published `@canton-network/wallet-sdk` TypeDoc snapshots.
 | Member | Type | Description |
 | --- | --- | --- |
 | `constructor` | `void` | - |
-| `command` | `{ cancel: (args: { parties: PreapprovalParties }) =&gt; Promise&lt;[{ ExerciseCommand: { choice: string; choiceArgument: unknown; contractId: string; templateId: string } &amp; { choice: string; choiceArgument: unknown; contractId: string; templateId: string } }, { contractId?: string; createdEventBlob: string; synchronizerId?: string; templateId?: string } &amp; { contractId?: string; createdEventBlob: string; synchronizerId?: string; templateId?: string }[]] \| readonly [null, readonly []]&gt;; create: (args: { parties: PreapprovalParties }) =&gt; Promise&lt;{ CreateCommand: { createArguments: unknown; templateId: string } &amp; { createArguments: unknown; templateId: string } }&gt; }` | Commands for managing transfer preapprovals. The return result can be used as an argument to pass to signing and execution of a transaction.<br/>Transfer preapprovals allow receivers to automatically accept incoming transfers. |
+| `command` | `{ cancel: (args: { parties: PreapprovalParties }) => Promise<[{ ExerciseCommand: { choice: string; choiceArgument: unknown; contractId: string; templateId: string } & { choice: string; choiceArgument: unknown; contractId: string; templateId: string } }, { contractId?: string; createdEventBlob: string; synchronizerId?: string; templateId?: string } & { contractId?: string; createdEventBlob: string; synchronizerId?: string; templateId?: string }[]] \| readonly [null, readonly []]>; create: (args: { parties: PreapprovalParties }) => Promise<{ CreateCommand: { createArguments: unknown; templateId: string } & { createArguments: unknown; templateId: string } }> }` | Commands for managing transfer preapprovals. The return result can be used as an argument to pass to signing and execution of a transaction.<br/>Transfer preapprovals allow receivers to automatically accept incoming transfers. |
 | `fetchQuick` | `void` | - |
 | `fetchStatus` | `void` | - |
 | `renew` | `void` | - |
@@ -226,7 +226,7 @@ Generated from published `@canton-network/wallet-sdk` TypeDoc snapshots.
 | Member | Type | Description |
 | --- | --- | --- |
 | `constructor` | `void` | - |
-| `preparedPromise` | `Promise&lt;{ costEstimation?: { confirmationRequestTrafficCostEstimation: number; confirmationResponseTrafficCostEstimation: number; estimationTimestamp: string; totalTrafficCostEstimation: number }; hashingDetails?: string; hashingSchemeVersion: "HASHING_SCHEME_VERSION_UNSPECIFIED" \| "HASHING_SCHEME_VERSION_V2" \| "HASHING_SCHEME_VERSION_V3"; preparedTransaction: string; preparedTransactionHash: string }&gt;` | - |
+| `preparedPromise` | `Promise<{ costEstimation?: { confirmationRequestTrafficCostEstimation: number; confirmationResponseTrafficCostEstimation: number; estimationTimestamp: string; totalTrafficCostEstimation: number }; hashingDetails?: string; hashingSchemeVersion: "HASHING_SCHEME_VERSION_UNSPECIFIED" \| "HASHING_SCHEME_VERSION_V2" \| "HASHING_SCHEME_VERSION_V3"; preparedTransaction: string; preparedTransactionHash: string }>` | - |
 | `decode` | `void` | - |
 | `sign` | `void` | - |
 | `toJSON` | `void` | - |
@@ -277,7 +277,7 @@ Generated from published `@canton-network/wallet-sdk` TypeDoc snapshots.
 | Member | Type | Description |
 | --- | --- | --- |
 | `constructor` | `void` | - |
-| `signedPromise` | `Promise&lt;{ response: { costEstimation?: { confirmationRequestTrafficCostEstimation: number; confirmationResponseTrafficCostEstimation: number; estimationTimestamp: string; totalTrafficCostEstimation: number }; hashingDetails?: string; hashingSchemeVersion: "HASHING_SCHEME_VERSION_UNSPECIFIED" \| "HASHING_SCHEME_VERSION_V2" \| "HASHING_SCHEME_VERSION_V3"; preparedTransaction: string; preparedTransactionHash: string }; signature: string }&gt;` | - |
+| `signedPromise` | `Promise<{ response: { costEstimation?: { confirmationRequestTrafficCostEstimation: number; confirmationResponseTrafficCostEstimation: number; estimationTimestamp: string; totalTrafficCostEstimation: number }; hashingDetails?: string; hashingSchemeVersion: "HASHING_SCHEME_VERSION_UNSPECIFIED" \| "HASHING_SCHEME_VERSION_V2" \| "HASHING_SCHEME_VERSION_V3"; preparedTransaction: string; preparedTransactionHash: string }; signature: string }>` | - |
 | `execute` | `void` | - |
 | `response` | `void` | - |
 | `signature` | `void` | - |
@@ -321,8 +321,8 @@ interface FeaturedAppService
 
 | Member | Type | Description |
 | --- | --- | --- |
-| `grant` | `(options?: GrantFeaturedAppRightsOptions) =&gt; Promise&lt;FeaturedAppRight&gt;` | Submits a command to grant feature app rights for validator operator. |
-| `rights` | `(options: LookupFeaturedAppRightsOptions) =&gt; Promise&lt;FeaturedAppRight&gt;` | Looks up if a party has FeaturedAppRight.<br/>Has an in built retry and delay between attempts |
+| `grant` | `(options?: GrantFeaturedAppRightsOptions) => Promise<FeaturedAppRight>` | Submits a command to grant feature app rights for validator operator. |
+| `rights` | `(options: LookupFeaturedAppRightsOptions) => Promise<FeaturedAppRight>` | Looks up if a party has FeaturedAppRight.<br/>Has an in built retry and delay between attempts |
 
 ### Type Aliases
 
@@ -712,7 +712,7 @@ type RegisteredPlugins<P extends Record<string, (ctx: SDKContext) => SDKPlugin> 
 
 | Name | Constraint | Default | Description |
 | --- | --- | --- | --- |
-| `P` | `Record&lt;string, (ctx: SDKContext) =&gt; SDKPlugin&gt;` | `Record&lt;string, (ctx: SDKContext) =&gt; SDKPlugin&gt;` | - |
+| `P` | `Record<string, (ctx: SDKContext) => SDKPlugin>` | `Record<string, (ctx: SDKContext) => SDKPlugin>` | - |
 
 <span id="type-alias-sdkcontext"></span>
 

--- a/src/x2mdx/typedoc/render.py
+++ b/src/x2mdx/typedoc/render.py
@@ -14,6 +14,14 @@ def escape_md_cell(text: str) -> str:
     return "<br/>".join(escape_mdx_text(line).replace("|", r"\|") for line in text.splitlines())
 
 
+def escape_md_code(text: str) -> str:
+    return str(text).replace("`", r"\`").replace("|", r"\|").replace("\n", " ").strip()
+
+
+def code_span(text: str) -> str:
+    return f"`{escape_md_code(text)}`"
+
+
 def escape_mdx_text(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
@@ -57,9 +65,9 @@ def version_change_summary_rows(exports: list[dict[str, object]], versions: list
 def _type_parameter_rows(items: list[dict[str, Any]]) -> list[list[str]]:
     return [
         [
-            f"`{escape_md_cell(item['name'])}`",
-            f"`{escape_md_cell(item['constraint'])}`" if item["constraint"] else "-",
-            f"`{escape_md_cell(item['default'])}`" if item["default"] else "-",
+            code_span(item["name"]),
+            code_span(item["constraint"]) if item["constraint"] else "-",
+            code_span(item["default"]) if item["default"] else "-",
             escape_md_cell(item["description"]) if item["description"] else "-",
         ]
         for item in items
@@ -74,14 +82,14 @@ def _signature_docs(signature_docs: list[dict[str, Any]]) -> list[dict[str, Any]
             "type_parameter_rows": _type_parameter_rows(signature["type_parameters"]),
             "parameter_rows": [
                 [
-                    f"`{escape_md_cell(item['name'])}`",
-                    f"`{escape_md_cell(item['type'])}`",
+                    code_span(item["name"]),
+                    code_span(item["type"]),
                     item["required"],
                     escape_md_cell(item["description"]) if item["description"] else "-",
                 ]
                 for item in signature["parameters"]
             ],
-            "returns": str(signature["returns"]),
+            "returns": escape_md_code(str(signature["returns"])),
         }
         for signature in signature_docs
     ]
@@ -112,7 +120,7 @@ def _export_context(export: dict[str, Any]) -> dict[str, Any]:
         "lifecycle_bits": lifecycle_bits,
         "change_rows": [
             [
-                f"`{escape_md_cell(str(entry['version']))}`",
+                code_span(str(entry["version"])),
                 escape_md_cell("; ".join(str(change) for change in entry["changes"])),
             ]
             for entry in export["change_details"]
@@ -123,8 +131,8 @@ def _export_context(export: dict[str, Any]) -> dict[str, Any]:
         "signature_docs": _signature_docs(export["signature_docs"]),
         "member_rows": [
             [
-                f"`{escape_md_cell(item['name'])}`",
-                f"`{escape_md_cell(item['type'])}`",
+                code_span(item["name"]),
+                code_span(item["type"]),
                 escape_md_cell(item["summary"]) if item["summary"] else "-",
             ]
             for item in export["members"]
@@ -157,13 +165,13 @@ def build_page(
         report=report,
         toc_rows=[
             [
-                f"[`{escape_md_cell(export['name'])}`](#{export['anchor']})",
+                f"[{code_span(export['name'])}](#{export['anchor']})",
                 escape_md_cell(export["kind_label"]),
                 render_summary_cell(str(export["summary"])),
-                f"`{export['introduced_in']}`",
+                code_span(export["introduced_in"]),
                 escape_md_cell(render_change_summary(export["change_details"])),
-                f"`{export['lifecycle_label']}`" if export["lifecycle_label"] == "Deprecated" else "-",
-                f"`{export['removed_in']}`" if export["removed_in"] else "-",
+                code_span(export["lifecycle_label"]) if export["lifecycle_label"] == "Deprecated" else "-",
+                code_span(export["removed_in"]) if export["removed_in"] else "-",
             ]
             for export in report.exports
         ],

--- a/tests/test_typedoc.py
+++ b/tests/test_typedoc.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 
 from x2mdx.cli import main as cli_main
-from x2mdx.typedoc.render import escape_md_cell
+from x2mdx.typedoc.render import code_span, escape_md_cell
 from x2mdx.typedoc.lifecycle import build_typedoc_report_from_sources, normalize_source_location, render_type
 from x2mdx.typedoc.snapshots import load_typedoc_sources
 
@@ -350,4 +350,10 @@ class TypeDocTests(unittest.TestCase):
         self.assertEqual(
             escape_md_cell("Provider<DappRpcTypes>\nleft|right"),
             "Provider&lt;DappRpcTypes&gt;<br/>left\\|right",
+        )
+
+    def test_code_spans_keep_typescript_generics_literal(self) -> None:
+        self.assertEqual(
+            code_span("() => Promise<ConnectResult> | null"),
+            "`() => Promise<ConnectResult> \\| null`",
         )


### PR DESCRIPTION
## Summary

Fixes the TypeDoc renderer so TypeScript syntax inside generated Markdown code spans is emitted as literal code instead of pre-escaped HTML entities.

This addresses the generated-output side of the problem seen in #895 / #875: Mintlify does not decode entities inside inline code spans, so generated forms like `Promise&lt;ConnectResult&gt;` render incorrectly. Prose/table summary text still goes through MDX-safe HTML escaping.

## Changes

- Split TypeDoc prose-cell escaping from code-span escaping.
- Keep literal `<`, `>`, `&`, and `=>` in generated TypeScript code spans while still escaping table pipes/backticks.
- Regenerated the checked-in TypeScript reference pages for `@daml/types`, Wallet SDK, and dApp SDK.
- Added a focused renderer test for TypeScript generics/arrows in code spans.

## Validation

- `direnv exec . python3 -m pytest tests/test_typedoc.py tests/test_typescript_bindings_reference.py`
- `direnv exec . npm run generate:typescript-bindings-reference`
- scan: no `&lt;`, `&gt;`, `=&gt;`, or `&amp;` inside inline code spans in generated TypeScript reference pages
- `direnv exec . python3 -m py_compile src/x2mdx/typedoc/render.py scripts/generate_typescript_bindings_reference.py`
- `git diff --check`

Local `npx mint validate` was attempted through `direnv exec`; it remained spinner-only for several minutes and was stopped. The PR CI should run the same Mintlify validation.
