### PR TITLE
Sync offline party replication summary (10 steps -> 13)

### DIFF
--- a/docs-main/global-synchronizer/production-operations/party-management.mdx
+++ b/docs-main/global-synchronizer/production-operations/party-management.mdx
@@ -326,16 +326,19 @@ This ensures you have a clean recovery point if the ACS import is interrupted (c
 
 These are the steps, which you must perform in **the exact order** they are listed:
 
-1.  **Target: Package Vetting** – Ensure the target participant vets all required packages.
+1.  **Target: Package Vetting** - Ensure the target participant vets all required packages.
 2.  **Source: Data Retention** - Ensure the source participant retains data long enough for the export.
 3.  **Target: Authorization** - Target participant authorizes new hosting with the onboarding flag set.
-4.  **Target: Isolation** - Disconnect from all synchronizers and disable auto-reconnect upon restart.
-5.  **Source: Party Authorization** - Party authorizes the replication with the onboarding flag set.
-6.  **Source: ACS Export** - The participant currently hosting the party exports the ACS.
-7.  **Target: Backup** - Back up the target participant before starting the ACS import.
-8.  **Target: ACS Import** - The target participant imports the ACS.
-9.  **Target: Reconnect** - The target participant reconnects to the synchronizers.
-10. **Target: Onboarding Flag Clearance** - The target participant issues the onboarding flag clearance.
+4.  **Target: Isolation** - Disconnect from all synchronizers.
+5.  **Target: Disable auto-reconnect** - Disable automatic reconnection upon restart.
+6.  **Source: Party Authorization** - Party authorizes the replication with the onboarding flag set.
+7.  **Source: ACS Export** - The participant currently hosting the party exports the ACS.
+8.  **Source: Re-enable pruning** *(optional)* - Re-enable automatic pruning.
+9.  **Target: Backup** - Back up the target participant before starting the ACS import.
+10. **Target: ACS Import** - The target participant imports the ACS.
+11. **Target: Reconnect** - The target participant reconnects to the synchronizers.
+12. **Target: Re-enable auto-reconnect** *(optional)* - Re-enable automatic reconnection.
+13. **Target: Onboarding Flag Clearance** - The target participant issues the onboarding flag clearance.
 
 <Warning>
 Offline party replication must be performed with care, strictly following the documented **steps in order**. Not following the outlined operational flow will result in errors potentially requiring significant manual correction.


### PR DESCRIPTION
Summary list showed 10 steps; walkthrough has 13. Expand to 13, map 1:1 to the headings, tidy labels.

Why: order-sensitive runbook — summary numbers must match the body or operators skip steps.