### PR TITLE
Fix generated docs workflow paths

### DIFF
--- a/scripts/update_generated_reference_prs.py
+++ b/scripts/update_generated_reference_prs.py
@@ -17,7 +17,6 @@ import summarize_version_changes
 REPO_ROOT = Path(__file__).resolve().parents[1]
 NETWORK_VARIABLE_TAB_PAGES = (
     "docs-main/appdev/deep-dives/token-standard.mdx",
-    "docs-main/global-synchronizer/canton-console/console-overview.mdx",
     "docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx",
     "docs-main/global-synchronizer/deployment/onboarding-process.mdx",
     "docs-main/global-synchronizer/deployment/required-network-parameters.mdx",
@@ -27,7 +26,6 @@ NETWORK_VARIABLE_TAB_PAGES = (
     "docs-main/global-synchronizer/deployment/validator-kubernetes.mdx",
     "docs-main/global-synchronizer/production-operations/validator-disaster-recovery.mdx",
     "docs-main/global-synchronizer/reference/canton-console-reference.mdx",
-    "docs-main/global-synchronizer/understand/local-testing.mdx",
     "docs-main/sdks-tools/api-reference/splice-daml-apis.mdx",
     "docs-main/sdks-tools/api-reference/splice-http-apis.mdx",
     "docs-main/sdks-tools/api-reference/splice-scan-bulk-data-api.mdx",

--- a/tests/test_update_generated_reference_prs.py
+++ b/tests/test_update_generated_reference_prs.py
@@ -199,6 +199,20 @@ def test_target_paths_exist_in_base_checkout() -> None:
     assert {key: paths for key, paths in missing_paths.items() if paths} == {}
 
 
+def test_network_variable_tab_target_pages_match_generated_blocks() -> None:
+    module = load_script_module()
+
+    generated_block_pages = tuple(
+        sorted(
+            path.relative_to(REPO_ROOT).as_posix()
+            for path in (REPO_ROOT / "docs-main").rglob("*.mdx")
+            if "{/* NETWORKVARS_START" in path.read_text(encoding="utf-8")
+        )
+    )
+
+    assert module.NETWORK_VARIABLE_TAB_PAGES == generated_block_pages
+
+
 def test_body_markdown_includes_description_changes_and_validation() -> None:
     module = load_script_module()
     target = next(target for target in module.UPDATE_TARGETS if target.key == "wallet-gateway-openrpc")


### PR DESCRIPTION
## Summary
- remove deleted network-variable tab pages from the generated-docs PR target path list
- add regression coverage that the target list matches the current MDX pages with generated `NETWORKVARS` blocks

## Root cause
The `Update generated docs` workflow failed while staging the version-dashboard/network-variable update PR because `scripts/update_generated_reference_prs.py` still listed pages that had been deleted or moved. `git add -- <paths>` exits non-zero when a listed path no longer exists.

## Validation
- `direnv exec . python3 -m pytest tests/test_update_generated_reference_prs.py -q`
- `direnv exec . python3 -m py_compile scripts/update_generated_reference_prs.py tests/test_update_generated_reference_prs.py`
- `git diff --check`