### PR TITLE
Update Canton snippet config and snippet

### DIFF
--- a/config/snippet-config/canton-snippet-list-remote.json
+++ b/config/snippet-config/canton-snippet-list-remote.json
@@ -4950,8 +4950,8 @@
       "sourceFilepath": "community/app/src/test/resources/documentation-snippets/docs-cn-global-synchronizer_performance_optimization.conf",
       "location": {
         "type": "lines",
-        "start": 14,
-        "end": 18
+        "start": 13,
+        "end": 16
       },
       "description": "HOCON: batching.max-burst-factor \u2014 docs-cn-global-synchronizer_performance_optimization.conf",
       "options": {

--- a/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/docs-global-synchronizer-performance-optimization-burst-factor-hocon-2.mdx
+++ b/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/docs-global-synchronizer-performance-optimization-burst-factor-hocon-2.mdx
@@ -1,7 +1,6 @@
 ```hocon
+canton.participants.participant.parameters.batching {
   # Prune data older than this duration
   max-pruning-batch-size = 1000
 }
-
-canton.participants.participant.parameters {
 ```


### PR DESCRIPTION
Updates the Canton snippet config, fixing an issue with the snippet exported from `community/app/src/test/resources/documentation-snippets/docs-cn-global-synchronizer_performance_optimization.conf`. 
Also updates this snippet accordingly.

fixes #917 